### PR TITLE
feat: stable ~/.openagi config + web search + BuildBetter transcripts (+ Mac open-at-login)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,7 +76,10 @@ TELEGRAM_WEBHOOK_SECRET=
 # --- Daemon ---
 HOST=127.0.0.1
 PORT=43210
-OPENAGI_DATA_DIR=.openagi
+# Optional override for where config/state live. Leave UNSET for the stable
+# default (~/.openagi). Only set this to an ABSOLUTE path (e.g. /data); a
+# relative value would make state depend on the launch directory.
+# OPENAGI_DATA_DIR=/absolute/path
 # Background ticker (ms). Set to 0 to disable; the runtime.tick() will then
 # only run on POST /tick.
 OPENAGI_TICKER_MS=10000

--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,32 @@ TELEGRAM_POLLING=
 # Tools surfaced to the agent: rize_query (raw GraphQL), rize_today_summary, rize_recent_sessions.
 RIZE_API_KEY=
 
+# --- Web search ---
+# Set at least one key to enable the web_search tool. With no key set, web_search
+# returns a "no provider configured" error; fetch_url still works via plain HTTP.
+# Auto-selection priority: exa -> tavily -> brave -> serpapi -> firecrawl -> perplexity
+EXA_API_KEY=
+TAVILY_API_KEY=
+FIRECRAWL_API_KEY=
+BRAVE_API_KEY=
+PERPLEXITY_API_KEY=
+SERPAPI_API_KEY=
+# Google Custom Search alternative (requires both):
+GOOGLE_API_KEY=
+GOOGLE_CSE_ID=
+# Force a specific provider (exa|tavily|firecrawl|brave|perplexity|serpapi).
+# Leave blank to let the agent auto-select.
+WEB_SEARCH_PROVIDER=
+
+# --- BuildBetter ---
+# Ingest mode: signals (default, action items -> tasks), transcripts (call
+# transcripts -> searchable memory via recall_activity), or both.
+BUILDBETTER_API_KEY=
+BUILDBETTER_USER_EMAIL=
+BUILDBETTER_USER_NAME=
+BUILDBETTER_WEBHOOK_SECRET=
+BUILDBETTER_INGEST_MODE=
+
 # --- Budget cap ---
 # Hard daily ceiling (USD). Provider calls throw BUDGET_EXCEEDED past this.
 OPENAGI_DAILY_USD_LIMIT=10

--- a/README.md
+++ b/README.md
@@ -287,6 +287,18 @@ Privacy posture (non-negotiable):
 
 ---
 
+## Floating widget — Quick Ask
+
+Press **⌥Space** (or click the tray icon → **Quick Ask**) to summon a small always-on-top pill that expands into an ask box over any app.
+
+**Screen context.** On each ask, the widget does an on-device OCR grab of the focused window using the same ScreenCaptureKit pipeline as the pattern miner. The capture exclusion list applies — 1Password, banking sites, 2FA screens, and private windows are never read. Requires **Screen Recording** permission; without it, the ask still works but the panel shows "no screen context."
+
+**Proactive nudges.** Suggestions from the agent's scrutiny layer surface as a badge on the pill. Open the nudge list to send it to chat or dismiss it.
+
+**Toggle.** Enable or disable the whole feature from the tray via **Enable Quick Ask** (on by default).
+
+---
+
 ## MCP servers
 
 Drop a config at `.openagi/mcp.json`:

--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ For Docker, run [Watchtower](https://containrrr.dev/watchtower/) alongside the O
 | **Telegram** | Webhook (`/channels/telegram/webhook`) or long polling (`TELEGRAM_POLLING=1`). |
 | **Persistent state** | All under `.openagi/`: memory (JSONL audit + atomic snapshot), cron jobs, agent/session store, specialist workspaces, MCP logs. |
 
+### Credits
+
+The **Credits** dashboard tab shows today's LLM spend vs the daily cap (`OPENAGI_DAILY_USD_LIMIT`), totals broken down **by activity** (chat / autopilot / cron / overlay / sms) and **by model**, a **30-day spend chart**, and a per-call **audit log** — each row records time, model, activity type, agent, cost, and tools called, so you can see exactly what cost credits and why.
+
+Ask the agent in chat via the **`recall_spend`** tool ("why did I spend $4 today?") — it reads the same ledger.
+
+Data is a local rolling 30-day ledger at `~/.openagi/budget/ledger.jsonl`. It stores cost + attribution only — **no message content**.
+
 ---
 
 ## Remote access (SMS, Telegram, tunneling)

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ npm run tunnel    # cloudflared (preferred) or ngrok, auto-detected
 
 ### Twilio bidirectional SMS
 
-1. Drop credentials into `.openagi/.env`:
+1. Drop credentials into `~/.openagi/.env`:
     ```bash
     TWILIO_ACCOUNT_SID=AC...
     TWILIO_AUTH_TOKEN=...
@@ -254,7 +254,7 @@ npm run tunnel    # cloudflared (preferred) or ngrok, auto-detected
 
 ### Telegram
 
-Create a bot via [@BotFather](https://t.me/BotFather), drop the token in `.openagi/.env`:
+Create a bot via [@BotFather](https://t.me/BotFather), drop the token in `~/.openagi/.env`:
 
 ```bash
 TELEGRAM_BOT_TOKEN=...
@@ -310,7 +310,7 @@ Drop a config at `.openagi/mcp.json`:
 
 Three transport+auth shapes are supported: **stdio** (spawn local process), **http+bearer** (URL with static API key), **http+oauth** (URL with browser-based OAuth — supports both dynamic registration and pre-registered clients).
 
-For the bearer shape, reference your secrets via `.openagi/.env` only — `${VAR}` substitution is allowlisted to keys defined in that file (closes the env-var exfiltration class). Restart the daemon and click **Connect** in the MCP tab — or:
+For the bearer shape, reference your secrets via `~/.openagi/.env` only — `${VAR}` substitution is allowlisted to keys defined in that file (closes the env-var exfiltration class). Restart the daemon and click **Connect** in the MCP tab — or:
 
 ```bash
 curl -s -X POST http://127.0.0.1:43210/mcp/connect/filesystem \
@@ -397,7 +397,7 @@ Webhooks self-validate instead:
 Additional defenses:
 
 - **Cross-origin POST blocked** — any browser request whose `Origin` doesn't match `Host` is rejected with 403, regardless of auth state.
-- **MCP register hardening** — `command` is allowlisted to known runners (`npx`, `node`, `bun`, `deno`, `python3`, `uvx`, `docker`); URL hosts may not be loopback / RFC1918 / link-local / cloud-metadata; `${VAR}` substitution is allowlisted to keys explicitly declared in `.openagi/.env`.
+- **MCP register hardening** — `command` is allowlisted to known runners (`npx`, `node`, `bun`, `deno`, `python3`, `uvx`, `docker`); URL hosts may not be loopback / RFC1918 / link-local / cloud-metadata; `${VAR}` substitution is allowlisted to keys explicitly declared in `~/.openagi/.env`.
 
 ---
 
@@ -434,7 +434,7 @@ Additional defenses:
 
 ## Environment
 
-See `.env.example`. All keys read from `.env` and `.openagi/.env`.
+See `.env.example`. All keys read from `.env` and `~/.openagi/.env` (override the location with `OPENAGI_DATA_DIR`).
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -436,6 +436,34 @@ Additional defenses:
 
 See `.env.example`. All keys read from `.env` and `~/.openagi/.env` (override the location with `OPENAGI_DATA_DIR`).
 
+### Web search
+
+The agent gains two tools — `web_search` and `fetch_url` — once at least one provider key is set. With no key configured, `web_search` returns a clear "no provider configured" error and `fetch_url` still works via a plain HTTP fetch.
+
+| Variable | Provider |
+|---|---|
+| `EXA_API_KEY` | [Exa](https://exa.ai) (default first choice) |
+| `TAVILY_API_KEY` | [Tavily](https://tavily.com) |
+| `BRAVE_API_KEY` | [Brave Search](https://brave.com/search/api/) |
+| `SERPAPI_API_KEY` | [SerpApi](https://serpapi.com) |
+| `FIRECRAWL_API_KEY` | [Firecrawl](https://firecrawl.dev) |
+| `PERPLEXITY_API_KEY` | [Perplexity](https://www.perplexity.ai/api) |
+| `GOOGLE_API_KEY` + `GOOGLE_CSE_ID` | Google Custom Search (alternative to the above) |
+
+`WEB_SEARCH_PROVIDER` — optional. Force a specific provider (`exa`, `tavily`, `firecrawl`, `brave`, `perplexity`, or `serpapi`). When unset the agent auto-selects the first configured provider in priority order `exa → tavily → brave → serpapi → firecrawl → perplexity`, falling back to the next on error.
+
+### BuildBetter
+
+Set `BUILDBETTER_API_KEY`, `BUILDBETTER_USER_EMAIL`, and `BUILDBETTER_USER_NAME` to enable the BuildBetter integration.
+
+`BUILDBETTER_INGEST_MODE` controls what the integration ingests:
+
+| Value | Behavior |
+|---|---|
+| `signals` _(default)_ | Action items from calls become agent tasks |
+| `transcripts` | Call transcripts are stored as searchable memory (queryable via `recall_activity`) |
+| `both` | Both of the above |
+
 ## Tests
 
 ```bash

--- a/docs/setup/remote-channels.md
+++ b/docs/setup/remote-channels.md
@@ -42,7 +42,7 @@ Same deal — copy the `https://*.ngrok-free.app` URL.
 
 This is required for Twilio signature verification (Twilio computes the HMAC over the URL it dialed, and the daemon must reconstruct the same URL).
 
-In `.openagi/.env`:
+In `~/.openagi/.env`:
 
 ```
 OPENAGI_PUBLIC_URL=https://abc-def-ghi.trycloudflare.com
@@ -61,7 +61,7 @@ Or if you're running it foreground: kill + `npm run serve`.
 
 You need a Twilio account, a phone number, and these three keys.
 
-### 3a. Drop creds into `.openagi/.env`
+### 3a. Drop creds into `~/.openagi/.env`
 
 ```
 TWILIO_ACCOUNT_SID=AC...
@@ -127,7 +127,7 @@ Talk to [@BotFather](https://t.me/BotFather), `/newbot`, copy the token.
 
 ### 4b. Set creds
 
-In `.openagi/.env`:
+In `~/.openagi/.env`:
 
 ```
 TELEGRAM_BOT_TOKEN=12345:ABC...
@@ -167,7 +167,7 @@ npm run install-launchd uninstall
 ## Verification checklist
 
 - [ ] `curl https://<tunnel>/health` returns 200.
-- [ ] `OPENAGI_PUBLIC_URL` is set in `.openagi/.env` and the daemon was restarted after.
+- [ ] `OPENAGI_PUBLIC_URL` is set in `~/.openagi/.env` and the daemon was restarted after.
 - [ ] Twilio console webhook points at `<tunnel>/channels/twilio/webhook`.
 - [ ] Texting your Twilio number triggers a TwiML reply.
 - [ ] `/channels` in the dashboard shows `outboundConfigured: true`.

--- a/docs/superpowers/plans/2026-06-02-config-location-and-knowledge-sources.md
+++ b/docs/superpowers/plans/2026-06-02-config-location-and-knowledge-sources.md
@@ -1,0 +1,1101 @@
+# Config Location + External Knowledge Sources — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make config/state persist in a stable `~/.openagi` location, then add web-search/page-fetch tools (6 providers) and BuildBetter transcript ingestion.
+
+**Architecture:** Part A introduces one `resolveDataDir()` resolver and routes all cwd-relative `.openagi` paths through it (default `~/.openagi`, `OPENAGI_DATA_DIR` override honored). Part B adds a provider-agnostic `web_search`/`fetch_url` tool pair backed by six adapters, and extends the BuildBetter integration with a `BUILDBETTER_INGEST_MODE` toggle that ingests call transcripts into the observation store (searchable via the existing `recall_activity`).
+
+**Tech Stack:** Node 22 (ESM), `node:test`, built-in `fetch`, better-sqlite3 (observation store), Swift (Mac app).
+
+**Sequencing note:** Part A lands first — the new provider keys in Part B rely on stable storage. Both specs:
+- `docs/superpowers/specs/2026-06-02-stable-config-location-design.md`
+- `docs/superpowers/specs/2026-06-02-external-knowledge-sources-design.md`
+
+**Spec decisions locked in:** default `~/.openagi` everywhere; unify ALL state via one resolver; NO migration (user re-runs `/setup` once); Mac `.app` also moves to `~/.openagi`.
+
+---
+
+# PART A — Stable config / data location
+
+### Task A1: `resolveDataDir()` resolver
+
+**Files:**
+- Create: `src/data-dir.js`
+- Test: `test/data-dir.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/data-dir.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { resolveDataDir, _resetDataDirCache } from "../src/data-dir.js";
+
+test("defaults to ~/.openagi when OPENAGI_DATA_DIR is unset", () => {
+  const prev = process.env.OPENAGI_DATA_DIR;
+  delete process.env.OPENAGI_DATA_DIR;
+  _resetDataDirCache();
+  assert.equal(resolveDataDir(), path.join(os.homedir(), ".openagi"));
+  if (prev !== undefined) process.env.OPENAGI_DATA_DIR = prev;
+  _resetDataDirCache();
+});
+
+test("honors OPENAGI_DATA_DIR as an absolute path", () => {
+  const prev = process.env.OPENAGI_DATA_DIR;
+  process.env.OPENAGI_DATA_DIR = "/tmp/openagi-test";
+  _resetDataDirCache();
+  assert.equal(resolveDataDir(), "/tmp/openagi-test");
+  if (prev !== undefined) process.env.OPENAGI_DATA_DIR = prev; else delete process.env.OPENAGI_DATA_DIR;
+  _resetDataDirCache();
+});
+
+test("resolves a relative OPENAGI_DATA_DIR to absolute", () => {
+  const prev = process.env.OPENAGI_DATA_DIR;
+  process.env.OPENAGI_DATA_DIR = "rel-data";
+  _resetDataDirCache();
+  assert.equal(resolveDataDir(), path.resolve("rel-data"));
+  if (prev !== undefined) process.env.OPENAGI_DATA_DIR = prev; else delete process.env.OPENAGI_DATA_DIR;
+  _resetDataDirCache();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/data-dir.test.js`
+Expected: FAIL — `Cannot find module '../src/data-dir.js'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```js
+// src/data-dir.js
+import os from "node:os";
+import path from "node:path";
+
+let cached = null;
+
+// Single source of truth for where OpenAGI keeps config + state.
+// Default is an ABSOLUTE ~/.openagi so it never depends on the process's
+// current working directory (which differs between `npm run serve`, the
+// .app, launchd, and re-clones — the cause of "my keys got wiped").
+// OPENAGI_DATA_DIR overrides it (Docker sets /data; the Mac app sets ~/.openagi).
+export function resolveDataDir() {
+  if (cached) return cached;
+  const override = process.env.OPENAGI_DATA_DIR;
+  cached = override ? path.resolve(override) : path.join(os.homedir(), ".openagi");
+  return cached;
+}
+
+// Test seam: drop the memoized value after mutating env in tests.
+export function _resetDataDirCache() {
+  cached = null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test test/data-dir.test.js`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/data-dir.js test/data-dir.test.js
+git commit -m "feat: resolveDataDir() — single ~/.openagi data-dir resolver"
+```
+
+---
+
+### Task A2: Repoint the env file path + boot loader
+
+**Files:**
+- Modify: `src/setup-wizard.js:43-45` (`envFilePath`)
+- Modify: `examples/hosted-server.js:5-10` (boot env loading)
+- Test: `test/env-persistence.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/env-persistence.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { _resetDataDirCache } from "../src/data-dir.js";
+import { envFilePath, saveEnv } from "../src/setup-wizard.js";
+
+test("saveEnv writes under OPENAGI_DATA_DIR and survives a reload", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-env-"));
+  const prev = process.env.OPENAGI_DATA_DIR;
+  process.env.OPENAGI_DATA_DIR = tmp;
+  _resetDataDirCache();
+
+  assert.equal(envFilePath(), path.join(tmp, ".env"));
+  saveEnv({ values: { ANTHROPIC_API_KEY: "sk-test-123" } });
+
+  const onDisk = fs.readFileSync(path.join(tmp, ".env"), "utf8");
+  assert.match(onDisk, /ANTHROPIC_API_KEY=sk-test-123/);
+
+  if (prev !== undefined) process.env.OPENAGI_DATA_DIR = prev; else delete process.env.OPENAGI_DATA_DIR;
+  _resetDataDirCache();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/env-persistence.test.js`
+Expected: FAIL — `envFilePath()` returns `.openagi/.env` (relative), not `<tmp>/.env`.
+
+- [ ] **Step 3: Repoint `envFilePath`**
+
+In `src/setup-wizard.js`, add the import near the top (after the existing imports):
+
+```js
+import { resolveDataDir } from "./data-dir.js";
+```
+
+Replace lines 43-45:
+
+```js
+export function envFilePath(dataDir) {
+  return path.join(dataDir ?? resolveDataDir(), ".env");
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test test/env-persistence.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Fix the boot loader**
+
+In `examples/hosted-server.js`, add the resolver import alongside the existing imports (the file already imports `loadEnvFile` and `path` — do NOT add a second `import path`):
+```js
+import { resolveDataDir } from "../src/data-dir.js";
+```
+Then replace the data-dir line + the three `loadEnvFile` calls (lines ~5-10):
+```js
+const dataDir = resolveDataDir();
+loadEnvFile(path.join(dataDir, ".env")); // canonical (loadEnvFile is first-wins)
+loadEnvFile(".env");                       // optional local-dev override in cwd
+```
+
+(Drop the old `loadEnvFile(".openagi/.env")` line — that relative path is exactly the bug. If `path` is NOT already imported in this file, add `import path from "node:path";` once.)
+
+- [ ] **Step 6: Smoke-test the round-trip manually**
+
+Run:
+```bash
+OPENAGI_DATA_DIR=/tmp/openagi-smoke node -e "import('./src/setup-wizard.js').then(m=>{m.saveEnv({values:{OPENAI_API_KEY:'sk-smoke'}});console.log('wrote', m.envFilePath())})"
+cat /tmp/openagi-smoke/.env
+```
+Expected: prints `wrote /tmp/openagi-smoke/.env` and the file contains `OPENAI_API_KEY=sk-smoke`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/setup-wizard.js examples/hosted-server.js test/env-persistence.test.js
+git commit -m "fix: env file + boot loader use resolveDataDir (stable ~/.openagi)"
+```
+
+---
+
+### Task A3: Sweep remaining cwd-relative `.openagi` call sites
+
+**Files (modify — each currently uses `path.join(process.cwd(), ".openagi", …)` or `?? ".openagi"`):**
+- `src/observation-store.js:34`
+- `src/scrutiny-fitter.js:26`
+- `src/file-backed-propagation-controller.js:9`
+- `src/outcome-store.js:13`
+- `src/tunnel-watcher.js:24`
+- `src/session-miner.js:51`
+- `src/suggestion-feed.js:163`
+- `src/proactive-observer.js:60`
+- `src/mcp-oauth.js:30`
+- `src/pending-actions.js:18`
+- `src/agent-store.js:78`
+- `src/clarification-store.js:28`
+- `src/channels.js:9,97,203`
+- `src/file-backed-cron-scheduler.js:9`
+- `src/hosted-interface.js:189,564,647,1215`
+- `src/abi-runtime.js:893` (and any sibling `.openagi` defaults)
+
+> Find the full list (do not trust this list to be exhaustive — the codebase may have shifted):
+> ```bash
+> grep -rn 'process.cwd(), "\.openagi"\|?? "\.openagi"' --include="*.js" src
+> ```
+
+- [ ] **Step 1: Enumerate every site**
+
+Run the grep above. Expected: ~35 matches. Keep the output open as your checklist.
+
+- [ ] **Step 2: Apply the transformation, file by file**
+
+For each match, add (once per file, near the top imports):
+```js
+import { resolveDataDir } from "./data-dir.js";
+```
+Then rewrite the path fallback. Transformation rule:
+
+- `path.join(process.cwd(), ".openagi", "observations")` → `path.join(resolveDataDir(), "observations")`
+- `options.dir ?? path.join(process.cwd(), ".openagi", "X")` → `options.dir ?? path.join(resolveDataDir(), "X")`
+- `options.dataDir ?? process.env.OPENAGI_DATA_DIR ?? ".openagi"` → `options.dataDir ?? resolveDataDir()`
+- `process.env.OPENAGI_DATA_DIR ?? ".openagi"` → `resolveDataDir()`
+
+Concrete example — `src/observation-store.js:34`:
+```js
+// before
+this.dir = options.dir ?? path.join(process.cwd(), ".openagi", "observations");
+// after
+this.dir = options.dir ?? path.join(resolveDataDir(), "observations");
+```
+
+Concrete example — `src/proactive-observer.js:60`:
+```js
+// before
+this.dataDir = options.dataDir ?? process.env.OPENAGI_DATA_DIR ?? ".openagi";
+// after
+this.dataDir = options.dataDir ?? resolveDataDir();
+```
+
+> Note on `hosted-interface.js`: this file is a Node template-literal-heavy module. Only touch the JS path expressions (lines 189/564/647/1215); do NOT edit text inside the embedded HTML template strings. Per repo memory, unescaped backticks / `${...}` inside that file's template comments crash at runtime — keep edits to plain code lines.
+
+- [ ] **Step 3: Verify nothing relative remains**
+
+Run:
+```bash
+grep -rn 'process.cwd(), "\.openagi"\|?? "\.openagi"\|"\.openagi/\.env"' --include="*.js" src examples
+```
+Expected: no matches (empty output).
+
+- [ ] **Step 4: Run the whole suite**
+
+Run: `node --test`
+Expected: all tests pass. If a test hard-coded `.openagi/...` relative paths, update it to set `OPENAGI_DATA_DIR` to a temp dir + `_resetDataDirCache()` (pattern from Task A2).
+
+- [ ] **Step 5: Smoke-test the daemon boots and serves**
+
+Run (foreground, then Ctrl-C):
+```bash
+OPENAGI_DATA_DIR=/tmp/openagi-smoke node examples/hosted-server.js &
+sleep 2 && curl -s 127.0.0.1:43210/health && kill %1
+```
+Expected: `/health` responds OK; state directories created under `/tmp/openagi-smoke/` (not `./.openagi`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A src examples test
+git commit -m "refactor: route all state dirs through resolveDataDir()"
+```
+
+---
+
+### Task A4: Mac app uses `~/.openagi`
+
+**Files:**
+- Modify: `mac/Sources/OpenAGI/AppState.swift:98-104` (`dataDir()`)
+
+- [ ] **Step 1: Change `dataDir()`**
+
+Replace the body of `nonisolated static func dataDir() -> URL`:
+
+```swift
+nonisolated static func dataDir() -> URL {
+  let home = FileManager.default.homeDirectoryForCurrentUser
+  let dir = home.appendingPathComponent(".openagi", isDirectory: true)
+  try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+  return dir
+}
+```
+
+`DaemonController` already sets `env["OPENAGI_DATA_DIR"] = dataDir.path` and `proc.currentDirectoryURL = dataDir` (DaemonController.swift:61-64), so the JS resolver agrees with the app.
+
+- [ ] **Step 2: Build the Mac app**
+
+Run: `cd mac && swift build`
+Expected: build succeeds. (If the host has no Swift toolchain, note that and defer the build to a macOS dev machine; the change is a 6-line edit.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mac/Sources/OpenAGI/AppState.swift
+git commit -m "feat(mac): app data dir -> ~/.openagi (unify with CLI daemon)"
+```
+
+> Reminder: no migration by design. Existing `.app` users re-run `/setup` once after this ships; their old `~/Library/Application Support/OpenAGI` data is left in place, not deleted.
+
+---
+
+### Task A5: Docs, install scripts, and `/setup` path display
+
+**Files:**
+- Modify: `README.md` (replace `.openagi/.env` references with `~/.openagi/.env`)
+- Modify: `scripts/install-launchd.sh`, `scripts/install-systemd.sh` (set `OPENAGI_DATA_DIR=$HOME/.openagi` in the generated unit)
+- Modify: `src/setup-wizard.js` (show the resolved path)
+
+- [ ] **Step 1: Update README references**
+
+Run to find them:
+```bash
+grep -rn '\.openagi/\.env\|\.openagi directory' README.md docs
+```
+Replace user-facing `.openagi/.env` with `~/.openagi/.env` and note that `OPENAGI_DATA_DIR` overrides it.
+
+- [ ] **Step 2: Pin the data dir in install scripts**
+
+In `scripts/install-launchd.sh` and `scripts/install-systemd.sh`, where the unit/plist environment is written, add `OPENAGI_DATA_DIR` set to `$HOME/.openagi` (launchd: an `EnvironmentVariables` dict entry; systemd: an `Environment=OPENAGI_DATA_DIR=%h/.openagi` line). This makes the location explicit and immune to WorkingDirectory.
+
+- [ ] **Step 3: Show the resolved path in `/setup`**
+
+In `src/setup-wizard.js`, the wizard copy currently interpolates `envFilePath()` (lines ~187 and ~347). Those now resolve to the absolute `~/.openagi/.env` automatically via Task A2 — verify the rendered text reads sensibly (absolute path). No code change needed beyond confirming; if a hardcoded `.openagi/.env` string exists in the copy, replace it with `${escapeHtml(envFilePath())}`.
+
+> Per repo memory: do NOT introduce backticks inside the wizard's embedded `<script>` template, and escape any `${...}` you add inside `renderWizard`/`renderApp` template literals.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs scripts/install-launchd.sh scripts/install-systemd.sh src/setup-wizard.js
+git commit -m "docs: ~/.openagi as the documented, explicit data location"
+```
+
+---
+
+# PART B — External knowledge sources
+
+### Task B1: Observation store gains a `transcript` kind
+
+**Files:**
+- Modify: `src/observation-store.js:88-128` (`record`)
+- Test: `test/observation-transcript.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/observation-transcript.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ObservationStore } from "../src/observation-store.js";
+
+test("records and searches a transcript observation", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obs-tx-"));
+  const store = new ObservationStore({ dir });
+  await store.record({
+    kind: "transcript",
+    at: "2026-06-01T10:00:00.000Z",
+    app: "BuildBetter",
+    window: "Acme <> Us — Discovery",
+    text: "We agreed to send the security questionnaire by Friday.",
+    ref: "buildbetter:call:42"
+  });
+  const results = await store.search({ query: "security questionnaire", limit: 5 });
+  assert.equal(results.length, 1);
+  assert.match(results[0].text ?? results[0].snippet ?? "", /security questionnaire/);
+
+  // Durable dedup lookup used by the BuildBetter transcript sync.
+  assert.equal(await store.existsRef("buildbetter:call:42"), true);
+  assert.equal(await store.existsRef("buildbetter:call:999"), false);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/observation-transcript.test.js`
+Expected: FAIL — `record` ignores unknown kinds, so `search` returns 0 rows.
+
+- [ ] **Step 3: Add the `transcript` branch to `record`**
+
+In `src/observation-store.js`, inside the `for (const o of observations)` loop in `record` (after the `frame`/`frame-summary` branch, before `count += 1`), add:
+
+```js
+} else if (o.kind === "transcript") {
+  // Long-form text (e.g. a BuildBetter call transcript) recorded so it's
+  // searchable via the same FTS path as OCR/activity (and thus recall_activity).
+  const ref = o.ref ? String(o.ref) : createId("txt");
+  if (o.text) insertText.run("transcript", ref, o.at ?? nowIso(), o.app ?? "", o.window ?? "", o.text);
+}
+```
+
+Note the existing chain uses `if (o.kind === "activity") { … } else if (o.kind === "frame" …) { … }` — append this as a new `else if`. The `insertText` prepared statement is already defined above in `record`.
+
+Also extend the **fallback** (jsonl) path so transcripts are searchable there too. In `record`, the fallback branch writes raw JSON lines, and `search`'s fallback filters on `o.ocrText`/`o.window`. Update the fallback `search` filter (around line 139) to also match transcript text:
+```js
+out = out.filter((o) => (o.ocrText || "").toLowerCase().includes(q) || (o.window || "").toLowerCase().includes(q) || (o.text || "").toLowerCase().includes(q));
+```
+
+Then add an `existsRef(ref)` method (durable dedup for the transcript sync — survives restarts because it queries persisted rows). Add it after `search`:
+```js
+async existsRef(ref) {
+  await this.ready;
+  if (!ref) return false;
+  if (this.fallback) {
+    try {
+      const rows = fs.readFileSync(this.fallbackPath, "utf8").split("\n").filter(Boolean).map(JSON.parse);
+      return rows.some((o) => o.ref === ref);
+    } catch { return false; }
+  }
+  const row = this.db.prepare(`SELECT 1 FROM texts WHERE ref = ? LIMIT 1`).get(ref);
+  return Boolean(row);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test test/observation-transcript.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/observation-store.js test/observation-transcript.test.js
+git commit -m "feat: observation store supports transcript text kind"
+```
+
+---
+
+### Task B2: Web-search provider adapters
+
+**Files:**
+- Create: `src/integrations/web-search-providers.js`
+- Test: `test/web-search-providers.test.js`
+
+Each adapter: `{ name, isConfigured(), async search(query, opts) }` (Firecrawl also `async fetch(url, opts)`). All return `NormalizedResult[]` = `{ title, url, snippet, publishedDate?, content? }`. 15s timeout via `AbortController`.
+
+- [ ] **Step 1: Write the failing test (Exa + Tavily mapping, fetch mocked)**
+
+```js
+// test/web-search-providers.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { PROVIDERS } from "../src/integrations/web-search-providers.js";
+
+function withMockFetch(handler, fn) {
+  const real = globalThis.fetch;
+  globalThis.fetch = handler;
+  return Promise.resolve(fn()).finally(() => { globalThis.fetch = real; });
+}
+const jsonResponse = (obj) => ({ ok: true, status: 200, json: async () => obj });
+
+test("exa adapter maps results", async () => {
+  const exa = PROVIDERS.find((p) => p.name === "exa");
+  await withMockFetch(async (url, init) => {
+    assert.equal(url, "https://api.exa.ai/search");
+    assert.equal(JSON.parse(init.body).query, "claude api");
+    return jsonResponse({ results: [{ title: "Docs", url: "https://x", text: "body", publishedDate: "2026-01-01" }] });
+  }, async () => {
+    const out = await exa.search("claude api", { numResults: 3, apiKey: "k" });
+    assert.equal(out[0].title, "Docs");
+    assert.equal(out[0].url, "https://x");
+    assert.equal(out[0].content, "body");
+  });
+});
+
+test("tavily adapter maps results", async () => {
+  const tav = PROVIDERS.find((p) => p.name === "tavily");
+  await withMockFetch(async (url) => {
+    assert.equal(url, "https://api.tavily.com/search");
+    return jsonResponse({ results: [{ title: "T", url: "https://t", content: "snip" }] });
+  }, async () => {
+    const out = await tav.search("q", { apiKey: "k" });
+    assert.equal(out[0].snippet, "snip");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/web-search-providers.test.js`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the adapters**
+
+```js
+// src/integrations/web-search-providers.js
+// Provider adapters for web_search/fetch_url. Each adapter is independent and
+// env-gated. Responses are mapped to a NormalizedResult:
+//   { title, url, snippet, publishedDate?, content? }
+
+const TIMEOUT_MS = 15_000;
+
+async function postJson(url, { headers = {}, body, apiKey } = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify(body),
+      signal: controller.signal
+    });
+    if (!res.ok) throw new Error(`${url} -> ${res.status}`);
+    return await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function getJson(url, { headers = {} } = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { headers, signal: controller.signal });
+    if (!res.ok) throw new Error(`${url} -> ${res.status}`);
+    return await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const str = (v) => (typeof v === "string" ? v : "");
+
+export const exa = {
+  name: "exa",
+  isConfigured: () => Boolean(process.env.EXA_API_KEY),
+  async search(query, opts = {}) {
+    const apiKey = opts.apiKey ?? process.env.EXA_API_KEY;
+    const data = await postJson("https://api.exa.ai/search", {
+      headers: { "x-api-key": apiKey },
+      body: { query, numResults: opts.numResults ?? 5, contents: { text: true } }
+    });
+    return (data.results ?? []).map((r) => ({
+      title: str(r.title), url: str(r.url), snippet: str(r.text).slice(0, 400),
+      publishedDate: r.publishedDate ?? undefined, content: r.text ?? undefined
+    }));
+  }
+};
+
+export const tavily = {
+  name: "tavily",
+  isConfigured: () => Boolean(process.env.TAVILY_API_KEY),
+  async search(query, opts = {}) {
+    const apiKey = opts.apiKey ?? process.env.TAVILY_API_KEY;
+    const data = await postJson("https://api.tavily.com/search", {
+      headers: { authorization: `Bearer ${apiKey}` },
+      body: { query, max_results: opts.numResults ?? 5, search_depth: "basic", include_answer: false }
+    });
+    return (data.results ?? []).map((r) => ({
+      title: str(r.title), url: str(r.url), snippet: str(r.content).slice(0, 400),
+      publishedDate: r.published_date ?? undefined, content: r.raw_content ?? undefined
+    }));
+  }
+};
+
+export const firecrawl = {
+  name: "firecrawl",
+  isConfigured: () => Boolean(process.env.FIRECRAWL_API_KEY),
+  async search(query, opts = {}) {
+    const apiKey = opts.apiKey ?? process.env.FIRECRAWL_API_KEY;
+    const data = await postJson("https://api.firecrawl.dev/v2/search", {
+      headers: { authorization: `Bearer ${apiKey}` },
+      body: { query, limit: opts.numResults ?? 5 }
+    });
+    // v2 returns { data: { web: [...] } } or { data: [...] } depending on sources.
+    const rows = Array.isArray(data.data) ? data.data : (data.data?.web ?? []);
+    return rows.map((r) => ({
+      title: str(r.title), url: str(r.url),
+      snippet: str(r.description || r.snippet).slice(0, 400),
+      content: r.markdown ?? undefined
+    }));
+  },
+  async fetch(url, opts = {}) {
+    const apiKey = opts.apiKey ?? process.env.FIRECRAWL_API_KEY;
+    const data = await postJson("https://api.firecrawl.dev/v2/scrape", {
+      headers: { authorization: `Bearer ${apiKey}` },
+      body: { url, formats: ["markdown"] }
+    });
+    return str(data.data?.markdown);
+  }
+};
+
+export const brave = {
+  name: "brave",
+  isConfigured: () => Boolean(process.env.BRAVE_API_KEY),
+  async search(query, opts = {}) {
+    const apiKey = opts.apiKey ?? process.env.BRAVE_API_KEY;
+    const count = opts.numResults ?? 5;
+    const data = await getJson(
+      `https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}&count=${count}`,
+      { headers: { accept: "application/json", "x-subscription-token": apiKey } }
+    );
+    return (data.web?.results ?? []).map((r) => ({
+      title: str(r.title), url: str(r.url), snippet: str(r.description).slice(0, 400),
+      publishedDate: r.age ?? undefined
+    }));
+  }
+};
+
+export const perplexity = {
+  name: "perplexity",
+  isConfigured: () => Boolean(process.env.PERPLEXITY_API_KEY),
+  async search(query, opts = {}) {
+    const apiKey = opts.apiKey ?? process.env.PERPLEXITY_API_KEY;
+    const data = await postJson("https://api.perplexity.ai/chat/completions", {
+      headers: { authorization: `Bearer ${apiKey}` },
+      body: { model: "sonar", messages: [{ role: "user", content: query }] }
+    });
+    const answer = str(data.choices?.[0]?.message?.content);
+    const citations = Array.isArray(data.citations) ? data.citations : [];
+    const out = [];
+    if (answer) out.push({ title: "Perplexity answer", url: citations[0] ?? "", snippet: answer.slice(0, 400), content: answer });
+    for (const c of citations) out.push({ title: c, url: c, snippet: "" });
+    return out.slice(0, (opts.numResults ?? 5) + 1);
+  }
+};
+
+export const serpapi = {
+  name: "serpapi",
+  isConfigured: () => Boolean(process.env.SERPAPI_API_KEY) || Boolean(process.env.GOOGLE_API_KEY && process.env.GOOGLE_CSE_ID),
+  async search(query, opts = {}) {
+    const num = opts.numResults ?? 5;
+    if (process.env.SERPAPI_API_KEY || opts.apiKey) {
+      const key = opts.apiKey ?? process.env.SERPAPI_API_KEY;
+      const data = await getJson(
+        `https://serpapi.com/search.json?engine=google&q=${encodeURIComponent(query)}&num=${num}&api_key=${encodeURIComponent(key)}`
+      );
+      return (data.organic_results ?? []).map((r) => ({
+        title: str(r.title), url: str(r.link), snippet: str(r.snippet).slice(0, 400),
+        publishedDate: r.date ?? undefined
+      }));
+    }
+    // Google Programmable Search fallback.
+    const data = await getJson(
+      `https://www.googleapis.com/customsearch/v1?key=${encodeURIComponent(process.env.GOOGLE_API_KEY)}&cx=${encodeURIComponent(process.env.GOOGLE_CSE_ID)}&q=${encodeURIComponent(query)}&num=${num}`
+    );
+    return (data.items ?? []).map((r) => ({
+      title: str(r.title), url: str(r.link), snippet: str(r.snippet).slice(0, 400)
+    }));
+  }
+};
+
+// Default priority order (spec): exa -> tavily -> brave -> serpapi -> firecrawl -> perplexity.
+export const PROVIDERS = [exa, tavily, brave, serpapi, firecrawl, perplexity];
+export const PROVIDER_BY_NAME = Object.fromEntries(PROVIDERS.map((p) => [p.name, p]));
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test test/web-search-providers.test.js`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/integrations/web-search-providers.js test/web-search-providers.test.js
+git commit -m "feat: six web-search provider adapters with normalized results"
+```
+
+---
+
+### Task B3: `web_search` + `fetch_url` tools + wiring
+
+**Files:**
+- Create: `src/integrations/web-search.js`
+- Modify: `src/abi-runtime.js` (register inside the `options.integrations !== false` block, ~line 363)
+- Test: `test/web-search-tools.test.js`
+
+- [ ] **Step 1: Write the failing test (provider resolution + fallback)**
+
+```js
+// test/web-search-tools.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ToolRegistry } from "../src/tool-registry.js";
+import { registerWebSearchTools } from "../src/integrations/web-search.js";
+
+function fakeProvider(name, behavior) {
+  return { name, isConfigured: () => true, search: behavior };
+}
+
+test("web_search uses explicit provider and normalizes", async () => {
+  const tools = new ToolRegistry();
+  registerWebSearchTools({ tools }, {
+    providers: [fakeProvider("exa", async () => [{ title: "A", url: "u", snippet: "s" }])]
+  });
+  const { result } = await tools.invoke("web_search", { query: "hi", provider: "exa" });
+  assert.equal(result.provider, "exa");
+  assert.equal(result.results[0].title, "A");
+});
+
+test("web_search falls back to the next configured provider on error", async () => {
+  const tools = new ToolRegistry();
+  registerWebSearchTools({ tools }, {
+    providers: [
+      fakeProvider("exa", async () => { throw new Error("boom"); }),
+      fakeProvider("tavily", async () => [{ title: "B", url: "u", snippet: "s" }])
+    ]
+  });
+  const { result } = await tools.invoke("web_search", { query: "hi" });
+  assert.equal(result.provider, "tavily");
+  assert.equal(result.results[0].title, "B");
+});
+
+test("web_search returns a clear error when nothing is configured", async () => {
+  const tools = new ToolRegistry();
+  registerWebSearchTools({ tools }, {
+    providers: [{ name: "exa", isConfigured: () => false, search: async () => [] }]
+  });
+  const { result } = await tools.invoke("web_search", { query: "hi" });
+  assert.match(result.error, /no web search provider/i);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/web-search-tools.test.js`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the tools**
+
+```js
+// src/integrations/web-search.js
+import { PROVIDERS, PROVIDER_BY_NAME, firecrawl } from "./web-search-providers.js";
+
+const PROVIDER_NAMES = PROVIDERS.map((p) => p.name);
+
+// opts.providers is a test seam; production uses the real PROVIDERS list.
+export function registerWebSearchTools(runtime, opts = {}) {
+  const providers = opts.providers ?? PROVIDERS;
+  const byName = opts.providers
+    ? Object.fromEntries(opts.providers.map((p) => [p.name, p]))
+    : PROVIDER_BY_NAME;
+
+  runtime.tools.register({
+    name: "web_search",
+    description: "Search the live web. Returns a list of results (title, url, snippet, and often page content). Picks a configured provider automatically; pass `provider` to force one.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "The search query." },
+        provider: { type: "string", enum: PROVIDER_NAMES, description: "Force a specific provider. Omit to auto-select." },
+        num_results: { type: "integer", minimum: 1, maximum: 20, description: "Max results (default 5)." },
+        recency: { type: "string", enum: ["day", "week", "month", "year"], description: "Optional recency hint." }
+      },
+      required: ["query"],
+      additionalProperties: false
+    },
+    handler: async (args) => {
+      const numResults = args.num_results ?? 5;
+      // Resolution order: explicit arg -> WEB_SEARCH_PROVIDER -> priority list.
+      let order = [];
+      if (args.provider) {
+        const p = byName[args.provider];
+        if (!p) return { error: `Unknown provider: ${args.provider}` };
+        if (!p.isConfigured()) return { error: `Provider ${args.provider} is not configured (missing API key).` };
+        order = [p];
+      } else {
+        const envDefault = process.env.WEB_SEARCH_PROVIDER && byName[process.env.WEB_SEARCH_PROVIDER];
+        const configured = providers.filter((p) => p.isConfigured());
+        order = envDefault && envDefault.isConfigured() ? [envDefault, ...configured.filter((p) => p !== envDefault)] : configured;
+      }
+      if (order.length === 0) return { error: "No web search provider configured. Set EXA_API_KEY, TAVILY_API_KEY, BRAVE_API_KEY, SERPAPI_API_KEY, FIRECRAWL_API_KEY, or PERPLEXITY_API_KEY in ~/.openagi/.env." };
+
+      const errors = [];
+      for (const p of order) {
+        try {
+          const results = await p.search(args.query, { numResults, recency: args.recency });
+          return { provider: p.name, count: results.length, results };
+        } catch (err) {
+          errors.push(`${p.name}: ${err.message}`);
+        }
+      }
+      return { error: `All providers failed. ${errors.join("; ")}` };
+    }
+  });
+
+  runtime.tools.register({
+    name: "fetch_url",
+    description: "Fetch the contents of a web page as markdown/text. Uses Firecrawl when configured, otherwise a plain fetch.",
+    parameters: {
+      type: "object",
+      properties: {
+        url: { type: "string", description: "The URL to fetch." },
+        format: { type: "string", enum: ["markdown", "text"], description: "Output format (default markdown)." }
+      },
+      required: ["url"],
+      additionalProperties: false
+    },
+    handler: async (args) => {
+      const format = args.format ?? "markdown";
+      if (firecrawl.isConfigured()) {
+        try {
+          const content = await firecrawl.fetch(args.url);
+          if (content) return { url: args.url, format: "markdown", content };
+        } catch (err) {
+          // fall through to plain fetch
+        }
+      }
+      try {
+        const res = await fetch(args.url, { headers: { "user-agent": "OpenAGI/1.0" } });
+        if (!res.ok) return { error: `${args.url} -> ${res.status}` };
+        const html = await res.text();
+        const text = html
+          .replace(/<script[\s\S]*?<\/script>/gi, " ")
+          .replace(/<style[\s\S]*?<\/style>/gi, " ")
+          .replace(/<[^>]+>/g, " ")
+          .replace(/\s+/g, " ")
+          .trim();
+        return { url: args.url, format: "text", content: text.slice(0, 20_000) };
+      } catch (err) {
+        return { error: `fetch_url failed: ${err.message}` };
+      }
+    }
+  });
+
+  return { registered: true };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test test/web-search-tools.test.js`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Wire into the runtime**
+
+In `src/abi-runtime.js`, add the import near the other integration imports (~line 16):
+```js
+import { registerWebSearchTools } from "./integrations/web-search.js";
+```
+Inside the `if (options.integrations !== false) {` block (the block that calls `registerRizeIntegration(this)` etc., ~line 363), add:
+```js
+// Web search tools (web_search / fetch_url). Always registered; web_search
+// returns a clear "no provider configured" error until a key is set.
+registerWebSearchTools(this);
+```
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `node --test`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/integrations/web-search.js src/abi-runtime.js test/web-search-tools.test.js
+git commit -m "feat: web_search + fetch_url tools with provider override and fallback"
+```
+
+---
+
+### Task B4: BuildBetter transcript ingestion + mode toggle
+
+**Files:**
+- Modify: `src/integrations/buildbetter-tasks.js`
+- Test: `test/buildbetter-transcripts.test.js`
+
+- [ ] **Step 1: Probe the live transcript schema (investigation step)**
+
+Use the connected BuildBetter MCP to confirm how a transcript is returned, so the GraphQL is correct rather than guessed:
+```
+Call MCP tool: mcp__claude_ai_BuildBetter__get-call-transcript  (or list-types / find-fields)
+for one recent interview id.
+```
+Record: the exact field path that yields transcript text (e.g. `interview.transcript`, or a `transcript`/`utterance` relation with `speaker` + `text` rows). Use that in Step 3's query. Expected outcome: you can name the field that returns the spoken text.
+
+- [ ] **Step 2: Write the failing test (mode gating + dedup, query mocked)**
+
+```js
+// test/buildbetter-transcripts.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { BuildBetterTaskSource } from "../src/integrations/buildbetter-tasks.js";
+
+function fakeObservations() {
+  const rows = [];
+  return {
+    record: async (o) => { rows.push(o); return { count: 1 }; },
+    search: async () => rows,
+    existsRef: async (ref) => rows.some((o) => o.ref === ref),
+    _rows: rows
+  };
+}
+
+test("syncTranscripts records one transcript per call and dedupes", async () => {
+  const observations = fakeObservations();
+  const src = new BuildBetterTaskSource({
+    apiKey: "k", userEmail: "me@x.com",
+    runtime: { observations }
+  });
+  // Stub the two network calls.
+  src.getRecentCalls = async () => [{ id: 7, name: "Acme Discovery", started_at: "2026-06-01T10:00:00Z" }];
+  src.getTranscript = async (callId) => `Transcript for ${callId}: ship it by Friday.`;
+
+  const first = await src.syncTranscripts({ now: new Date("2026-06-02T00:00:00Z") });
+  assert.equal(first.created, 1);
+  assert.equal(observations._rows[0].kind, "transcript");
+  assert.equal(observations._rows[0].ref, "buildbetter:call:7");
+
+  // Second run: same call already recorded -> no new row.
+  const second = await src.syncTranscripts({ now: new Date("2026-06-02T00:05:00Z") });
+  assert.equal(second.created, 0);
+});
+
+test("ingestMode defaults to signals", () => {
+  const prev = process.env.BUILDBETTER_INGEST_MODE;
+  delete process.env.BUILDBETTER_INGEST_MODE;
+  const src = new BuildBetterTaskSource({ apiKey: "k", userEmail: "me@x.com" });
+  assert.equal(src.ingestMode, "signals");
+  if (prev !== undefined) process.env.BUILDBETTER_INGEST_MODE = prev;
+});
+```
+
+- [ ] **Step 3: Implement transcript sync + mode**
+
+In `src/integrations/buildbetter-tasks.js`:
+
+(a) In the constructor, add:
+```js
+const mode = (options.ingestMode ?? process.env.BUILDBETTER_INGEST_MODE ?? "signals").toLowerCase();
+this.ingestMode = ["signals", "transcripts", "both"].includes(mode) ? mode : "signals";
+```
+
+(b) Add a `getTranscript` method (use the field confirmed in Step 1; the shape below assembles speaker-tagged lines — adapt to the real relation name):
+```js
+async getTranscript(callId) {
+  const query = `
+    query Transcript($id: bigint!) {
+      interview_by_pk(id: $id) {
+        id
+        transcript { speaker text start_ts }
+      }
+    }
+  `;
+  const data = await this.query(query, { id: Number(callId) });
+  const rows = data?.interview_by_pk?.transcript ?? [];
+  if (!rows.length) return "";
+  return rows.map((u) => `${u.speaker ? u.speaker + ": " : ""}${u.text ?? ""}`.trim()).filter(Boolean).join("\n");
+}
+```
+
+(c) Add `syncTranscripts`:
+```js
+async syncTranscripts({ now = new Date() } = {}) {
+  if (!this.apiKey) return { skipped: true, reason: "BUILDBETTER_API_KEY not set" };
+  if (!this.runtime?.observations?.record) return { skipped: true, reason: "no observation store" };
+
+  const sinceIso = new Date(now.getTime() - LOOKBACK_DAYS * 86400 * 1000).toISOString();
+  let calls;
+  try {
+    calls = await this.getRecentCalls(sinceIso);
+  } catch (err) {
+    return { skipped: true, reason: `recent calls: ${err.message}` };
+  }
+
+  let created = 0;
+  for (const call of calls) {
+    const ref = `buildbetter:call:${call.id}`;
+    // Durable dedup: already-recorded transcripts are skipped even across
+    // daemon restarts (existsRef queries persisted rows, not in-memory state).
+    if (await this.runtime.observations.existsRef(ref)) continue;
+    let text;
+    try {
+      text = await this.getTranscript(call.id);
+    } catch (err) {
+      continue; // skip this call; try again next sweep
+    }
+    if (!text) continue;
+    await this.runtime.observations.record({
+      kind: "transcript",
+      at: call.started_at ?? now.toISOString(),
+      app: "BuildBetter",
+      window: call.name ?? "Call",
+      text,
+      ref
+    });
+    created += 1;
+  }
+  return { scanned: calls.length, created };
+}
+```
+
+(d) Make the single cron entry mode-aware. Rename the existing `sync` body to `syncSignals` and add a dispatcher `sync` that runs the right pass(es):
+```js
+async sync({ now = new Date() } = {}) {
+  const out = {};
+  if (this.ingestMode === "signals" || this.ingestMode === "both") {
+    out.signals = await this.syncSignals({ now });
+  }
+  if (this.ingestMode === "transcripts" || this.ingestMode === "both") {
+    out.transcripts = await this.syncTranscripts({ now });
+  }
+  return out;
+}
+```
+> Rename the current `async sync({ now } = {})` (lines ~117-179) to `async syncSignals(...)` verbatim — its body is unchanged. The new `sync` above replaces the cron entry point, so `abi-runtime.js:553` (`this.buildBetterTaskSource.sync({ now })`) keeps working with no change.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test test/buildbetter-transcripts.test.js`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Run the full suite (guard the signals path didn't regress)**
+
+Run: `node --test`
+Expected: all pass, including any existing BuildBetter task tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/integrations/buildbetter-tasks.js test/buildbetter-transcripts.test.js
+git commit -m "feat: BuildBetter transcript ingestion via BUILDBETTER_INGEST_MODE"
+```
+
+---
+
+### Task B5: Config surface for the new keys
+
+**Files:**
+- Modify: `src/setup-wizard.js:12-30` (`WIZARD_FIELDS`)
+- Modify: `README.md` and/or `.env.example` (document the new vars)
+
+- [ ] **Step 1: Add the new env vars to the allowlist**
+
+In `src/setup-wizard.js`, extend the `WIZARD_FIELDS` array (before the MCP spread) with:
+```js
+  "EXA_API_KEY", "TAVILY_API_KEY", "FIRECRAWL_API_KEY", "BRAVE_API_KEY",
+  "PERPLEXITY_API_KEY", "SERPAPI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_CSE_ID",
+  "WEB_SEARCH_PROVIDER",
+  "BUILDBETTER_INGEST_MODE",
+```
+This lets `/setup/save` persist them (the merge logic and `0600` write already handle any allowlisted key).
+
+- [ ] **Step 2: Document the vars**
+
+Add a "Web search" section to the README (and `.env.example` if present) listing the six keys, the optional `WEB_SEARCH_PROVIDER` (one of `exa|tavily|firecrawl|brave|perplexity|serpapi`), and `BUILDBETTER_INGEST_MODE` (`signals|transcripts|both`, default `signals`). Note that web search degrades gracefully: no key → `web_search` returns a clear error, `fetch_url` still works via plain fetch.
+
+- [ ] **Step 3: (Optional) add a wizard UI step**
+
+If you want the keys editable in the `/setup` browser flow (not just via `.env`), add input fields in the relevant `renderWizard` step. Per repo memory: do NOT use backticks inside the wizard's embedded `<script>` template literal, and escape any `${...}` you add inside the template. If short on time, skip — the allowlist (Step 1) already makes the keys persistable, and they can be set in `~/.openagi/.env` directly.
+
+- [ ] **Step 4: Run the full suite + smoke test**
+
+Run: `node --test`
+Expected: all pass.
+
+Smoke: with `OPENAGI_DATA_DIR=/tmp/openagi-smoke` set, run `/setup/save` (or `saveEnv`) with an `EXA_API_KEY` and confirm it lands in `/tmp/openagi-smoke/.env`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/setup-wizard.js README.md
+git commit -m "feat: persist web-search + BUILDBETTER_INGEST_MODE keys via setup allowlist"
+```
+
+---
+
+## Final verification
+
+- [ ] Run `node --test` — entire suite green.
+- [ ] `grep -rn 'process.cwd(), "\.openagi"\|?? "\.openagi"' --include="*.js" src examples` — empty.
+- [ ] Boot with `OPENAGI_DATA_DIR=/tmp/openagi-final node examples/hosted-server.js`, hit `/health`, confirm state lands under `/tmp/openagi-final/`.
+- [ ] `web_search` with no keys returns the "no provider configured" error; with `EXA_API_KEY` set, returns live results.
+- [ ] `BUILDBETTER_INGEST_MODE=transcripts` records transcripts; `recall_activity` with a query from a recent call returns them.
+```

--- a/docs/superpowers/plans/2026-06-05-floating-widget.md
+++ b/docs/superpowers/plans/2026-06-05-floating-widget.md
@@ -1,0 +1,656 @@
+# Floating Widget ("Quick Ask") Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A native macOS always-on-top pill that expands to ask OpenAGI from anywhere, grounded in the focused window, with a global hotkey (⌥Space) + tray toggle and (phase 2) proactive nudges.
+
+**Architecture:** SwiftUI hosted in an AppKit `NSPanel` inside the existing menu-bar app, talking to the local daemon over HTTP. One JS change: `agent-host` injects `metadata.screenContext` into the turn. Screen context reuses the existing ScreenCapturer + Vision OCR (exclusion-aware).
+
+**Tech Stack:** Swift / AppKit / SwiftUI / ScreenCaptureKit / Vision / Carbon (hotkey); Node 22 ESM (daemon) with `node:test`.
+
+**Verification reality:** The macOS UI cannot be unit-tested here (all existing tests are JS). Each Swift task is verified by `cd mac && swift build` (compile-clean). The one JS seam (`agent-host` screen-context) gets a real `node:test`. A manual smoke checklist (Task 8) is for the user.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-floating-widget-design.md`
+
+---
+
+# Phase 1 — Ask flow
+
+### Task 1: Daemon — inject `metadata.screenContext` into the agent turn
+
+**Files:**
+- Modify: `src/agent-host.js`
+- Test: `test/agent-host-screen-context.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/agent-host-screen-context.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { formatScreenContextBlock } from "../src/agent-host.js";
+
+test("formats a labeled active-window block from screenContext", () => {
+  const block = formatScreenContextBlock({ app: "Safari", window: "Spec — Notion", text: "the deadline is Friday" });
+  assert.match(block, /Active window the user is looking at right now \(Safari · Spec — Notion\)/);
+  assert.match(block, /the deadline is Friday/);
+});
+
+test("returns empty string for missing/empty screenContext", () => {
+  assert.equal(formatScreenContextBlock(null), "");
+  assert.equal(formatScreenContextBlock({ app: "X" }), ""); // no text
+  assert.equal(formatScreenContextBlock({ text: "   " }), ""); // blank text
+});
+
+test("truncates very long screen text to 4000 chars", () => {
+  const block = formatScreenContextBlock({ app: "X", text: "a".repeat(5000) });
+  // 4000 of the body + the surrounding labels; assert body itself is capped
+  const body = block.split("\n").find((l) => l.startsWith("aaaa"));
+  assert.ok(body.length <= 4000, `body should be <= 4000, got ${body.length}`);
+});
+
+test("falls back to 'active window' when app is absent", () => {
+  const block = formatScreenContextBlock({ text: "hello" });
+  assert.match(block, /\(active window\)/);
+});
+```
+
+- [ ] **Step 2: Run it — verify it FAILS**
+
+Run: `node --test test/agent-host-screen-context.test.js`
+Expected: FAIL — `formatScreenContextBlock` is not exported.
+
+- [ ] **Step 3: Implement**
+
+In `src/agent-host.js`, add this exported pure function near the bottom (next to `friendlyProviderLabel`):
+
+```js
+// Format the fresh focused-window context the floating widget attaches to a
+// message (metadata.screenContext = { app, window, text }) into a labeled
+// prompt block. Returns "" when absent/empty. Pure + exported for testing.
+export function formatScreenContextBlock(screenContext) {
+  if (!screenContext || typeof screenContext.text !== "string" || !screenContext.text.trim()) return "";
+  const where = screenContext.window
+    ? `${screenContext.app || "?"} · ${screenContext.window}`
+    : (screenContext.app || "active window");
+  const body = screenContext.text.slice(0, 4000);
+  return `\nActive window the user is looking at right now (${where}):\n${body}\nGround your answer in this if it's relevant; don't quote it back verbatim.\n`;
+}
+```
+
+Then thread it through `instructionsForAgent`:
+- Change the signature: `instructionsForAgent(agent, output, intuitions = [], ambientContext = null, screenContext = null) {`
+- After the `ambientBlock` is built (before the `return` template), add:
+  ```js
+  const screenBlock = formatScreenContextBlock(screenContext);
+  ```
+- In the returned template string, insert `${screenBlock}` immediately after `${ambientBlock}` (so it reads `...${intuitionBlock}${ambientBlock}${screenBlock}\nAnswer the user plainly...`).
+
+And pass it from `handleMessage`: change the existing call (currently `this.instructionsForAgent(agent, output, intuitions, ambientContext)`) to:
+```js
+instructions: this.instructionsForAgent(agent, output, intuitions, ambientContext, input.metadata?.screenContext ?? null),
+```
+
+(The `"overlay"` channel already receives ambient context — the gate is `channel !== "autopilot" && channel !== "cron"` — so no channel-list change is needed.)
+
+- [ ] **Step 4: Run it — verify it PASSES**
+
+Run: `node --test test/agent-host-screen-context.test.js` → 4 pass.
+
+- [ ] **Step 5: Full suite**
+
+Run: `node --test` → all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agent-host.js test/agent-host-screen-context.test.js
+git commit -m "feat: agent-host injects metadata.screenContext into the turn
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Swift — `captureFocusedText()` on ScreenCapturer
+
+**Files:**
+- Modify: `mac/Sources/OpenAGI/Capture/ScreenCapturer.swift`
+
+Factor an on-demand capture+OCR that returns text instead of recording, reusing the existing exclusion check and Vision OCR.
+
+- [ ] **Step 1: Add the `ScreenContext` type + method**
+
+At the top of `ScreenCapturer.swift` (after imports), add:
+
+```swift
+struct ScreenContext {
+  let app: String
+  let window: String?
+  let text: String
+}
+```
+
+Add this method to `ScreenCapturer` (it reuses the private `runOcr` and the same SCScreenshotManager path as `captureOnce`, but returns the OCR text via a continuation and does NOT write to storage):
+
+```swift
+// On-demand grab for the floating widget: OCR the current screen (dominated by
+// the frontmost window) and return the text. Honors the same exclusion list as
+// ambient capture, and returns nil when excluded or when capture/permission is
+// unavailable — callers then proceed without screen context.
+func captureFocusedText() async -> ScreenContext? {
+  let app = NSWorkspace.shared.frontmostApplication
+  let bundleId = app?.bundleIdentifier
+  let appName = app?.localizedName ?? bundleId ?? "(unknown)"
+  let windowTitle = Self.frontmostWindowTitle()
+
+  if CaptureSettings.shared.isExcluded(bundleId: bundleId, windowTitle: windowTitle) {
+    return nil
+  }
+
+  do {
+    let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+    guard let display = content.displays.first else { return nil }
+    let filter = SCContentFilter(display: display, excludingWindows: [])
+    let cfg = SCStreamConfiguration()
+    cfg.width = display.width
+    cfg.height = display.height
+    cfg.minimumFrameInterval = CMTime(value: 1, timescale: 1)
+    cfg.queueDepth = 1
+    cfg.scalesToFit = true
+    cfg.showsCursor = false
+
+    let cgImage = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: cfg)
+    let text: String = await withCheckedContinuation { cont in
+      ocrQueue.async {
+        Self.runOcr(image: cgImage) { ocrText, _ in cont.resume(returning: ocrText) }
+      }
+    }
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty { return ScreenContext(app: appName, window: windowTitle, text: "") }
+    return ScreenContext(app: appName, window: windowTitle, text: String(trimmed.prefix(8000)))
+  } catch {
+    NSLog("OpenAGI overlay capture: \(error.localizedDescription)")
+    return nil
+  }
+}
+```
+
+> Note: `ocrQueue` and `runOcr` are existing private members of `ScreenCapturer`, so this method must live in that class (it does). The daemon caps the text again at 4000 (Task 1); 8000 here is a generous upper bound.
+
+- [ ] **Step 2: Build**
+
+Run: `cd mac && swift build 2>&1 | tail -15`
+Expected: build succeeds (warnings OK).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
+git commit -m "feat(mac): ScreenCapturer.captureFocusedText() for on-demand context
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Swift — AppState overlay networking + nudge state hook
+
+**Files:**
+- Modify: `mac/Sources/OpenAGI/AppState.swift`
+
+- [ ] **Step 1: Add a public ask method + a nudges list**
+
+In `AppState`, add a published nudges array near the other `@Published` props:
+```swift
+@Published var nudges: [Nudge] = []
+
+struct Nudge: Identifiable, Equatable {
+  let id: String
+  let title: String
+  let body: String
+  let category: String
+}
+```
+
+Add a public overlay-ask method (uses the existing private `post`):
+```swift
+struct MessageReply: Decodable { let reply: String? }
+
+// Send a question to the agent from the floating widget, attaching fresh
+// focused-window context. Returns the agent's reply text.
+func askOverlay(text: String, screenContext: ScreenContext?) async throws -> String {
+  var meta: [String: Any] = [:]
+  if let s = screenContext, !s.text.isEmpty {
+    meta["screenContext"] = ["app": s.app, "window": s.window as Any, "text": s.text]
+  }
+  let payload: [String: Any] = ["text": text, "channel": "overlay", "metadata": meta]
+  let body = try JSONSerialization.data(withJSONObject: payload)
+  let data = try await post("/message", body: body)
+  let decoded = try JSONDecoder().decode(MessageReply.self, from: data)
+  return decoded.reply ?? "(no reply)"
+}
+```
+
+`askOverlay` is a method on `AppState`, so it can call the existing `private func post` directly — no visibility change needed.
+
+In `handleSSEEvent`, in the existing `if event == "proactive-suggestion"` block, AFTER the `notify(...)` call, append to the nudge list so the widget can show it:
+```swift
+      let nudge = Nudge(
+        id: suggestionId.isEmpty ? UUID().uuidString : suggestionId,
+        title: parsed.name ?? "OpenAGI noticed something",
+        body: body,
+        category: category
+      )
+      nudges.removeAll { $0.id == nudge.id }
+      nudges.insert(nudge, at: 0)
+      if nudges.count > 20 { nudges = Array(nudges.prefix(20)) }
+```
+(`suggestionId`, `parsed`, `category`, `body` are all already in scope in that block.)
+
+- [ ] **Step 2: Build**
+
+Run: `cd mac && swift build 2>&1 | tail -15` → succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mac/Sources/OpenAGI/AppState.swift
+git commit -m "feat(mac): AppState.askOverlay + nudge list from proactive events
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Swift — the panel, view model, and view
+
+**Files:**
+- Create: `mac/Sources/OpenAGI/Overlay/OverlayState.swift`
+- Create: `mac/Sources/OpenAGI/Overlay/OverlayView.swift`
+- Create: `mac/Sources/OpenAGI/Overlay/OverlayController.swift`
+
+- [ ] **Step 1: `OverlayState.swift`**
+
+```swift
+import Foundation
+import SwiftUI
+
+@MainActor
+final class OverlayState: ObservableObject {
+  static let shared = OverlayState()
+
+  @Published var expanded = false
+  @Published var question = ""
+  @Published var answer: String = ""
+  @Published var isLoading = false
+  @Published var error: String? = nil
+  @Published var contextNote: String? = nil   // e.g. "reading Safari" / "no screen context"
+
+  func ask() async {
+    let q = question.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !q.isEmpty else { return }
+    isLoading = true; error = nil; answer = ""
+    let ctx = await ScreenCapturer.shared.captureFocusedText()
+    if let ctx, !ctx.text.isEmpty {
+      contextNote = "reading \(ctx.app)"
+    } else {
+      contextNote = "no screen context"
+    }
+    do {
+      answer = try await AppState.shared.askOverlay(text: q, screenContext: ctx)
+    } catch {
+      self.error = error.localizedDescription
+    }
+    isLoading = false
+  }
+}
+```
+
+- [ ] **Step 2: `OverlayView.swift`**
+
+```swift
+import SwiftUI
+
+struct OverlayView: View {
+  @ObservedObject var state = OverlayState.shared
+  @ObservedObject var app = AppState.shared
+  var onCollapse: () -> Void = {}
+
+  var body: some View {
+    if state.expanded {
+      expandedPanel
+    } else {
+      pill
+    }
+  }
+
+  private var pill: some View {
+    Button(action: { state.expanded = true }) {
+      ZStack {
+        Circle().fill(Color.accentColor).frame(width: 16, height: 16)
+        if !app.nudges.isEmpty {
+          Text("\(app.nudges.count)")
+            .font(.system(size: 9, weight: .bold)).foregroundColor(.white)
+        }
+      }
+      .padding(8)
+    }
+    .buttonStyle(.plain)
+    .background(.ultraThinMaterial, in: Circle())
+  }
+
+  private var expandedPanel: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack {
+        Text("Ask OpenAGI").font(.caption).foregroundStyle(.secondary)
+        Spacer()
+        Button(action: { state.expanded = false; onCollapse() }) {
+          Image(systemName: "xmark.circle.fill").foregroundStyle(.tertiary)
+        }.buttonStyle(.plain)
+      }
+      if app.status == .down {
+        Text("OpenAGI is offline").font(.caption).foregroundStyle(.red)
+      }
+      TextField("Ask about what you're looking at…", text: $state.question, onCommit: { Task { await state.ask() } })
+        .textFieldStyle(.roundedBorder)
+        .disabled(app.status == .down)
+      if let note = state.contextNote {
+        Text(note).font(.system(size: 10)).foregroundStyle(.tertiary)
+      }
+      if state.isLoading {
+        ProgressView().controlSize(.small)
+      } else if let err = state.error {
+        Text(err).font(.caption).foregroundStyle(.red)
+      } else if !state.answer.isEmpty {
+        ScrollView { Text(state.answer).font(.callout).textSelection(.enabled).frame(maxWidth: .infinity, alignment: .leading) }
+          .frame(maxHeight: 220)
+        Button("Continue in chat") { app.openDashboard(path: "/?tab=chat") }
+          .font(.caption).buttonStyle(.plain).foregroundStyle(.blue)
+      }
+    }
+    .padding(12)
+    .frame(width: 320)
+    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+  }
+}
+```
+
+- [ ] **Step 3: `OverlayController.swift`**
+
+```swift
+import AppKit
+import SwiftUI
+
+@MainActor
+final class OverlayController {
+  static let shared = OverlayController()
+  private var panel: NSPanel?
+
+  private static let enabledKey = "openagi.overlay.enabled"
+  private static let frameKey = "openagi.overlay.originX" // y stored alongside
+
+  static var isEnabled: Bool {
+    UserDefaults.standard.object(forKey: enabledKey) == nil ? true : UserDefaults.standard.bool(forKey: enabledKey)
+  }
+  static func setEnabled(_ on: Bool) {
+    UserDefaults.standard.set(on, forKey: enabledKey)
+    if on { shared.show() } else { shared.hide() }
+  }
+
+  func startIfEnabled() { if Self.isEnabled { show() } }
+
+  func show() {
+    if panel == nil { panel = makePanel() }
+    positionPanel()
+    panel?.orderFrontRegardless()
+  }
+
+  func hide() { panel?.orderOut(nil) }
+
+  func toggle() {
+    if panel?.isVisible == true {
+      // toggle expands/collapses rather than hiding entirely
+      OverlayState.shared.expanded.toggle()
+      sizeToContent()
+    } else {
+      OverlayState.shared.expanded = true
+      show(); sizeToContent()
+    }
+  }
+
+  private func makePanel() -> NSPanel {
+    let p = NSPanel(
+      contentRect: NSRect(x: 0, y: 0, width: 320, height: 60),
+      styleMask: [.nonactivatingPanel, .borderless, .fullSizeContentView],
+      backing: .buffered, defer: false)
+    p.isFloatingPanel = true
+    p.level = .statusBar
+    p.hidesOnDeactivate = false
+    p.isMovableByWindowBackground = true
+    p.backgroundColor = .clear
+    p.hasShadow = true
+    p.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+    let host = NSHostingView(rootView: OverlayView(onCollapse: { [weak self] in self?.sizeToContent() }))
+    host.translatesAutoresizingMaskIntoConstraints = true
+    p.contentView = host
+    return p
+  }
+
+  private func sizeToContent() {
+    guard let p = panel, let host = p.contentView else { return }
+    let fitting = host.fittingSize
+    var frame = p.frame
+    let newH = max(44, fitting.height)
+    frame.origin.y += (frame.height - newH) // keep top-left anchored
+    frame.size.height = newH
+    frame.size.width = OverlayState.shared.expanded ? 320 : 44
+    p.setFrame(frame, display: true, animate: false)
+  }
+
+  private func positionPanel() {
+    guard let p = panel, let screen = NSScreen.main else { return }
+    let d = UserDefaults.standard
+    if d.object(forKey: Self.frameKey) != nil {
+      let x = d.double(forKey: Self.frameKey)
+      let y = d.double(forKey: "openagi.overlay.originY")
+      p.setFrameOrigin(NSPoint(x: x, y: y))
+    } else {
+      // default: bottom-right inset
+      let vf = screen.visibleFrame
+      p.setFrameOrigin(NSPoint(x: vf.maxX - 360, y: vf.minY + 80))
+    }
+    sizeToContent()
+  }
+
+  func persistPosition() {
+    guard let p = panel else { return }
+    UserDefaults.standard.set(Double(p.frame.origin.x), forKey: Self.frameKey)
+    UserDefaults.standard.set(Double(p.frame.origin.y), forKey: "openagi.overlay.originY")
+  }
+}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `cd mac && swift build 2>&1 | tail -20` → succeeds. Fix any compile errors (SwiftUI `onCommit` is deprecated but compiles; if the toolchain rejects it, switch the TextField to `.onSubmit { Task { await state.ask() } }`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mac/Sources/OpenAGI/Overlay/
+git commit -m "feat(mac): floating overlay panel, view, and ask view-model
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Swift — global hotkey + app/tray wiring
+
+**Files:**
+- Create: `mac/Sources/OpenAGI/Overlay/HotkeyManager.swift`
+- Modify: `mac/Sources/OpenAGI/AppDelegate.swift`
+- Modify: `mac/Sources/OpenAGI/TrayController.swift`
+
+- [ ] **Step 1: `HotkeyManager.swift` (Carbon, ⌥Space)**
+
+```swift
+import AppKit
+import Carbon.HIToolbox
+
+// System-wide hotkey via Carbon RegisterEventHotKey (needs no Accessibility
+// permission). Default: ⌥Space. Fires onHotkey on the main actor.
+@MainActor
+final class HotkeyManager {
+  static let shared = HotkeyManager()
+  private var ref: EventHotKeyRef?
+  private var handler: EventHandlerRef?
+  var onHotkey: () -> Void = {}
+
+  func register() {
+    var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: OSType(kEventHotKeyPressed))
+    InstallEventHandler(GetApplicationEventTarget(), { _, _, userData -> OSStatus in
+      let me = Unmanaged<HotkeyManager>.fromOpaque(userData!).takeUnretainedValue()
+      Task { @MainActor in me.onHotkey() }
+      return noErr
+    }, 1, &eventType, Unmanaged.passUnretained(self).toOpaque(), &handler)
+
+    let hotKeyID = EventHotKeyID(signature: OSType(0x4F41_4749 /* 'OAGI' */), id: 1)
+    let status = RegisterEventHotKey(UInt32(kVK_Space), UInt32(optionKey), hotKeyID, GetApplicationEventTarget(), 0, &ref)
+    if status != noErr { NSLog("OpenAGI: hotkey registration failed (\(status)) — tray-only") }
+  }
+
+  func unregister() {
+    if let ref { UnregisterEventHotKey(ref) }
+    if let handler { RemoveEventHandler(handler) }
+    ref = nil; handler = nil
+  }
+}
+```
+
+- [ ] **Step 2: Wire into `AppDelegate.applicationDidFinishLaunching`**
+
+Inside the `Task { @MainActor in ... }` block, after `ReplayController.shared.start()`, add:
+```swift
+      OverlayController.shared.startIfEnabled()
+      HotkeyManager.shared.onHotkey = { OverlayController.shared.toggle() }
+      HotkeyManager.shared.register()
+```
+And in `applicationWillTerminate`'s `Task { @MainActor in ... }`, before `DaemonController.shared.stop()`, add:
+```swift
+      OverlayController.shared.persistPosition()
+      HotkeyManager.shared.unregister()
+```
+
+- [ ] **Step 3: Tray toggle + Quick Ask item in `TrayController.swift`**
+
+In `footerSection`, just above the existing `Toggle("Open at Login", ...)`, add:
+```swift
+      Button("Quick Ask  ⌥Space") { OverlayController.shared.toggle() }
+      Toggle("Enable Quick Ask", isOn: Binding(
+        get: { OverlayController.isEnabled },
+        set: { OverlayController.setEnabled($0) }
+      ))
+```
+
+- [ ] **Step 4: Build**
+
+Run: `cd mac && swift build 2>&1 | tail -20` → succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mac/Sources/OpenAGI/Overlay/HotkeyManager.swift mac/Sources/OpenAGI/AppDelegate.swift mac/Sources/OpenAGI/TrayController.swift
+git commit -m "feat(mac): ⌥Space global hotkey + tray Quick Ask toggle, wired in
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+# Phase 2 — Proactive nudges in the pill
+
+### Task 6: Swift — render nudges in the expanded panel
+
+**Files:**
+- Modify: `mac/Sources/OpenAGI/Overlay/OverlayView.swift`
+
+The badge on the collapsed pill already reflects `app.nudges.count` (Task 4). Now show the list when expanded and let the user act.
+
+- [ ] **Step 1: Add a nudges section to `expandedPanel`**
+
+In `OverlayView.expandedPanel`, after the answer block (inside the `VStack`), add:
+```swift
+      if !app.nudges.isEmpty {
+        Divider()
+        Text("Nudges").font(.system(size: 10, weight: .semibold)).foregroundStyle(.secondary)
+        ForEach(app.nudges.prefix(4)) { n in
+          HStack(alignment: .top, spacing: 6) {
+            VStack(alignment: .leading, spacing: 1) {
+              Text(n.title).font(.system(size: 11, weight: .medium))
+              if !n.body.isEmpty { Text(n.body).font(.system(size: 10)).foregroundStyle(.secondary).lineLimit(2) }
+            }
+            Spacer()
+            Button(action: { app.openDashboard(path: "/?tab=chat&suggestion=\(n.id)") }) {
+              Image(systemName: "arrow.up.right.square")
+            }.buttonStyle(.plain).help("Review in chat")
+            Button(action: { app.nudges.removeAll { $0.id == n.id } }) {
+              Image(systemName: "xmark")
+            }.buttonStyle(.plain).help("Dismiss")
+          }
+        }
+      }
+```
+
+(Reviewing a nudge routes into the dashboard chat with the suggestion id — reusing the existing approve/dismiss surface — and "Dismiss" just clears it from the pill. This keeps Phase 2 backend-free, per the spec.)
+
+- [ ] **Step 2: Build**
+
+Run: `cd mac && swift build 2>&1 | tail -20` → succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mac/Sources/OpenAGI/Overlay/OverlayView.swift
+git commit -m "feat(mac): show proactive nudges in the overlay panel
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Docs
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1:** Add a short "Floating widget (Quick Ask)" subsection: ⌥Space (or the tray) opens a floating pill to ask OpenAGI about whatever you're looking at; answers are grounded in the focused window via on-device OCR (honors the capture exclusion list; needs Screen Recording permission, degrades gracefully without it); proactive nudges appear in the pill. Toggle it from the tray ("Enable Quick Ask").
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: floating widget (Quick Ask)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Manual smoke checklist (for the user — not automated)
+
+Document in the PR body. The user runs the packaged app and verifies:
+- [ ] ⌥Space toggles the pill/panel from any app (incl. a fullscreen app).
+- [ ] The panel floats above other windows and doesn't steal focus (you can keep typing in the app behind it).
+- [ ] Asking a question about the visible window returns an answer that reflects on-screen content (Screen Recording granted).
+- [ ] With an excluded app frontmost (e.g. 1Password), the answer notes "no screen context" and nothing is OCR'd.
+- [ ] A proactive suggestion shows a badge on the pill and appears in the panel's Nudges list.
+- [ ] "Enable Quick Ask" off in the tray hides the widget; on shows it; position persists across restarts.
+
+---
+
+## Final verification
+- [ ] `node --test` — full suite green (Task 1's test included).
+- [ ] `cd mac && swift build` — compile-clean.
+- [ ] `grep -rn "formatScreenContextBlock" src test` — used + tested.

--- a/docs/superpowers/plans/2026-06-06-credit-audit-log.md
+++ b/docs/superpowers/plans/2026-06-06-credit-audit-log.md
@@ -1,0 +1,486 @@
+# Credit Usage Audit Log — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A per-call LLM credit (USD) audit log — what cost credits, when, and why (activity/agent/session/tools) — surfaced as a Credits dashboard view (totals + spend chart + audit log) and a `recall_spend` agent tool.
+
+**Architecture:** A focused append-only `CreditLedger` (JSONL, 30-day window). `BudgetGuard` already prices each call; it appends a line item with the context `model-provider` passes. A new endpoint + agent tool + dashboard view read it.
+
+**Tech Stack:** Node 22 ESM, `node:test`. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-credit-audit-log-design.md`
+
+---
+
+# Phase 1 — data + agent (no dashboard UI)
+
+### Task 1: `CreditLedger`
+
+**Files:** Create `src/credit-ledger.js`; create `test/credit-ledger.test.js`.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/credit-ledger.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { CreditLedger } from "../src/credit-ledger.js";
+
+function tmpLedger(opts = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ledger-"));
+  return new CreditLedger({ storePath: path.join(dir, "ledger.jsonl"), ...opts });
+}
+const entry = (over = {}) => ({
+  model: "claude-opus-4-7", usd: 0.05, channel: "chat", agentId: "main",
+  sessionId: "s1", from: "user", tools: ["web_search"],
+  tokens: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0 }, ...over
+});
+
+test("records and queries entries newest-first", () => {
+  const L = tmpLedger();
+  L.record(entry({ usd: 0.01, at: "2026-06-05T10:00:00.000Z" }));
+  L.record(entry({ usd: 0.02, at: "2026-06-06T10:00:00.000Z" }));
+  const rows = L.query({ days: 30, now: new Date("2026-06-06T12:00:00.000Z") });
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0].usd, 0.02); // newest first
+  assert.equal(rows[0].channel, "chat");
+});
+
+test("query window excludes entries older than `days`", () => {
+  const L = tmpLedger();
+  L.record(entry({ at: "2026-05-01T10:00:00.000Z" })); // ~36 days before now
+  L.record(entry({ at: "2026-06-06T10:00:00.000Z" }));
+  const rows = L.query({ days: 30, now: new Date("2026-06-06T12:00:00.000Z") });
+  assert.equal(rows.length, 1);
+});
+
+test("analytics groups by day, model, activity", () => {
+  const L = tmpLedger();
+  L.record(entry({ usd: 0.10, channel: "autopilot", model: "claude-opus-4-7", at: "2026-06-06T09:00:00.000Z" }));
+  L.record(entry({ usd: 0.04, channel: "chat", model: "gpt-5", at: "2026-06-06T10:00:00.000Z" }));
+  L.record(entry({ usd: 0.01, channel: "chat", model: "gpt-5", at: "2026-06-05T10:00:00.000Z" }));
+  const a = L.analytics({ days: 30, now: new Date("2026-06-06T12:00:00.000Z") });
+  assert.equal(a.totalCalls, 3);
+  assert.equal(a.totalUsd, 0.15);
+  assert.equal(a.byActivity.find((x) => x.activity === "autopilot").usd, 0.10);
+  assert.equal(a.byActivity[0].activity, "autopilot"); // sorted by usd desc
+  assert.equal(a.byModel.find((x) => x.model === "gpt-5").calls, 2);
+  assert.deepEqual(a.byDay.map((d) => d.date), ["2026-06-05", "2026-06-06"]); // chronological
+});
+
+test("compacts when the file exceeds the byte threshold, keeping the window", () => {
+  const L = tmpLedger({ compactBytes: 1 }); // force compaction every write
+  L.record(entry({ at: "2026-05-01T10:00:00.000Z" })); // old
+  L.record(entry({ at: "2026-06-06T10:00:00.000Z", now: new Date("2026-06-06T10:00:00.000Z") }));
+  // After a compaction triggered with a recent `now`, the 36-day-old row is gone from disk.
+  const onDisk = fs.readFileSync(L.storePath, "utf8").split("\n").filter(Boolean);
+  assert.equal(onDisk.length, 1);
+});
+
+test("tolerates a missing/corrupt file", () => {
+  const L = tmpLedger();
+  assert.deepEqual(L.query(), []);
+  fs.writeFileSync(L.storePath, "not json\n{bad\n");
+  assert.deepEqual(L.query(), []);
+});
+```
+
+- [ ] **Step 2: Run it — verify FAIL**
+
+`node --test test/credit-ledger.test.js` → module not found.
+
+- [ ] **Step 3: Implement `src/credit-ledger.js`**
+
+```js
+// src/credit-ledger.js
+import fs from "node:fs";
+import path from "node:path";
+import { ensureDir } from "./file-utils.js";
+import { resolveDataDir } from "./data-dir.js";
+
+const RETENTION_DAYS = 30;
+const COMPACT_BYTES = 4 * 1024 * 1024; // compact when the file grows past ~4MB
+
+// Append-only per-call credit (USD) ledger. record() is O(1) append (it runs in
+// the hot path of every LLM call); old entries are filtered out of query()/
+// analytics() by the rolling window, and the file is compacted only when it
+// grows large. Stores no message content — just cost + attribution.
+export class CreditLedger {
+  constructor(options = {}) {
+    this.storePath = options.storePath ?? path.join(resolveDataDir(), "budget", "ledger.jsonl");
+    this.retentionDays = options.retentionDays ?? RETENTION_DAYS;
+    this.compactBytes = options.compactBytes ?? COMPACT_BYTES;
+    ensureDir(path.dirname(this.storePath));
+  }
+
+  _cutoff(days, now) {
+    return new Date(now.getTime() - days * 86400 * 1000).toISOString();
+  }
+
+  _readAll() {
+    let text;
+    try { text = fs.readFileSync(this.storePath, "utf8"); } catch { return []; }
+    const out = [];
+    for (const line of text.split("\n")) {
+      if (!line.trim()) continue;
+      try { out.push(JSON.parse(line)); } catch { /* skip corrupt line */ }
+    }
+    return out;
+  }
+
+  record(entry = {}, { now = new Date() } = {}) {
+    const row = {
+      at: entry.at ?? now.toISOString(),
+      model: entry.model ?? null,
+      tokens: entry.tokens ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      usd: Number(entry.usd ?? 0),
+      channel: entry.channel ?? null,
+      agentId: entry.agentId ?? null,
+      sessionId: entry.sessionId ?? null,
+      from: entry.from ?? null,
+      tools: Array.isArray(entry.tools) ? entry.tools : []
+    };
+    fs.appendFileSync(this.storePath, JSON.stringify(row) + "\n");
+    this._maybeCompact(now);
+    return row;
+  }
+
+  _maybeCompact(now) {
+    let size = 0;
+    try { size = fs.statSync(this.storePath).size; } catch { return; }
+    if (size < this.compactBytes) return;
+    const cutoff = this._cutoff(this.retentionDays, now);
+    const kept = this._readAll().filter((r) => (r.at ?? "") >= cutoff);
+    fs.writeFileSync(this.storePath, kept.map((r) => JSON.stringify(r)).join("\n") + (kept.length ? "\n" : ""));
+  }
+
+  query({ days = this.retentionDays, now = new Date() } = {}) {
+    const cutoff = this._cutoff(days, now);
+    return this._readAll()
+      .filter((r) => (r.at ?? "") >= cutoff)
+      .sort((a, b) => (b.at ?? "").localeCompare(a.at ?? ""));
+  }
+
+  analytics({ days = this.retentionDays, now = new Date() } = {}) {
+    const rows = this.query({ days, now });
+    const byDay = {}, byModel = {}, byActivity = {};
+    let totalUsd = 0, totalCalls = 0;
+    for (const r of rows) {
+      const day = (r.at ?? "").slice(0, 10);
+      const model = r.model ?? "unknown";
+      const activity = r.channel ?? "unknown";
+      const usd = Number(r.usd ?? 0);
+      totalUsd += usd; totalCalls += 1;
+      (byDay[day] ??= { date: day, usd: 0, calls: 0 });        byDay[day].usd += usd; byDay[day].calls += 1;
+      (byModel[model] ??= { model, usd: 0, calls: 0 });        byModel[model].usd += usd; byModel[model].calls += 1;
+      (byActivity[activity] ??= { activity, usd: 0, calls: 0 }); byActivity[activity].usd += usd; byActivity[activity].calls += 1;
+    }
+    const round = (o) => ({ ...o, usd: Number(o.usd.toFixed(4)) });
+    return {
+      totalUsd: Number(totalUsd.toFixed(4)),
+      totalCalls,
+      byDay: Object.values(byDay).sort((a, b) => a.date.localeCompare(b.date)).map(round),
+      byModel: Object.values(byModel).sort((a, b) => b.usd - a.usd).map(round),
+      byActivity: Object.values(byActivity).sort((a, b) => b.usd - a.usd).map(round)
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run it — verify PASS** (`node --test test/credit-ledger.test.js`), then full suite `node --test`.
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/credit-ledger.js test/credit-ledger.test.js
+git commit -m "feat: CreditLedger — per-call cost line items (30-day JSONL)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `BudgetGuard.record(usage, model, meta)` appends a ledger entry
+
+**Files:** Modify `src/budget-guard.js`; create `test/budget-guard-ledger.test.js`.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/budget-guard-ledger.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { BudgetGuard } from "../src/budget-guard.js";
+import { CreditLedger } from "../src/credit-ledger.js";
+
+function tmp() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bg-"));
+  const ledger = new CreditLedger({ storePath: path.join(dir, "ledger.jsonl") });
+  const guard = new BudgetGuard({ storePath: path.join(dir, "usage.json"), ledger });
+  return { guard, ledger };
+}
+
+test("record(meta) writes a ledger entry carrying the context", () => {
+  const { guard, ledger } = tmp();
+  guard.record({ input_tokens: 1000, output_tokens: 500 }, "claude-opus-4-7", {
+    channel: "autopilot", agentId: "main", sessionId: "s9", from: "cron", tools: ["web_search", "add_task"]
+  });
+  const rows = ledger.query({ days: 1 });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].channel, "autopilot");
+  assert.deepEqual(rows[0].tools, ["web_search", "add_task"]);
+  assert.equal(rows[0].model, "claude-opus-4-7");
+  assert.ok(rows[0].usd > 0);
+  assert.equal(rows[0].tokens.input, 1000);
+});
+
+test("record without meta still aggregates and does not throw (back-compat)", () => {
+  const { guard, ledger } = tmp();
+  const res = guard.record({ input_tokens: 100, output_tokens: 50 }, "gpt-5");
+  assert.ok(res.added > 0);
+  // a ledger row is still written, just with null context
+  const rows = ledger.query({ days: 1 });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].channel, null);
+});
+```
+
+- [ ] **Step 2: Run — verify FAIL** (`node --test test/budget-guard-ledger.test.js`): `meta` ignored, no ledger.
+
+- [ ] **Step 3: Implement**
+
+In `src/budget-guard.js`:
+- Add imports at top: `import { nowIso } from "./utils.js";` and `import { CreditLedger } from "./credit-ledger.js";`
+- In the constructor, after `this.state = ...`, add:
+  ```js
+  this.ledger = options.ledger ?? new CreditLedger({ storePath: path.join(path.dirname(this.storePath), "ledger.jsonl") });
+  ```
+- Change `record(usage, model)` to `record(usage, model, meta = {})`. After the daily-aggregate block (after `day.calls += 1;` and before `this.persist();`), append the ledger entry (best-effort — never let a ledger failure break the model call):
+  ```js
+  try {
+    this.ledger?.record({
+      at: nowIso(),
+      model,
+      tokens,
+      usd,
+      channel: meta.channel ?? null,
+      agentId: meta.agentId ?? null,
+      sessionId: meta.sessionId ?? null,
+      from: meta.from ?? null,
+      tools: Array.isArray(meta.tools) ? meta.tools : []
+    });
+  } catch { /* ledger is best-effort; never break a reply over it */ }
+  ```
+
+- [ ] **Step 4: Run — verify PASS**, then full suite `node --test`.
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/budget-guard.js test/budget-guard-ledger.test.js
+git commit -m "feat: BudgetGuard.record appends a credit-ledger line item
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `model-provider` threads context + tool names into `record`
+
+**Files:** Modify `src/model-provider.js`.
+
+- [ ] **Step 1:** Both providers call `this.budgetGuard?.record(json.usage, this.model);` (Anthropic ~line 253, OpenAI ~line 146). At each site, `context` and the local `toolCalls` array are in scope. Replace each call with:
+
+```js
+      this.budgetGuard?.record(json.usage, this.model, {
+        channel: context.channel,
+        agentId: context.agentId,
+        sessionId: context.sessionId,
+        from: context.from,
+        tools: toolCalls.map((c) => c.name)
+      });
+```
+
+Verify at each site that `toolCalls` is the in-scope array of `{ name, ... }` (it is — both providers build it before recording). Use grep to find both: `grep -n "budgetGuard?.record" src/model-provider.js`.
+
+- [ ] **Step 2:** Run the full suite `node --test` → all green (no provider unit test calls the network; existing tests must still pass). Also import-smoke: `node -e "import('./src/model-provider.js').then(()=>console.log('ok'))"`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/model-provider.js
+git commit -m "feat: pass activity/agent/session/tools context to budget record
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `GET /budget/ledger` endpoint
+
+**Files:** Modify `src/hosted-interface.js` (routing section only — NOT the renderApp template).
+
+- [ ] **Step 1:** Find the existing budget route: `grep -n 'pathname === "/budget"' src/hosted-interface.js` (around line 340). Immediately after that line, add a sibling route:
+
+```js
+      if (method === "GET" && pathname === "/budget/ledger") {
+        const ledger = runtime.budget?.ledger;
+        if (!ledger) return sendJson(res, 200, { error: "no-ledger" });
+        const days = Math.max(1, Math.min(90, Number.parseInt(url.searchParams.get("days") ?? "30", 10) || 30));
+        return sendJson(res, 200, { days, entries: ledger.query({ days }), analytics: ledger.analytics({ days }) });
+      }
+```
+
+Confirm how the existing routes read query params (the file already parses a `url`/`pathname`; match the existing pattern — if it uses `new URL(req.url, base)`, reuse that `url.searchParams`; if query parsing differs, follow the local convention). Do NOT touch any template-literal/renderApp code.
+
+- [ ] **Step 2:** Smoke-test the route wiring with a runtime:
+```bash
+node -e "import('./src/index.js').then(async ({createDurableRuntime, createHostedInterface})=>{const rt=createDurableRuntime({});const app=createHostedInterface(rt,{host:'127.0.0.1',port:0});const {port}=await app.listen();const r=await fetch('http://127.0.0.1:'+port+'/budget/ledger?days=7');console.log(r.status, JSON.stringify(await r.json()).slice(0,120));process.exit(0)})" 2>&1 | tail -3
+```
+Expected: `200` with `{days:7,entries:[...],analytics:{...}}` (entries likely empty on a fresh runtime). If auth gates the route, the smoke may 401 — that's fine, it confirms the route exists; note it.
+
+- [ ] **Step 3:** `node --test` → still green. Commit:
+```bash
+git add src/hosted-interface.js
+git commit -m "feat: GET /budget/ledger returns credit entries + analytics
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `recall_spend` agent tool
+
+**Files:** Modify `src/tool-registry.js`; create `test/recall-spend.test.js`.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/recall-spend.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ToolRegistry, registerCoreTools } from "../src/tool-registry.js";
+import { CreditLedger } from "../src/credit-ledger.js";
+
+test("recall_spend summarizes the ledger", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rs-"));
+  const ledger = new CreditLedger({ storePath: path.join(dir, "ledger.jsonl") });
+  ledger.record({ usd: 0.10, channel: "autopilot", model: "claude-opus-4-7", tools: ["web_search"] });
+  ledger.record({ usd: 0.02, channel: "chat", model: "gpt-5", tools: [] });
+  const registry = new ToolRegistry();
+  registerCoreTools(registry, { budget: { ledger } });
+  const { result } = await registry.invoke("recall_spend", { days: 30 });
+  assert.ok(result.totalUsd >= 0.12 - 1e-9);
+  assert.equal(result.byActivity[0].activity, "autopilot");
+  assert.ok(Array.isArray(result.top));
+});
+```
+(If `registerCoreTools` requires a fuller runtime, pass a minimal stub with just `{ budget: { ledger } }` and whatever else it dereferences at registration time — registration only defines the tool; the handler reads `runtime.budget.ledger` at call time.)
+
+- [ ] **Step 2: Run — verify FAIL** (unknown tool `recall_spend`).
+
+- [ ] **Step 3: Implement** — in `src/tool-registry.js`, inside `registerCoreTools(registry, runtime)`, add:
+
+```js
+  registry.register({
+    name: "recall_spend",
+    description: "Summarize LLM credit (USD) usage: how much has been spent, on what activity/model, and the costliest recent calls. Use to answer questions about cost/credits/budget — e.g. 'why did I spend $4 today?'.",
+    parameters: {
+      type: "object",
+      properties: {
+        days: { type: "integer", minimum: 1, maximum: 90, description: "Look-back window in days (default 1 = today)." }
+      },
+      additionalProperties: false
+    },
+    handler: async (args) => {
+      const ledger = runtime.budget?.ledger;
+      if (!ledger) return { error: "no credit ledger available" };
+      const days = args.days ?? 1;
+      const analytics = ledger.analytics({ days });
+      const top = ledger.query({ days })
+        .slice()
+        .sort((a, b) => (b.usd ?? 0) - (a.usd ?? 0))
+        .slice(0, 10)
+        .map((r) => ({ at: r.at, model: r.model, activity: r.channel, agentId: r.agentId, usd: Number((r.usd ?? 0).toFixed(4)), tools: r.tools ?? [] }));
+      return { days, totalUsd: analytics.totalUsd, calls: analytics.totalCalls, byActivity: analytics.byActivity, byModel: analytics.byModel, top };
+    }
+  });
+```
+
+- [ ] **Step 4: Run — verify PASS**, then full suite `node --test`.
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tool-registry.js test/recall-spend.test.js
+git commit -m "feat: recall_spend tool — answer credit/cost questions from the ledger
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+# Phase 2 — Credits dashboard view
+
+### Task 6: Evolve the Budget tab into "Credits"
+
+**Files:** Modify `src/hosted-interface.js` (the `renderApp` template + the client-side tab JS).
+
+> ⚠️ **Template-literal trap (repo memory):** `renderApp` is a giant Node template literal that emits the dashboard HTML+JS. Any `${...}` you add that should appear literally in the *client* JS must be written escaped (`\${...}`), and do not introduce stray backticks. Mirror exactly how the existing `renderBudget`/budget tab code is written (find it: `grep -n "budget" src/hosted-interface.js` and read the existing tab's render + fetch code before editing). Build the new view in the SAME style.
+
+- [ ] **Step 1:** Locate the existing Budget tab rendering and its data fetch (it calls `/budget`). Read it fully to learn the established escaping + DOM-building idiom used elsewhere in `renderApp`.
+
+- [ ] **Step 2:** Rename the nav label to **Credits** (the `<button data-tab="budget" ...>Budget</button>` at ~line 1832 → `>Credits<`; keep `data-tab="budget"` to avoid touching the tab-routing JS, OR rename to `credits` consistently in the nav + the client tab switch + the render function — pick one and be consistent).
+
+- [ ] **Step 3:** Extend the tab's render to fetch `/budget/ledger?days=30` and render three blocks, matching the existing dashboard component styling (cards/tokens):
+  1. **Header (existing):** today's spend vs cap (keep).
+  2. **Grouped totals:** `analytics.byActivity` and `analytics.byModel` as small labeled rows (e.g. "autopilot — $4.10 (12 calls)").
+  3. **Spend-over-time chart:** an inline **SVG** bar chart over `analytics.byDay` (last 30). No library — compute bar heights from `usd` relative to the max; render `<rect>`s in a fixed-size `<svg>`. Keep it ~120px tall.
+  4. **Audit log:** a scrollable list of `entries` (newest first): `time · model · activity · agent · $X.XXXX · tools`. Cap the rendered rows (e.g. first 200) with a note if truncated.
+
+  Escape all interpolations per the trap above. Reuse the existing fetch helper the dashboard uses for `/budget`.
+
+- [ ] **Step 4: Verify the file still parses / route renders.** Run:
+```bash
+node -e "import('./src/hosted-interface.js').then(()=>console.log('module ok'))"
+node -e "import('./src/index.js').then(async ({createDurableRuntime, createHostedInterface})=>{const rt=createDurableRuntime({});const app=createHostedInterface(rt,{host:'127.0.0.1',port:0});const {port}=await app.listen();const r=await fetch('http://127.0.0.1:'+port+'/');console.log('GET /', r.status);process.exit(0)})" 2>&1 | tail -2
+```
+Expected: `module ok` and `GET / 200` (or 401 if auth-gated — either confirms `renderApp` didn't crash at runtime, which is the trap this guards against). Run `node --test` → green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hosted-interface.js
+git commit -m "feat: Credits dashboard — totals, spend chart, and per-call audit log
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Docs
+
+**Files:** Modify `README.md`.
+
+- [ ] **Step 1:** Add a short "Credits / cost audit" note: the Credits tab shows today's spend vs cap, totals by activity/model, a 30-day spend chart, and a per-call audit log (what cost credits and why); ask the agent in chat via `recall_spend` ("why did I spend $X today?"); data is a local 30-day ledger at `~/.openagi/budget/ledger.jsonl` (no message content stored).
+
+- [ ] **Step 2: Commit**
+```bash
+git add README.md
+git commit -m "docs: credit usage audit log (Credits tab + recall_spend)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+- [ ] `node --test` — full suite green (Tasks 1, 2, 5 add real tests).
+- [ ] `node -e "import('./src/index.js').then(()=>console.log('ok'))"` — imports clean.
+- [ ] `grep -rn "recall_spend" src` — tool registered; `grep -rn "ledger" src/budget-guard.js` — wired.

--- a/docs/superpowers/specs/2026-06-02-external-knowledge-sources-design.md
+++ b/docs/superpowers/specs/2026-06-02-external-knowledge-sources-design.md
@@ -1,0 +1,174 @@
+# External Knowledge Sources — Design
+
+**Date:** 2026-06-02
+**Status:** Approved (brainstorming) — pending implementation plan
+**Scope:** Two independent features in one spec:
+1. Web search + page-fetch tools backed by a multi-provider abstraction.
+2. BuildBetter transcript ingestion (alongside the existing action-item "signals" ingestion).
+
+These give the agent live web grounding (parity with competitors' web search) and let it
+ground answers in the user's actual call transcripts, not just extracted action items.
+
+---
+
+## Feature 1 — Web search + page fetch
+
+### Goal
+The agent can search the live web and fetch page contents through a single, provider-agnostic
+tool surface, with any of six providers wired in and pluggable by which API keys are set.
+
+### Module & wiring
+- New module: `src/integrations/web-search.js`, exporting `registerWebSearchTools(runtime)`.
+- Called from `src/abi-runtime.js` alongside the other `register*` integrations (same pattern as
+  `registerComputerUseTools(runtime)`). Registers tools via `runtime.tools.register(...)`.
+
+### Provider abstraction
+Each provider is a small adapter with a uniform interface:
+
+```
+{
+  name: string,
+  isConfigured(): boolean,          // true when its API key env var(s) are present
+  async search(query, opts): NormalizedResult[],
+  async fetch?(url, opts): string,  // optional; only Firecrawl implements rich fetch
+}
+```
+
+`NormalizedResult` shape (provider responses are mapped into this):
+
+```
+{ title: string, url: string, snippet: string, publishedDate?: string, content?: string }
+```
+
+Shared adapter rules:
+- One `fetch()` call per request (POST or GET per provider), 15s timeout (`AbortController`).
+- On non-2xx or network/timeout error, throw a typed error; the tool layer catches and either
+  falls back or returns a structured `{ error }`.
+- Never throw raw secrets into error messages.
+
+### The six adapters
+
+| Provider    | Endpoint                                         | Auth header                    | Key env var(s)                        | Notes |
+|-------------|--------------------------------------------------|--------------------------------|---------------------------------------|-------|
+| exa         | `POST https://api.exa.ai/search`                 | `x-api-key`                    | `EXA_API_KEY`                         | body `{ query, numResults, contents: { text: true } }` |
+| tavily      | `POST https://api.tavily.com/search`             | `Authorization: Bearer`        | `TAVILY_API_KEY`                      | body `{ query, max_results, search_depth, include_answer }` |
+| firecrawl   | `POST https://api.firecrawl.dev/v2/search`       | `Authorization: Bearer`        | `FIRECRAWL_API_KEY`                   | also implements `fetch()` via `/v2/scrape` (markdown) |
+| brave       | `GET https://api.search.brave.com/res/v1/web/search?q=` | `X-Subscription-Token`  | `BRAVE_API_KEY`                       | results under `web.results[]` |
+| perplexity  | `POST https://api.perplexity.ai/chat/completions`| `Authorization: Bearer`        | `PERPLEXITY_API_KEY`                  | answer API (model `sonar`); map answer + `citations[]` into results |
+| serpapi     | `GET https://serpapi.com/search.json?engine=google&q=` | query param `api_key`    | `SERPAPI_API_KEY`                     | Google SERP. Alt: Google CSE if `GOOGLE_API_KEY`+`GOOGLE_CSE_ID` set |
+
+> Exact request/response field names are confirmed against each provider's current docs during
+> implementation; the table is the contract, adapters absorb per-provider quirks.
+
+### Tools the agent sees
+Both tools are **read-only → no confirmation gate** (`needsConfirmation: false`).
+
+1. **`web_search`**
+   - Params: `{ query: string, provider?: enum(exa|tavily|firecrawl|brave|perplexity|serpapi),
+     num_results?: int (default 5), recency?: enum(day|week|month|year) }`
+   - Provider resolution order:
+     1. explicit `provider` arg (if that adapter is configured; else error)
+     2. `WEB_SEARCH_PROVIDER` env default (if configured)
+     3. first configured adapter in the default priority order
+   - **Default priority order:** `exa → tavily → brave → serpapi → firecrawl → perplexity`
+     (configurable later; documented as the built-in default).
+   - **Fallback:** if the chosen provider throws, try the next configured adapter in priority
+     order. If all fail (or none configured), return `{ error }` with a clear message.
+   - Returns: `{ provider, results: NormalizedResult[] }`.
+
+2. **`fetch_url`**
+   - Params: `{ url: string, format?: enum(markdown|text) (default markdown) }`
+   - Uses Firecrawl `/v2/scrape` when `FIRECRAWL_API_KEY` is set (best markdown);
+     otherwise a plain `fetch` + minimal HTML→text fallback, so it works with **zero keys**.
+   - Returns: `{ url, format, content }` or `{ error }`.
+
+### Config surface
+New env vars, surfaced in `setup-wizard.js`, README, and `.env` example:
+- `EXA_API_KEY`, `TAVILY_API_KEY`, `FIRECRAWL_API_KEY`, `BRAVE_API_KEY`,
+  `PERPLEXITY_API_KEY`, `SERPAPI_API_KEY` (and optional `GOOGLE_API_KEY` + `GOOGLE_CSE_ID`)
+- `WEB_SEARCH_PROVIDER` — optional default provider override.
+
+If **no** provider key is set, `web_search` registers but returns a structured "no web search
+provider configured" error when called (consistent with how other env-gated features degrade).
+`fetch_url` still works keyless via the plain-fetch fallback.
+
+---
+
+## Feature 2 — BuildBetter transcripts vs signals
+
+### Goal
+Let the user choose whether the BuildBetter integration ingests **action-item signals**
+(today's behavior), **full transcripts** (searchable context), or **both**.
+
+### Config toggle
+New env var **`BUILDBETTER_INGEST_MODE`**:
+- `signals` (**default** — preserves today's exact behavior; no change unless opted in)
+- `transcripts`
+- `both`
+
+Parsed in `BuildBetterTaskSource` (`src/integrations/buildbetter-tasks.js`). Unknown/empty →
+`signals`.
+
+### Behavior by mode
+- **signals** → unchanged: `getRecentCalls()` → `getActionItems()` → `runtime.tasks.add(...)`.
+- **transcripts** → new `syncTranscripts()`:
+  1. Reuse `getRecentCalls(sinceIso)` (existing attended-call filter by email/name).
+  2. For each call, fetch its transcript via a new GraphQL query.
+  3. Record into the observation store as a new **`transcript`** text kind:
+     `{ kind: "transcript", at: call.started_at, app: "BuildBetter",
+        window: call.name, text: <transcript text>, ref: "buildbetter:call:<id>" }`
+  4. **Dedup** by `ref` — skip calls already recorded (check existing texts for that ref, or
+     track a synced-call set / `lastTranscriptSyncedAt`).
+  5. Because transcripts live in the observation store, **`recall_activity` searches them for
+     free** — no new search tool needed.
+- **both** → run signals sync and transcript sync in the same pass.
+
+### Dependencies this creates
+1. **`observation-store.js` `record()` gains a `transcript` kind.** It currently handles only
+   `activity` and `frame`/`frame-summary`. Add a branch that inserts into the `texts` FTS table
+   with `kind = "transcript"`, `ref = <call ref>`, `at`, `app`, `window`, `text`. This is the
+   single targeted change to the store; it keeps transcripts searchable via the existing
+   `search()` / `recall_activity` path.
+2. **Exact BuildBetter transcript GraphQL field is not yet in the codebase.** The BuildBetter MCP
+   (`get-call-transcript`, etc.) confirms transcripts are available. During implementation, probe
+   the live BuildBetter schema (via the connected MCP) to nail the exact query — whether it's an
+   `interview.transcript` field or a separate utterances/segments table — before finalizing
+   `syncTranscripts()`.
+
+### Polling
+Reuse the existing coalesced 15-min sync. `registerBuildBetterTaskSource` already adds the
+`buildbetter-task-sync` cron job and the `triggerSync()` coalescing path. Extend the single sync
+pass to do signals and/or transcripts based on `BUILDBETTER_INGEST_MODE` (one job, mode-gated),
+rather than adding a second job.
+
+### Registration gating
+`isConfigured()` stays `apiKey && (userEmail || userName)`. The mode only selects *what* is
+synced; an unconfigured BuildBetter integration still no-ops.
+
+---
+
+## Testing
+
+- **Web search adapters:** unit test each adapter with a mocked `fetch` — assert request shape
+  (URL, headers, body) and response→`NormalizedResult` mapping.
+- **`web_search` tool:** provider resolution (explicit arg / env default / priority order),
+  fallback-on-error across configured providers, and the "no provider configured" path.
+- **`fetch_url`:** Firecrawl path vs keyless plain-fetch fallback (both mocked).
+- **BuildBetter transcripts:** `syncTranscripts()` with a mocked `query()` and an in-memory
+  observation store (same isolation approach as the pattern-miner test); assert dedup by `ref`
+  and that mode gating runs the right sync(s).
+- **observation-store:** `record()` accepts and stores the new `transcript` kind; `search()`
+  returns it.
+
+## Out of scope (YAGNI)
+- No per-provider result re-ranking or merging across providers (single provider per call +
+  fallback only).
+- No transcript summarization/embedding beyond FTS (the store's existing search is enough).
+- No UI beyond the existing dashboard/recall surfaces.
+- No new mobile/overlay work (tracked separately).
+
+## Build sequencing (for the plan)
+1. Web search provider abstraction + `web_search`/`fetch_url` tools + tests + config surface.
+2. observation-store `transcript` kind + test.
+3. BuildBetter `BUILDBETTER_INGEST_MODE` + `syncTranscripts()` + tests + config surface
+   (depends on step 2; probe live schema first).

--- a/docs/superpowers/specs/2026-06-02-stable-config-location-design.md
+++ b/docs/superpowers/specs/2026-06-02-stable-config-location-design.md
@@ -1,0 +1,156 @@
+# Stable Config / Data Location — Design
+
+**Date:** 2026-06-02
+**Status:** Approved (brainstorming decisions) — pending user spec review → implementation plan
+**Problem:** API keys and setup state don't survive updates / relaunches in dev / bare-source /
+launchd installs.
+
+## Root cause
+
+Config and state paths default to the **cwd-relative** string `".openagi"`:
+
+- `envFilePath()` (`src/setup-wizard.js:44`): `path.join(process.env.OPENAGI_DATA_DIR ?? ".openagi", ".env")`
+- ~35 other call sites independently use `path.join(process.cwd(), ".openagi", …)` for
+  observations, channels, cron, agents, pending-actions, outcomes, etc.
+
+There is **no single source of truth** for the data directory, and the default is resolved
+against the current working directory. Consequences by launch mode:
+
+| Launch mode | `OPENAGI_DATA_DIR` | `.env` location | Stable? |
+|---|---|---|---|
+| Mac `.app` | `~/Library/Application Support/OpenAGI` | stable | yes |
+| Docker | `/data` (+ volume) | stable | yes |
+| `npm run serve` / bare source / launchd | **unset** → `.openagi` | `<cwd>/.openagi/.env` (inside the checkout) | **no** |
+
+The `saveEnv()` merge logic itself is correct (read-merge-write, `0600`, preserves untouched
+keys). Nothing deletes the file maliciously — the daemon simply reads a *different cwd-relative
+folder* than the one written to when launched from a different directory, re-cloned, or when the
+`.app` "adopts" a terminal daemon (`DaemonController.swift:48`) so the source of truth flip-flops.
+
+## Decisions (from brainstorming)
+
+1. **Default location:** `~/.openagi` on every OS (single predictable path).
+2. **Scope:** unify ALL state through one resolver, not just `.env`.
+3. **Migration:** none — start fresh at the new location; user re-runs `/setup` once.
+
+## Design
+
+### 1. Single resolver — `src/data-dir.js`
+
+```js
+import os from "node:os";
+import path from "node:path";
+
+let cached = null;
+
+export function resolveDataDir() {
+  if (cached) return cached;
+  const override = process.env.OPENAGI_DATA_DIR;
+  cached = override ? path.resolve(override) : path.join(os.homedir(), ".openagi");
+  return cached;
+}
+
+// Test seam: clear the memoized value (used by unit tests that mutate env).
+export function _resetDataDirCache() { cached = null; }
+```
+
+- Honors `OPENAGI_DATA_DIR` (Docker `/data`, Mac app, power users) — absolute via `path.resolve`.
+- Default is an **absolute** `~/.openagi`, independent of cwd → survives updates, re-clones,
+  launch-dir changes.
+
+### 2. Route everything through it
+
+Replace the cwd-relative fallbacks. Each store keeps its explicit `options.dir` override; only
+the *default* changes. Examples:
+
+- `envFilePath(dataDir)` → `path.join(dataDir ?? resolveDataDir(), ".env")`
+- `observation-store.js`: `options.dir ?? path.join(resolveDataDir(), "observations")`
+- channels / cron / agents / pending-actions / outcomes / scrutiny / clarifications /
+  session-miner / proactive-observer / mcp-oauth / tunnel-watcher / suggestion-feed / etc.
+
+**Layout side effect (intended):** today the Mac app writes `.env` at `<dataDir>/.env` but
+observations at `<cwd>/.openagi/observations` (a nested `.openagi`). After the refactor every
+store sits directly under the resolved dir — one clean tree:
+
+```
+~/.openagi/
+  .env
+  observations/
+  channels/
+  cron/
+  agents/
+  ...
+```
+
+### 3. Boot loader — `examples/hosted-server.js`
+
+Replace:
+```js
+const dataDir = process.env.OPENAGI_DATA_DIR ?? ".openagi";
+loadEnvFile(path.join(dataDir, ".env"));
+loadEnvFile(".env");
+loadEnvFile(".openagi/.env");
+```
+with:
+```js
+const dataDir = resolveDataDir();
+loadEnvFile(path.join(dataDir, ".env"));   // canonical (first-wins via loadEnvFile)
+loadEnvFile(".env");                         // optional local-dev override in cwd
+```
+`loadEnvFile` only sets a key when it's absent (`if (!(key in process.env))`), so the canonical
+file wins and a stray cwd `.env` can only fill gaps.
+
+### 4. Mac app (Swift)
+
+Update `AppState.dataDir()` (`mac/Sources/OpenAGI/AppState.swift:98`) to return
+`~/.openagi` so the `.app` and the CLI/terminal daemon share one directory:
+
+```swift
+nonisolated static func dataDir() -> URL {
+  let home = FileManager.default.homeDirectoryForCurrentUser
+  let dir = home.appendingPathComponent(".openagi", isDirectory: true)
+  try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+  return dir
+}
+```
+
+`DaemonController` continues to set `OPENAGI_DATA_DIR = dataDir.path` and cwd, so the JS resolver
+agrees.
+
+> ⚠️ **Risk to confirm at review:** with no migration, existing `.app` users' state currently in
+> `~/Library/Application Support/OpenAGI` is *not* moved — they re-run `/setup` once after the
+> update. Alternative: leave the Mac app on Application Support (already stable) and accept that
+> "everywhere `~/.openagi`" applies to non-app installs only. **Default in this spec: change the
+> app to `~/.openagi` for true unification.**
+
+### 5. Docs / scripts / UX
+
+- README, setup-wizard copy, dashboard hints: `.openagi/.env` → `~/.openagi/.env`.
+- `/setup` shows the **resolved absolute path** (`resolveDataDir()`) so the location is never a
+  mystery.
+- `install-launchd.sh` / `install-systemd.sh`: WorkingDirectory no longer matters for state, but
+  set `OPENAGI_DATA_DIR=~/.openagi` (or `$HOME/.openagi`) explicitly in the unit for clarity.
+- `.gitignore`: the repo-local `.openagi/*` ignore can stay (harmless); state no longer lands
+  there by default.
+
+## Testing
+
+- `resolveDataDir()`: returns `~/.openagi` when env unset; returns resolved absolute of
+  `OPENAGI_DATA_DIR` when set; memoization + `_resetDataDirCache()`.
+- A representative store (e.g. ObservationStore) writes under `resolveDataDir()` when no
+  `options.dir` is passed, and under the override when env is set.
+- `saveEnv` / `loadEnvFile` round-trip against a temp `OPENAGI_DATA_DIR`.
+
+## Out of scope (YAGNI)
+
+- No automatic migration/copy from the old location (explicitly declined).
+- No split of secrets vs state into separate dirs (single tree is enough for now).
+- No encryption-at-rest of `.env` beyond the existing `0600` perms.
+
+## Build sequencing (for the plan)
+
+1. `src/data-dir.js` + tests.
+2. Repoint `envFilePath()` + boot loader; verify `/setup` save→reload round-trips to `~/.openagi`.
+3. Sweep the remaining ~34 cwd-relative `.openagi` call sites through `resolveDataDir()`.
+4. Swift `AppState.dataDir()` change (gated on review decision).
+5. Docs / install scripts / UX copy.

--- a/docs/superpowers/specs/2026-06-05-floating-widget-design.md
+++ b/docs/superpowers/specs/2026-06-05-floating-widget-design.md
@@ -1,0 +1,144 @@
+# Floating Widget ("Quick Ask") — Design
+
+**Date:** 2026-06-05
+**Status:** Approved (brainstorming) — pending implementation plan
+**Branch:** `feat/floating-widget` (stacks on `feat/external-knowledge-sources`)
+
+## Goal
+A native macOS always-on-top floating widget (a collapsed pill that expands into a
+panel) that lets the user ask OpenAGI a question from anywhere, grounded in the
+content of the window they're looking at, and surfaces proactive nudges. This closes
+the last of the three littlebird.ai gaps (web search and BuildBetter transcripts are
+already shipped on the sibling branch).
+
+## Decisions (from brainstorming)
+- **Form factor:** floating pill (collapsed `●`) that expands into a panel.
+- **Summon:** global hotkey (default **⌥Space**) **and** a tray menu item.
+- **v1 behavior:** ask → answer inline, **plus** proactive nudges in the panel.
+- **Context:** live-grab the focused window per ask, reusing the existing
+  ScreenCapturer + Vision OCR pipeline (honoring the privacy exclusion list).
+
+## Architecture
+The widget is added to the existing SwiftUI menu-bar app (`mac/Sources/OpenAGI`). It
+hosts SwiftUI inside a native AppKit `NSPanel` and talks to the daemon the app already
+manages (`http://127.0.0.1:43210`) over HTTP — no new service, no new process. One
+small daemon-side (JS) change lets a message carry fresh screen context and is the
+single automated-test seam.
+
+```
+⌥Space / pill tap
+  → FocusedWindowGrabber: OCR frontmost window (privacy-filtered) → {app, window, text}
+  → POST /message { text, channel:"overlay", metadata:{ screenContext } }
+  → daemon agent-host injects screenContext into the turn context → agent answers
+  → OverlayView renders the reply (markdown) with a "continue in chat" link
+```
+
+## Components
+
+### macOS (new files under `mac/Sources/OpenAGI/Overlay/`)
+1. **`OverlayPanelController.swift`** (AppKit) — owns an `NSPanel`:
+   - style: `[.nonactivatingPanel, .borderless]`; `isFloatingPanel = true`;
+     `level = .statusBar`; `hidesOnDeactivate = false`;
+     `collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]`
+     so it floats over every Space/app incl. fullscreen without stealing focus.
+   - hosts an `NSHostingView(rootView: OverlayView)`.
+   - manages collapsed↔expanded sizing, draggable position persisted to
+     `UserDefaults` (`openagi.overlay.frame`), and `show()/hide()/toggle()`.
+   - the panel's own window is excluded from capture (so the pill never OCRs itself —
+     add its `windowNumber` to the `SCContentFilter` excluded set, or rely on the
+     frontmost-window targeting which never targets a non-activating panel).
+2. **`OverlayView.swift`** (SwiftUI) — observes `OverlayState`:
+   - **collapsed:** a small `●` pill; in Phase 2 a badge with the nudge count.
+   - **expanded:** a text field ("Ask OpenAGI…"), submit affordance (Return), an
+     answer area rendering markdown, a "Continue in chat" button (opens the dashboard
+     via the existing `AppState.openDashboard`), a subtle "reading <app>"/"no screen
+     context" indicator, and (Phase 2) a nudges list.
+3. **`OverlayState.swift`** (`@MainActor ObservableObject`) — the view model:
+   - `ask(_ question:)`: calls `FocusedWindowGrabber`, POSTs `/message`, sets
+     `answer`/`isLoading`/`error`. Daemon-health aware via `AppState.shared`.
+   - holds `nudges: [Suggestion]` fed from `AppState` (Phase 2).
+4. **`HotkeyManager.swift`** — registers a system-wide hotkey via Carbon
+   `RegisterEventHotKey` (default ⌥Space; constant in v1, configurable later). On fire,
+   calls `OverlayPanelController.toggle()`. Carbon hotkeys need no Accessibility
+   permission. Unregisters on teardown.
+5. **`FocusedWindowGrabber.swift`** — a focused, on-demand capture factored from
+   `ScreenCapturer.captureOnce()`:
+   - `func grab() async -> ScreenContext?` returns `{ app, window, text }` where `text`
+     is the Vision-OCR'd frontmost window content, truncated (e.g. 4000 chars).
+   - honors `CaptureSettings.shared.isExcluded(bundleId:windowTitle:)` — returns `nil`
+     (no context) for excluded apps/windows (1Password, banking, etc.).
+   - returns `nil` quietly if Screen Recording permission is absent.
+
+### macOS (edits to existing files)
+6. **`AppDelegate.swift`** — instantiate `OverlayPanelController` + `HotkeyManager` at
+   startup (gated on the overlay-enabled setting), tear down on quit.
+7. **`TrayController.swift`** — add a "Quick Ask  ⌥Space" item that toggles the panel,
+   and an "Enable Quick Ask" toggle (persisted in `UserDefaults`
+   `openagi.overlay.enabled`, default **on**; mirrors the login-item toggle pattern).
+8. **`AppState.swift`** — expose the proactive-suggestion list it already receives via
+   `SSEDelegate` (`/events`) so `OverlayState` can show nudges (Phase 2); add a small
+   `postMessage(text:metadata:)` helper if one isn't already present.
+
+### Daemon (JS — the one backend change + its test)
+9. **`src/agent-host.js`** — when an inbound message has
+   `metadata.screenContext = { app, window, text }`, include it in the turn's context
+   block (the same place `observations.getRecentContext` output is added), clearly
+   labeled (e.g. `Active window (<app> — <window>):\n<text>`). Treat the `"overlay"`
+   channel as a context-bearing channel (like `"local"`). Truncate the injected text
+   defensively. **No secret/PII handling beyond honoring the client-side exclusion
+   list** (the grabber already filtered).
+
+## Data flow & transport
+- **Ask:** synchronous `POST /message` returns the agent's reply in the HTTP response
+  (`channels.handleLocalMessage`), so Phase 1 renders the full answer on completion
+  with a thinking state. Token-by-token streaming via the existing `/events` SSE is a
+  deferred enhancement, not required for v1.
+- **Nudges (Phase 2):** reuse the existing SSE path — `SSEDelegate` already routes
+  `proactive-suggestion` events into `AppState`; `OverlayState` mirrors that list and
+  uses the existing suggestion accept/dismiss endpoints.
+
+## Error handling
+- Daemon offline → panel shows "OpenAGI is offline" (from `AppState.status`); ask
+  disabled.
+- OCR unavailable / window excluded → ask proceeds **without** screen context, with a
+  subtle "no screen context" note (never block the ask).
+- Hotkey registration fails (conflict) → log + fall back to tray-only; surface a one-time
+  note in the tray.
+- `/message` non-200 → inline error in the panel, ask remains retryable.
+
+## Privacy & permissions
+- **Screen Recording** permission (reused from ambient capture) gates OCR; absent → no
+  context, ask still works.
+- The `CaptureSettings` exclusion list is honored on every grab, so excluded
+  apps/windows are never read.
+- The panel shows which app it read ("reading Safari…") so context capture is never
+  invisible.
+- Carbon global hotkey needs no permission.
+
+## Testing & honest constraints
+- The macOS UI (NSPanel, hotkey, OCR grab, SwiftUI) is **not** unit-testable in this
+  repo (all existing tests are JS) — it is verified by `swift build` (compile-clean) and
+  manual runtime checks by the user (the panel floats, ⌥Space toggles, an ask returns a
+  grounded answer, excluded apps yield no context).
+- **Automated test (JS):** `test/agent-host-screen-context.test.js` — a message with
+  `metadata.screenContext` produces a turn whose context block contains the labeled
+  active-window text, and the `"overlay"` channel is handled like `"local"`. This is the
+  one behavior with a real seam, so it gets a real test.
+
+## Out of scope (YAGNI)
+- Token-by-token answer streaming (deferred; sync reply is enough for v1).
+- Configurable hotkey UI (default ⌥Space hardcoded for v1; wire a setting later).
+- Inline action-approval buttons in the panel (the agent's draft/pending-action
+  surfaces stay in the dashboard for v1; "continue in chat" bridges there).
+- Windows/Linux equivalents (macOS-only feature).
+
+## Build sequencing (for the plan)
+**Phase 1 — ask flow**
+1. Daemon: `agent-host` `screenContext` injection + `overlay` channel + JS test.
+2. `FocusedWindowGrabber` (factor from ScreenCapturer) — returns OCR'd focused-window text, exclusion-aware.
+3. `OverlayPanelController` + `OverlayView` + `OverlayState` — the pill/panel and ask flow (POST /message with screenContext).
+4. `HotkeyManager` (⌥Space) + `AppDelegate` wiring + `TrayController` toggle.
+5. `swift build` green; manual smoke checklist documented.
+
+**Phase 2 — proactive nudges**
+6. `AppState` exposes the suggestion list; `OverlayState` mirrors it; `OverlayView` shows badge + list with accept/dismiss via existing endpoints.

--- a/docs/superpowers/specs/2026-06-06-credit-audit-log-design.md
+++ b/docs/superpowers/specs/2026-06-06-credit-audit-log-design.md
@@ -1,0 +1,144 @@
+# Credit Usage Audit Log — Design
+
+**Date:** 2026-06-06
+**Status:** Approved (brainstorming) — pending implementation plan
+**Branch:** `feat/credit-audit-log` (off `feat/external-knowledge-sources`)
+
+## Goal
+A per-call audit log of LLM credit (USD) usage so the user can see **what** cost
+credits, **when**, and **why** (which activity / agent / session / tools). Today
+`BudgetGuard` only stores daily aggregates (`{input, output, cacheRead, cacheWrite,
+usd, calls}` per day) — there is no per-call record. This adds the line-item ledger,
+a Credits dashboard view with totals + charts, and a `recall_spend` agent tool.
+
+## Decisions (from brainstorming)
+- **What to log:** rich per-call context — time, model, tokens, `$`, plus the why
+  (channel/activity, agent, session, tools called that turn).
+- **Surface:** evolve the existing **Budget** dashboard tab into **Credits**, AND add a
+  `recall_spend` agent tool so the user can ask cost questions in chat.
+- **Depth:** full analytics — line items + grouped totals + spend-over-time charts.
+- **Retention:** rolling **30 days** (capped file).
+
+## Architecture
+A focused `CreditLedger` (append-only JSONL) records one entry per priced LLM call.
+`BudgetGuard` already prices each call and computes the `$`; it composes the ledger and
+appends the line item with the context passed by `model-provider`. The dashboard and a
+new agent tool read the ledger. No new process, no external dependency.
+
+```
+LLM call → BudgetGuard.record(usage, model, meta)
+             ├─ daily aggregate (existing, unchanged)
+             └─ CreditLedger.record({ at, model, tokens, usd, ...meta })
+GET /budget/ledger?days=30 → { entries, analytics }   → Credits dashboard view
+recall_spend tool (chat)   → ledger summary           → "why did I spend $X today?"
+```
+
+## Components
+
+### 1. `CreditLedger` — `src/credit-ledger.js` (new)
+One responsibility: durable per-call cost line items.
+- Storage: JSONL at `path.join(resolveDataDir(), "budget", "ledger.jsonl")`.
+- `record(entry)` — appends `{ at: ISO, model, tokens: {input, output, cacheRead,
+  cacheWrite}, usd, channel, agentId, sessionId, from, tools: string[] }`. Prunes
+  entries older than the retention window on write (rolling 30 days).
+- `query({ days = 30 })` — returns entries within the window, newest first.
+- `analytics({ days = 30 })` — returns grouped totals:
+  - `byDay`: `[{ date, usd, calls }]` (for the spend-over-time chart)
+  - `byModel`: `[{ model, usd, calls }]`
+  - `byActivity`: `[{ activity, usd, calls }]` (activity = channel, e.g. chat /
+    autopilot / cron / overlay / sms)
+  - `totalUsd`, `totalCalls` for the window.
+- Constructor takes `{ storePath, retentionDays = 30 }` for test injection. Degrades
+  safely (missing/corrupt file → empty ledger).
+
+### 2. `BudgetGuard.record(usage, model, meta = {})` — `src/budget-guard.js`
+- Pricing + daily-aggregate logic unchanged.
+- After computing `usd`, append a ledger entry:
+  `this.ledger?.record({ at: nowIso(), model, tokens, usd, channel: meta.channel ?? null,
+  agentId: meta.agentId ?? null, sessionId: meta.sessionId ?? null, from: meta.from ??
+  null, tools: meta.tools ?? [] })`.
+- `meta` is optional → existing callers/tests keep working unchanged.
+- BudgetGuard constructs `this.ledger = options.ledger ?? new CreditLedger({ storePath:
+  <budgetDir>/ledger.jsonl })`. `status()` gains nothing new (the ledger has its own
+  query/analytics); a thin `ledger(opts)` passthrough may be added for the endpoint.
+
+### 3. `model-provider.js` — thread the context (lines ~146 and ~253)
+Both `record(json.usage, this.model)` call sites become:
+```js
+this.budgetGuard?.record(json.usage, this.model, {
+  channel: context.channel, agentId: context.agentId,
+  sessionId: context.sessionId, from: context.from,
+  tools: toolCalls.map((c) => c.name)
+});
+```
+`context` and `toolCalls` are already in scope at both sites.
+
+### 4. Endpoint — `src/hosted-interface.js`
+`GET /budget/ledger?days=30` → `sendJson(200, { entries, analytics })` from
+`runtime.budget.ledger.query(...)` + `.analytics(...)`. Returns `{ error }` when no
+budget/ledger is wired.
+
+### 5. `recall_spend` agent tool — `src/tool-registry.js`
+- Params: `{ days?: integer (default 1) }`.
+- Handler: reads `runtime.budget.ledger.analytics({ days })` + top N costliest entries,
+  returns `{ totalUsd, calls, byActivity, byModel, top: [...] }` so the agent can answer
+  "what's been costing me credits and why".
+- Read-only, no confirmation gate.
+
+### 6. Dashboard: Budget tab → "Credits" — `src/hosted-interface.js`
+Evolve the existing `data-tab="budget"` surface (keep today's spend vs cap header), add:
+- **Grouped totals:** by activity and by model (e.g. "autopilot $4.10 · chat $1.20").
+- **Spend-over-time chart:** lightweight inline **SVG bars** over `byDay` (no charting
+  library) — last 30 days.
+- **Audit log:** a scrollable list of line items — `time · model · activity · agent ·
+  $ · tools`.
+- Rename the tab label to "Credits"; keep `data-tab="budget"` (or switch to
+  `data-tab="credits"` consistently — pick one and update the nav + the client tab JS).
+> ⚠️ This file is template-literal-heavy. Per the repo's known trap, escape any `${...}`
+> added inside `renderApp`'s template literal and avoid stray backticks, or the route
+> crashes at runtime.
+
+## Data flow & privacy
+- The ledger stores: timestamp, model, token counts, `$`, channel/activity, agentId,
+  sessionId, from, and tool **names** — **no message content, no secrets**. Local file
+  under `~/.openagi/budget/`, pruned to 30 days.
+- `analytics`/`query` never leave the machine (local dashboard + local agent tool).
+
+## Error handling
+- Missing/corrupt ledger file → treated as empty (record re-creates it). Never throws
+  into the model-generate path (record is best-effort; a ledger failure must not break a
+  reply — wrap the append in try/catch and swallow, mirroring the existing best-effort
+  pattern around budget).
+- Endpoint/tool with no budget wired → structured `{ error }`.
+
+## Testing
+- **`CreditLedger`** (real unit tests): `record` appends; `query({days})` filters the
+  window; `analytics` groups by day/model/activity correctly; 30-day prune drops old
+  entries; corrupt-file tolerance.
+- **`BudgetGuard.record`**: with `meta`, writes a ledger entry carrying the context;
+  without `meta`, still records the aggregate (back-compat).
+- **`recall_spend`**: returns a correct summary from a seeded ledger.
+- **Endpoint**: `GET /budget/ledger` returns `{ entries, analytics }` (via the existing
+  hosted-interface test pattern, if present; else a focused runtime test).
+- The dashboard JS (template-literal UI) is not unit-testable here — verified by
+  reasoning + manual.
+
+## Out of scope (YAGNI)
+- Tracking non-LLM external costs (web-search/MCP provider charges aren't priced by the
+  app today). The ledger records the **tool names** invoked in a turn for attribution,
+  but not separate $ for them.
+- Per-message content logging.
+- CSV export / external billing integration.
+- Configurable retention UI (30 days is fixed; constructor-overridable).
+
+## Build sequencing (for the plan)
+**Phase 1 — data + agent (no `hosted-interface.js` UI):**
+1. `CreditLedger` + tests.
+2. `BudgetGuard.record(meta)` composes the ledger + test.
+3. `model-provider` threads context/tools into `record`.
+4. `GET /budget/ledger` endpoint.
+5. `recall_spend` tool + test.
+
+**Phase 2 — Credits dashboard view (`hosted-interface.js`):**
+6. Evolve the Budget tab into Credits: grouped totals + inline-SVG spend chart + audit
+   log line items.

--- a/examples/hosted-server.js
+++ b/examples/hosted-server.js
@@ -7,7 +7,7 @@ const dataDir = resolveDataDir();
 
 // Load env in priority order — canonical data dir wins over local-dev overrides.
 loadEnvFile(path.join(dataDir, ".env")); // canonical (loadEnvFile is first-wins)
-loadEnvFile(".env");                      // optional local-dev override in cwd
+loadEnvFile(".env");                       // fills in keys absent from the canonical file (cwd, local dev)
 
 const port = Number.parseInt(process.env.PORT ?? "43210", 10);
 const host = process.env.HOST ?? "127.0.0.1";

--- a/examples/hosted-server.js
+++ b/examples/hosted-server.js
@@ -1,17 +1,37 @@
+import fs from "node:fs";
 import path from "node:path";
 import { createDurableRuntime, createHostedInterface } from "../src/index.js";
 import { loadEnvFile } from "../src/file-utils.js";
 import { resolveDataDir, _resetDataDirCache } from "../src/data-dir.js";
 
-// A bootstrap .env in the cwd may itself set OPENAGI_DATA_DIR, so it MUST be
-// loaded before the data dir is resolved (resolveDataDir memoizes its result).
-// Reset the cache first in case an import already resolved it, then resolve and
-// load the canonical <dataDir>/.env for the remaining keys (loadEnvFile is
-// first-wins, so the bootstrap file stays authoritative for OPENAGI_DATA_DIR).
-loadEnvFile(".env");
+// Read a single var from an env file WITHOUT importing the rest of its keys.
+function peekEnvVar(file, key) {
+  try {
+    for (const raw of fs.readFileSync(file, "utf8").split(/\r?\n/)) {
+      const line = raw.trim();
+      if (!line || line.startsWith("#")) continue;
+      const i = line.indexOf("=");
+      if (i <= 0 || line.slice(0, i).trim() !== key) continue;
+      let v = line.slice(i + 1).trim();
+      if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
+      return v;
+    }
+  } catch { /* no file */ }
+  return null;
+}
+
+// A cwd .env may set OPENAGI_DATA_DIR, which must be known BEFORE the data dir
+// is resolved (resolveDataDir memoizes). But we must NOT bulk-load the cwd .env
+// first: its blank sample entries (OPENAI_API_KEY=, EXA_API_KEY=) would shadow
+// the real values in the canonical ~/.openagi/.env, since loadEnvFile is
+// first-wins. So: peek only OPENAGI_DATA_DIR, resolve, load the canonical file
+// (authoritative), then let the cwd .env fill any remaining gaps.
+const cwdDataDir = peekEnvVar(".env", "OPENAGI_DATA_DIR");
+if (cwdDataDir && !process.env.OPENAGI_DATA_DIR) process.env.OPENAGI_DATA_DIR = cwdDataDir;
 _resetDataDirCache();
 const dataDir = resolveDataDir();
-loadEnvFile(path.join(dataDir, ".env"));
+loadEnvFile(path.join(dataDir, ".env")); // canonical — authoritative (first-wins)
+loadEnvFile(".env");                       // cwd .env fills only keys the canonical didn't set
 
 const port = Number.parseInt(process.env.PORT ?? "43210", 10);
 const host = process.env.HOST ?? "127.0.0.1";

--- a/examples/hosted-server.js
+++ b/examples/hosted-server.js
@@ -1,13 +1,17 @@
 import path from "node:path";
 import { createDurableRuntime, createHostedInterface } from "../src/index.js";
 import { loadEnvFile } from "../src/file-utils.js";
-import { resolveDataDir } from "../src/data-dir.js";
+import { resolveDataDir, _resetDataDirCache } from "../src/data-dir.js";
 
+// A bootstrap .env in the cwd may itself set OPENAGI_DATA_DIR, so it MUST be
+// loaded before the data dir is resolved (resolveDataDir memoizes its result).
+// Reset the cache first in case an import already resolved it, then resolve and
+// load the canonical <dataDir>/.env for the remaining keys (loadEnvFile is
+// first-wins, so the bootstrap file stays authoritative for OPENAGI_DATA_DIR).
+loadEnvFile(".env");
+_resetDataDirCache();
 const dataDir = resolveDataDir();
-
-// Load env in priority order — canonical data dir wins over local-dev overrides.
-loadEnvFile(path.join(dataDir, ".env")); // canonical (loadEnvFile is first-wins)
-loadEnvFile(".env");                       // fills in keys absent from the canonical file (cwd, local dev)
+loadEnvFile(path.join(dataDir, ".env"));
 
 const port = Number.parseInt(process.env.PORT ?? "43210", 10);
 const host = process.env.HOST ?? "127.0.0.1";

--- a/examples/hosted-server.js
+++ b/examples/hosted-server.js
@@ -1,13 +1,13 @@
 import path from "node:path";
 import { createDurableRuntime, createHostedInterface } from "../src/index.js";
 import { loadEnvFile } from "../src/file-utils.js";
+import { resolveDataDir } from "../src/data-dir.js";
 
-const dataDir = process.env.OPENAGI_DATA_DIR ?? ".openagi";
+const dataDir = resolveDataDir();
 
-// Load env in priority order — explicit data dir wins over the conventional fallbacks.
-loadEnvFile(path.join(dataDir, ".env"));
-loadEnvFile(".env");
-loadEnvFile(".openagi/.env");
+// Load env in priority order — canonical data dir wins over local-dev overrides.
+loadEnvFile(path.join(dataDir, ".env")); // canonical (loadEnvFile is first-wins)
+loadEnvFile(".env");                      // optional local-dev override in cwd
 
 const port = Number.parseInt(process.env.PORT ?? "43210", 10);
 const host = process.env.HOST ?? "127.0.0.1";

--- a/mac/Sources/OpenAGI/AppDelegate.swift
+++ b/mac/Sources/OpenAGI/AppDelegate.swift
@@ -22,6 +22,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
       UpdateController.shared.start()
       CaptureController.shared.start()
       ReplayController.shared.start()
+      OverlayController.shared.startIfEnabled()
+      HotkeyManager.shared.onHotkey = { OverlayController.shared.toggle() }
+      HotkeyManager.shared.register()
 
       // Wake observer: the moment macOS resumes from sleep we (1) probe
       // /health to see if the daemon survived the sleep cycle, restart
@@ -52,6 +55,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
       ReplayController.shared.stop()
       CaptureController.shared.stop()
       _ = await CaptureBridge.flushNow()
+      OverlayController.shared.persistPosition()
+      HotkeyManager.shared.unregister()
       DaemonController.shared.stop()
     }
   }

--- a/mac/Sources/OpenAGI/AppDelegate.swift
+++ b/mac/Sources/OpenAGI/AppDelegate.swift
@@ -14,6 +14,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
       UNUserNotificationCenter.current().delegate = self
       UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
 
+      LoginItem.registerOnFirstLaunchIfNeeded()
+
       DaemonController.shared.start()
       AppState.shared.startPolling()
       AppState.shared.startSSE()

--- a/mac/Sources/OpenAGI/AppState.swift
+++ b/mac/Sources/OpenAGI/AppState.swift
@@ -26,6 +26,14 @@ final class AppState: ObservableObject {
   @Published var recentSessions: [SessionSummary] = []
   @Published var topTasks: [TaskSummary] = []
   @Published var paused: Bool = false
+  @Published var nudges: [Nudge] = []
+
+  struct Nudge: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let body: String
+    let category: String
+  }
 
   private var pollTimer: Timer?
   private var sseTask: URLSessionDataTask?
@@ -262,6 +270,15 @@ final class AppState: ObservableObject {
       let suggestionId = parseField(data, "id") ?? ""
       let pathPart = suggestionId.isEmpty ? "/?tab=chat" : "/?tab=chat&suggestion=\(urlEncode(suggestionId))"
       notify(title: title, body: body, path: pathPart)
+      let nudge = Nudge(
+        id: suggestionId.isEmpty ? UUID().uuidString : suggestionId,
+        title: parsed.name ?? "OpenAGI noticed something",
+        body: body,
+        category: category
+      )
+      nudges.removeAll { $0.id == nudge.id }
+      nudges.insert(nudge, at: 0)
+      if nudges.count > 20 { nudges = Array(nudges.prefix(20)) }
     }
     if event == "daily-recap" {
       // Story 7: evening "what did you get done today" notification.
@@ -332,6 +349,24 @@ final class AppState: ObservableObject {
     content.userInfo = ["path": path]
     let req = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
     UNUserNotificationCenter.current().add(req)
+  }
+
+  struct MessageReply: Decodable { let reply: String? }
+
+  // Send a question to the agent from the floating widget, attaching fresh
+  // focused-window context. Returns the agent's reply text.
+  func askOverlay(text: String, screenContext: ScreenContext?) async throws -> String {
+    var meta: [String: Any] = [:]
+    if let s = screenContext, !s.text.isEmpty {
+      var sc: [String: Any] = ["app": s.app, "text": s.text]
+      if let w = s.window { sc["window"] = w }
+      meta["screenContext"] = sc
+    }
+    let payload: [String: Any] = ["text": text, "channel": "overlay", "metadata": meta]
+    let body = try JSONSerialization.data(withJSONObject: payload)
+    let data = try await post("/message", body: body)
+    let decoded = try JSONDecoder().decode(MessageReply.self, from: data)
+    return decoded.reply ?? "(no reply)"
   }
 
   func togglePause() async {

--- a/mac/Sources/OpenAGI/AppState.swift
+++ b/mac/Sources/OpenAGI/AppState.swift
@@ -96,8 +96,8 @@ final class AppState: ObservableObject {
 
   // Non-isolated so DaemonController (and any future non-main-actor code) can call it.
   nonisolated static func dataDir() -> URL {
-    let support = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-    let dir = support.appendingPathComponent("OpenAGI", isDirectory: true)
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    let dir = home.appendingPathComponent(".openagi", isDirectory: true)
     try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
     return dir
   }

--- a/mac/Sources/OpenAGI/AppState.swift
+++ b/mac/Sources/OpenAGI/AppState.swift
@@ -300,12 +300,22 @@ final class AppState: ObservableObject {
     return (json["name"] as? String, json["description"] as? String)
   }
 
+  // Tracks whether we've already fired the budget notification for the current
+  // over-cap episode. pollOnce() calls fetchAuditAndNotify() every ~5s while
+  // degraded, so without this latch the budget warning notifies on every poll
+  // (spam once spend crosses 70%). Re-armed when spend drops back under the cap
+  // (or resets at day rollover).
+  private var budgetNotified = false
+
   private func fetchAuditAndNotify() async {
-    if findings.contains(where: { $0.severity == "warn" && $0.area == "budget" }) {
-      notify(title: "OpenAGI budget", body: "Today's spend > 70% of daily cap.", path: "/")
-    }
-    if findings.contains(where: { $0.area == "specialists" }) {
-      // Avoid spamming — only notify on transitions; for now, no-op.
+    let budgetWarn = findings.contains { $0.severity == "warn" && $0.area == "budget" }
+    if budgetWarn {
+      if !budgetNotified {
+        notify(title: "OpenAGI budget", body: "Today's spend > 70% of daily cap.", path: "/")
+        budgetNotified = true
+      }
+    } else {
+      budgetNotified = false
     }
   }
 

--- a/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
+++ b/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
@@ -119,7 +119,19 @@ final class ScreenCapturer {
 
     do {
       let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
-      guard let display = content.displays.first else { return nil }
+      // Pick the display the frontmost window is actually on — on multi-monitor
+      // setups the focused window may not be on the primary display, and grabbing
+      // displays.first would OCR the wrong monitor. Match the front app's
+      // on-screen window (preferring the AX focused-window title, else its
+      // largest window) and use the display containing that window's center.
+      let frontPid = app?.processIdentifier
+      let appWindows = content.windows.filter { $0.owningApplication?.processID == frontPid && $0.isOnScreen }
+      let frontWindow = appWindows.first { ($0.title ?? "") == (windowTitle ?? "") && !(windowTitle ?? "").isEmpty }
+        ?? appWindows.max { ($0.frame.width * $0.frame.height) < ($1.frame.width * $1.frame.height) }
+      let display = frontWindow.flatMap { w in
+        content.displays.first { $0.frame.contains(CGPoint(x: w.frame.midX, y: w.frame.midY)) }
+      } ?? content.displays.first
+      guard let display else { return nil }
       var excluded: [SCWindow] = []
       if let wn = excludingWindowNumber {
         excluded = content.windows.filter { $0.windowID == CGWindowID(wn) }

--- a/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
+++ b/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
@@ -132,20 +132,33 @@ final class ScreenCapturer {
         content.displays.first { $0.frame.contains(CGPoint(x: w.frame.midX, y: w.frame.midY)) }
       } ?? content.displays.first
       guard let display else { return nil }
-      var excluded: [SCWindow] = []
-      if let wn = excludingWindowNumber {
-        excluded += content.windows.filter { $0.windowID == CGWindowID(wn) }
-      }
-      // Also cut out any window belonging to an excluded app/title, so OCR never
-      // reads e.g. 1Password sitting beside the focused app on the same display
-      // (the frontmost-only privacy check above doesn't cover other visible windows).
-      excluded += content.windows.filter { w in
-        CaptureSettings.shared.isExcluded(bundleId: w.owningApplication?.bundleIdentifier, windowTitle: w.title)
-      }
-      let filter = SCContentFilter(display: display, excludingWindows: excluded)
+      let filter: SCContentFilter
       let cfg = SCStreamConfiguration()
-      cfg.width = display.width
-      cfg.height = display.height
+      if let frontWindow {
+        // We matched the focused window: capture JUST that window. A
+        // display-level grab would OCR every other (non-excluded) window
+        // sharing the monitor — side-by-side Mail/Slack/docs text — and
+        // attribute it to the focused app, misgrounding the answer.
+        filter = SCContentFilter(desktopIndependentWindow: frontWindow)
+        let scale = CGFloat(filter.pointPixelScale)
+        cfg.width = max(1, Int(frontWindow.frame.width * scale))
+        cfg.height = max(1, Int(frontWindow.frame.height * scale))
+      } else {
+        // No window match — fall back to the whole display, minus the overlay
+        // and any window belonging to an excluded app/title, so OCR never
+        // reads e.g. 1Password sitting beside the focused app on the display
+        // (the frontmost-only privacy check above doesn't cover other windows).
+        var excluded: [SCWindow] = []
+        if let wn = excludingWindowNumber {
+          excluded += content.windows.filter { $0.windowID == CGWindowID(wn) }
+        }
+        excluded += content.windows.filter { w in
+          CaptureSettings.shared.isExcluded(bundleId: w.owningApplication?.bundleIdentifier, windowTitle: w.title)
+        }
+        filter = SCContentFilter(display: display, excludingWindows: excluded)
+        cfg.width = display.width
+        cfg.height = display.height
+      }
       cfg.minimumFrameInterval = CMTime(value: 1, timescale: 1)
       cfg.queueDepth = 1
       cfg.scalesToFit = true

--- a/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
+++ b/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
@@ -106,7 +106,8 @@ final class ScreenCapturer {
   // the frontmost window) and return the text. Honors the same exclusion list as
   // ambient capture, and returns nil when excluded or when capture/permission is
   // unavailable — callers then proceed without screen context.
-  func captureFocusedText() async -> ScreenContext? {
+  func captureFocusedText(excludingWindowNumber: Int? = nil) async -> ScreenContext? {
+    if !CaptureSettings.shared.isActiveNow() { return nil }
     let app = NSWorkspace.shared.frontmostApplication
     let bundleId = app?.bundleIdentifier
     let appName = app?.localizedName ?? bundleId ?? "(unknown)"
@@ -119,7 +120,11 @@ final class ScreenCapturer {
     do {
       let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
       guard let display = content.displays.first else { return nil }
-      let filter = SCContentFilter(display: display, excludingWindows: [])
+      var excluded: [SCWindow] = []
+      if let wn = excludingWindowNumber {
+        excluded = content.windows.filter { $0.windowID == CGWindowID(wn) }
+      }
+      let filter = SCContentFilter(display: display, excludingWindows: excluded)
       let cfg = SCStreamConfiguration()
       cfg.width = display.width
       cfg.height = display.height

--- a/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
+++ b/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
@@ -134,7 +134,13 @@ final class ScreenCapturer {
       guard let display else { return nil }
       var excluded: [SCWindow] = []
       if let wn = excludingWindowNumber {
-        excluded = content.windows.filter { $0.windowID == CGWindowID(wn) }
+        excluded += content.windows.filter { $0.windowID == CGWindowID(wn) }
+      }
+      // Also cut out any window belonging to an excluded app/title, so OCR never
+      // reads e.g. 1Password sitting beside the focused app on the same display
+      // (the frontmost-only privacy check above doesn't cover other visible windows).
+      excluded += content.windows.filter { w in
+        CaptureSettings.shared.isExcluded(bundleId: w.owningApplication?.bundleIdentifier, windowTitle: w.title)
       }
       let filter = SCContentFilter(display: display, excludingWindows: excluded)
       let cfg = SCStreamConfiguration()

--- a/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
+++ b/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
@@ -13,6 +13,12 @@ import Vision
 // exclusion check (so private windows / banking sites are skipped before
 // OCR runs).
 
+struct ScreenContext {
+  let app: String
+  let window: String?
+  let text: String
+}
+
 @MainActor
 final class ScreenCapturer {
   static let shared = ScreenCapturer()
@@ -93,6 +99,47 @@ final class ScreenCapturer {
       }
     } catch {
       NSLog("OpenAGI capture: \(error.localizedDescription)")
+    }
+  }
+
+  // On-demand grab for the floating widget: OCR the current screen (dominated by
+  // the frontmost window) and return the text. Honors the same exclusion list as
+  // ambient capture, and returns nil when excluded or when capture/permission is
+  // unavailable — callers then proceed without screen context.
+  func captureFocusedText() async -> ScreenContext? {
+    let app = NSWorkspace.shared.frontmostApplication
+    let bundleId = app?.bundleIdentifier
+    let appName = app?.localizedName ?? bundleId ?? "(unknown)"
+    let windowTitle = Self.frontmostWindowTitle()
+
+    if CaptureSettings.shared.isExcluded(bundleId: bundleId, windowTitle: windowTitle) {
+      return nil
+    }
+
+    do {
+      let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+      guard let display = content.displays.first else { return nil }
+      let filter = SCContentFilter(display: display, excludingWindows: [])
+      let cfg = SCStreamConfiguration()
+      cfg.width = display.width
+      cfg.height = display.height
+      cfg.minimumFrameInterval = CMTime(value: 1, timescale: 1)
+      cfg.queueDepth = 1
+      cfg.scalesToFit = true
+      cfg.showsCursor = false
+
+      let cgImage = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: cfg)
+      let text: String = await withCheckedContinuation { cont in
+        ocrQueue.async {
+          Self.runOcr(image: cgImage) { ocrText, _ in cont.resume(returning: ocrText) }
+        }
+      }
+      let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+      if trimmed.isEmpty { return ScreenContext(app: appName, window: windowTitle, text: "") }
+      return ScreenContext(app: appName, window: windowTitle, text: String(trimmed.prefix(8000)))
+    } catch {
+      NSLog("OpenAGI overlay capture: \(error.localizedDescription)")
+      return nil
     }
   }
 

--- a/mac/Sources/OpenAGI/LoginItem.swift
+++ b/mac/Sources/OpenAGI/LoginItem.swift
@@ -1,0 +1,40 @@
+import Foundation
+import ServiceManagement
+
+// Manages the macOS "open at login" state via SMAppService (macOS 13+).
+// Registration only takes effect when running as a proper signed .app bundle
+// (built by scripts/build-mac-app.sh); under a bare `swift build` executable
+// the calls compile but may no-op/throw at runtime, which we log and ignore.
+enum LoginItem {
+  private static let didInitialRegisterKey = "openagi.loginItem.didInitialRegister"
+
+  static var isEnabled: Bool {
+    SMAppService.mainApp.status == .enabled
+  }
+
+  static func setEnabled(_ enabled: Bool) {
+    do {
+      if enabled {
+        if SMAppService.mainApp.status != .enabled {
+          try SMAppService.mainApp.register()
+        }
+      } else {
+        if SMAppService.mainApp.status == .enabled {
+          try SMAppService.mainApp.unregister()
+        }
+      }
+    } catch {
+      NSLog("OpenAGI: login item \(enabled ? "register" : "unregister") failed: \(error.localizedDescription)")
+    }
+  }
+
+  // Enable open-at-login ONCE on first launch so it's on by default, but record
+  // that we did it — so if the user later turns it off, we never silently turn
+  // it back on.
+  static func registerOnFirstLaunchIfNeeded() {
+    let defaults = UserDefaults.standard
+    if defaults.bool(forKey: didInitialRegisterKey) { return }
+    setEnabled(true)
+    defaults.set(true, forKey: didInitialRegisterKey)
+  }
+}

--- a/mac/Sources/OpenAGI/Overlay/HotkeyManager.swift
+++ b/mac/Sources/OpenAGI/Overlay/HotkeyManager.swift
@@ -1,0 +1,31 @@
+import AppKit
+import Carbon.HIToolbox
+
+// System-wide hotkey via Carbon RegisterEventHotKey (needs no Accessibility
+// permission). Default: ⌥Space. Fires onHotkey on the main actor.
+@MainActor
+final class HotkeyManager {
+  static let shared = HotkeyManager()
+  private var ref: EventHotKeyRef?
+  private var handler: EventHandlerRef?
+  var onHotkey: () -> Void = {}
+
+  func register() {
+    var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: OSType(kEventHotKeyPressed))
+    InstallEventHandler(GetApplicationEventTarget(), { _, _, userData -> OSStatus in
+      let me = Unmanaged<HotkeyManager>.fromOpaque(userData!).takeUnretainedValue()
+      Task { @MainActor in me.onHotkey() }
+      return noErr
+    }, 1, &eventType, Unmanaged.passUnretained(self).toOpaque(), &handler)
+
+    let hotKeyID = EventHotKeyID(signature: OSType(0x4F41_4749), id: 1)
+    let status = RegisterEventHotKey(UInt32(kVK_Space), UInt32(optionKey), hotKeyID, GetApplicationEventTarget(), 0, &ref)
+    if status != noErr { NSLog("OpenAGI: hotkey registration failed (\(status)) — tray-only") }
+  }
+
+  func unregister() {
+    if let ref { UnregisterEventHotKey(ref) }
+    if let handler { RemoveEventHandler(handler) }
+    ref = nil; handler = nil
+  }
+}

--- a/mac/Sources/OpenAGI/Overlay/OverlayController.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayController.swift
@@ -1,0 +1,88 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class OverlayController {
+  static let shared = OverlayController()
+  private var panel: NSPanel?
+
+  private static let enabledKey = "openagi.overlay.enabled"
+  private static let frameKey = "openagi.overlay.originX"
+
+  static var isEnabled: Bool {
+    UserDefaults.standard.object(forKey: enabledKey) == nil ? true : UserDefaults.standard.bool(forKey: enabledKey)
+  }
+  static func setEnabled(_ on: Bool) {
+    UserDefaults.standard.set(on, forKey: enabledKey)
+    if on { shared.show() } else { shared.hide() }
+  }
+
+  func startIfEnabled() { if Self.isEnabled { show() } }
+
+  func show() {
+    if panel == nil { panel = makePanel() }
+    positionPanel()
+    panel?.orderFrontRegardless()
+  }
+
+  func hide() { panel?.orderOut(nil) }
+
+  func toggle() {
+    if panel?.isVisible == true {
+      OverlayState.shared.expanded.toggle()
+      sizeToContent()
+    } else {
+      OverlayState.shared.expanded = true
+      show(); sizeToContent()
+    }
+  }
+
+  private func makePanel() -> NSPanel {
+    let p = NSPanel(
+      contentRect: NSRect(x: 0, y: 0, width: 320, height: 60),
+      styleMask: [.nonactivatingPanel, .borderless, .fullSizeContentView],
+      backing: .buffered, defer: false)
+    p.isFloatingPanel = true
+    p.level = .statusBar
+    p.hidesOnDeactivate = false
+    p.isMovableByWindowBackground = true
+    p.backgroundColor = .clear
+    p.hasShadow = true
+    p.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+    let host = NSHostingView(rootView: OverlayView(onCollapse: { [weak self] in self?.sizeToContent() }))
+    host.translatesAutoresizingMaskIntoConstraints = true
+    p.contentView = host
+    return p
+  }
+
+  private func sizeToContent() {
+    guard let p = panel, let host = p.contentView else { return }
+    let fitting = host.fittingSize
+    var frame = p.frame
+    let newH = max(44, fitting.height)
+    frame.origin.y += (frame.height - newH)
+    frame.size.height = newH
+    frame.size.width = OverlayState.shared.expanded ? 320 : 44
+    p.setFrame(frame, display: true, animate: false)
+  }
+
+  private func positionPanel() {
+    guard let p = panel, let screen = NSScreen.main else { return }
+    let d = UserDefaults.standard
+    if d.object(forKey: Self.frameKey) != nil {
+      let x = d.double(forKey: Self.frameKey)
+      let y = d.double(forKey: "openagi.overlay.originY")
+      p.setFrameOrigin(NSPoint(x: x, y: y))
+    } else {
+      let vf = screen.visibleFrame
+      p.setFrameOrigin(NSPoint(x: vf.maxX - 360, y: vf.minY + 80))
+    }
+    sizeToContent()
+  }
+
+  func persistPosition() {
+    guard let p = panel else { return }
+    UserDefaults.standard.set(Double(p.frame.origin.x), forKey: Self.frameKey)
+    UserDefaults.standard.set(Double(p.frame.origin.y), forKey: "openagi.overlay.originY")
+  }
+}

--- a/mac/Sources/OpenAGI/Overlay/OverlayController.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayController.swift
@@ -31,14 +31,16 @@ final class OverlayController {
     if panel?.isVisible == true {
       OverlayState.shared.expanded.toggle()
       sizeToContent()
+      if OverlayState.shared.expanded { panel?.makeKey() }
     } else {
       OverlayState.shared.expanded = true
       show(); sizeToContent()
+      panel?.makeKey()
     }
   }
 
   private func makePanel() -> NSPanel {
-    let p = NSPanel(
+    let p = KeyableOverlayPanel(
       contentRect: NSRect(x: 0, y: 0, width: 320, height: 60),
       styleMask: [.nonactivatingPanel, .borderless, .fullSizeContentView],
       backing: .buffered, defer: false)
@@ -85,4 +87,11 @@ final class OverlayController {
     UserDefaults.standard.set(Double(p.frame.origin.x), forKey: Self.frameKey)
     UserDefaults.standard.set(Double(p.frame.origin.y), forKey: "openagi.overlay.originY")
   }
+}
+
+// Borderless NSPanels return false for canBecomeKey by default; override so the
+// Quick Ask field can receive keystrokes. .nonactivatingPanel keeps the owning
+// app from activating, so summoning never steals focus from the user's app.
+final class KeyableOverlayPanel: NSPanel {
+  override var canBecomeKey: Bool { true }
 }

--- a/mac/Sources/OpenAGI/Overlay/OverlayController.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayController.swift
@@ -27,7 +27,10 @@ final class OverlayController {
 
   func hide() { panel?.orderOut(nil) }
 
+  var panelWindowNumber: Int? { panel?.windowNumber }
+
   func toggle() {
+    guard Self.isEnabled else { return }
     if panel?.isVisible == true {
       OverlayState.shared.expanded.toggle()
       sizeToContent()
@@ -51,7 +54,10 @@ final class OverlayController {
     p.backgroundColor = .clear
     p.hasShadow = true
     p.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
-    let host = NSHostingView(rootView: OverlayView(onCollapse: { [weak self] in self?.sizeToContent() }))
+    let host = NSHostingView(rootView: OverlayView(
+      onCollapse: { [weak self] in self?.sizeToContent() },
+      onExpand: { [weak self] in DispatchQueue.main.async { self?.sizeToContent() } }
+    ))
     host.translatesAutoresizingMaskIntoConstraints = true
     p.contentView = host
     return p

--- a/mac/Sources/OpenAGI/Overlay/OverlayState.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayState.swift
@@ -1,0 +1,32 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class OverlayState: ObservableObject {
+  static let shared = OverlayState()
+
+  @Published var expanded = false
+  @Published var question = ""
+  @Published var answer: String = ""
+  @Published var isLoading = false
+  @Published var error: String? = nil
+  @Published var contextNote: String? = nil
+
+  func ask() async {
+    let q = question.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !q.isEmpty else { return }
+    isLoading = true; error = nil; answer = ""
+    let ctx = await ScreenCapturer.shared.captureFocusedText()
+    if let ctx, !ctx.text.isEmpty {
+      contextNote = "reading \(ctx.app)"
+    } else {
+      contextNote = "no screen context"
+    }
+    do {
+      answer = try await AppState.shared.askOverlay(text: q, screenContext: ctx)
+    } catch {
+      self.error = error.localizedDescription
+    }
+    isLoading = false
+  }
+}

--- a/mac/Sources/OpenAGI/Overlay/OverlayState.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayState.swift
@@ -16,7 +16,7 @@ final class OverlayState: ObservableObject {
     let q = question.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !q.isEmpty else { return }
     isLoading = true; error = nil; answer = ""
-    let ctx = await ScreenCapturer.shared.captureFocusedText()
+    let ctx = await ScreenCapturer.shared.captureFocusedText(excludingWindowNumber: OverlayController.shared.panelWindowNumber)
     if let ctx, !ctx.text.isEmpty {
       contextNote = "reading \(ctx.app)"
     } else {

--- a/mac/Sources/OpenAGI/Overlay/OverlayView.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayView.swift
@@ -5,6 +5,7 @@ struct OverlayView: View {
   @ObservedObject var app = AppState.shared
   @FocusState private var fieldFocused: Bool
   var onCollapse: () -> Void = {}
+  var onExpand: () -> Void = {}
 
   var body: some View {
     if state.expanded {
@@ -15,7 +16,7 @@ struct OverlayView: View {
   }
 
   private var pill: some View {
-    Button(action: { state.expanded = true }) {
+    Button(action: { state.expanded = true; onExpand() }) {
       ZStack {
         Circle().fill(Color.accentColor).frame(width: 16, height: 16)
         if !app.nudges.isEmpty {

--- a/mac/Sources/OpenAGI/Overlay/OverlayView.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayView.swift
@@ -57,6 +57,25 @@ struct OverlayView: View {
         Button("Continue in chat") { app.openDashboard(path: "/?tab=chat") }
           .font(.caption).buttonStyle(.plain).foregroundStyle(.blue)
       }
+      if !app.nudges.isEmpty {
+        Divider()
+        Text("Nudges").font(.system(size: 10, weight: .semibold)).foregroundStyle(.secondary)
+        ForEach(app.nudges.prefix(4)) { n in
+          HStack(alignment: .top, spacing: 6) {
+            VStack(alignment: .leading, spacing: 1) {
+              Text(n.title).font(.system(size: 11, weight: .medium))
+              if !n.body.isEmpty { Text(n.body).font(.system(size: 10)).foregroundStyle(.secondary).lineLimit(2) }
+            }
+            Spacer()
+            Button(action: { app.openDashboard(path: "/?tab=chat&suggestion=\(n.id)") }) {
+              Image(systemName: "arrow.up.right.square")
+            }.buttonStyle(.plain).help("Review in chat")
+            Button(action: { app.nudges.removeAll { $0.id == n.id } }) {
+              Image(systemName: "xmark")
+            }.buttonStyle(.plain).help("Dismiss")
+          }
+        }
+      }
     }
     .padding(12)
     .frame(width: 320)

--- a/mac/Sources/OpenAGI/Overlay/OverlayView.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct OverlayView: View {
   @ObservedObject var state = OverlayState.shared
   @ObservedObject var app = AppState.shared
+  @FocusState private var fieldFocused: Bool
   var onCollapse: () -> Void = {}
 
   var body: some View {
@@ -42,6 +43,7 @@ struct OverlayView: View {
       }
       TextField("Ask about what you're looking at…", text: $state.question)
         .textFieldStyle(.roundedBorder)
+        .focused($fieldFocused)
         .disabled(app.status == .down)
         .onSubmit { Task { await state.ask() } }
       if let note = state.contextNote {
@@ -80,5 +82,7 @@ struct OverlayView: View {
     .padding(12)
     .frame(width: 320)
     .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+    .onAppear { fieldFocused = true }
+    .onChange(of: state.expanded) { _, expanded in if expanded { fieldFocused = true } }
   }
 }

--- a/mac/Sources/OpenAGI/Overlay/OverlayView.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct OverlayView: View {
+  @ObservedObject var state = OverlayState.shared
+  @ObservedObject var app = AppState.shared
+  var onCollapse: () -> Void = {}
+
+  var body: some View {
+    if state.expanded {
+      expandedPanel
+    } else {
+      pill
+    }
+  }
+
+  private var pill: some View {
+    Button(action: { state.expanded = true }) {
+      ZStack {
+        Circle().fill(Color.accentColor).frame(width: 16, height: 16)
+        if !app.nudges.isEmpty {
+          Text("\(app.nudges.count)")
+            .font(.system(size: 9, weight: .bold)).foregroundColor(.white)
+        }
+      }
+      .padding(8)
+    }
+    .buttonStyle(.plain)
+    .background(.ultraThinMaterial, in: Circle())
+  }
+
+  private var expandedPanel: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack {
+        Text("Ask OpenAGI").font(.caption).foregroundStyle(.secondary)
+        Spacer()
+        Button(action: { state.expanded = false; onCollapse() }) {
+          Image(systemName: "xmark.circle.fill").foregroundStyle(.tertiary)
+        }.buttonStyle(.plain)
+      }
+      if app.status == .down {
+        Text("OpenAGI is offline").font(.caption).foregroundStyle(.red)
+      }
+      TextField("Ask about what you're looking at…", text: $state.question)
+        .textFieldStyle(.roundedBorder)
+        .disabled(app.status == .down)
+        .onSubmit { Task { await state.ask() } }
+      if let note = state.contextNote {
+        Text(note).font(.system(size: 10)).foregroundStyle(.tertiary)
+      }
+      if state.isLoading {
+        ProgressView().controlSize(.small)
+      } else if let err = state.error {
+        Text(err).font(.caption).foregroundStyle(.red)
+      } else if !state.answer.isEmpty {
+        ScrollView { Text(state.answer).font(.callout).textSelection(.enabled).frame(maxWidth: .infinity, alignment: .leading) }
+          .frame(maxHeight: 220)
+        Button("Continue in chat") { app.openDashboard(path: "/?tab=chat") }
+          .font(.caption).buttonStyle(.plain).foregroundStyle(.blue)
+      }
+    }
+    .padding(12)
+    .frame(width: 320)
+    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+  }
+}

--- a/mac/Sources/OpenAGI/TrayController.swift
+++ b/mac/Sources/OpenAGI/TrayController.swift
@@ -206,6 +206,11 @@ struct TrayMenu: View {
       Button(UpdateController.shared.isEnabled ? "Check for updates…" : "About auto-updates…") {
         UpdateController.shared.checkForUpdates()
       }
+      Button("Quick Ask  ⌥Space") { OverlayController.shared.toggle() }
+      Toggle("Enable Quick Ask", isOn: Binding(
+        get: { OverlayController.isEnabled },
+        set: { OverlayController.setEnabled($0) }
+      ))
       Toggle("Open at Login", isOn: Binding(
         get: { LoginItem.isEnabled },
         set: { LoginItem.setEnabled($0) }

--- a/mac/Sources/OpenAGI/TrayController.swift
+++ b/mac/Sources/OpenAGI/TrayController.swift
@@ -206,6 +206,10 @@ struct TrayMenu: View {
       Button(UpdateController.shared.isEnabled ? "Check for updates…" : "About auto-updates…") {
         UpdateController.shared.checkForUpdates()
       }
+      Toggle("Open at Login", isOn: Binding(
+        get: { LoginItem.isEnabled },
+        set: { LoginItem.setEnabled($0) }
+      ))
       Divider()
       Button("Quit OpenAGI") {
         DaemonController.shared.stop()

--- a/scripts/build-mac-app.sh
+++ b/scripts/build-mac-app.sh
@@ -31,7 +31,12 @@ if [[ -z "${VERSION:-}" ]]; then
     VERSION="$(node -p "require('${ROOT}/package.json').version")"
   fi
 fi
-BUILD_NUM="${BUILD_NUM:-$(date +%s)}"
+# Build number must use the SAME scheme as CI (release-mac.yml stamps
+# `date -u +%y%m%d%H%M`). A local epoch-seconds value (~1.78e9) is numerically
+# smaller than any YYMMDDHHMM value (~2.6e9 in 2026), so Sparkle would treat a
+# locally-built app as forever older than every CI release of the same version
+# and nag to "update" to it endlessly. Keep both schemes identical.
+BUILD_NUM="${BUILD_NUM:-$(date -u +%y%m%d%H%M)}"
 NODE_VERSION="${NODE_VERSION:-22.21.1}"
 
 ARCH="$(uname -m)"

--- a/scripts/install-launchd.sh
+++ b/scripts/install-launchd.sh
@@ -69,6 +69,8 @@ cat > "${PLIST}" <<EOF
   <dict>
     <key>PATH</key>
     <string>$(dirname "${NODE_BIN}"):/usr/local/bin:/usr/bin:/bin</string>
+    <key>OPENAGI_DATA_DIR</key>
+    <string>${HOME}/.openagi</string>
   </dict>
 </dict>
 </plist>

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -36,8 +36,8 @@ Wants=network-online.target
 Type=simple
 ExecStart=${NODE_BIN} ${PROJECT_DIR}/examples/hosted-server.js
 WorkingDirectory=${PROJECT_DIR}
-EnvironmentFile=-${PROJECT_DIR}/.openagi/.env
-Environment=OPENAGI_DATA_DIR=${HOME}/.openagi
+EnvironmentFile=-${2}/.env
+Environment=OPENAGI_DATA_DIR=${2}
 Restart=on-failure
 RestartSec=10s
 StandardOutput=journal
@@ -48,7 +48,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=full
 ProtectHome=read-only
-ReadWritePaths=${PROJECT_DIR}/.openagi ${HOME}/.openagi
+ReadWritePaths=${2}
 
 [Install]
 WantedBy=${1:-multi-user.target}
@@ -78,7 +78,8 @@ fi
 
 if [[ "${MODE}" == "user" ]]; then
   mkdir -p "$HOME/.config/systemd/user"
-  build_unit default.target > "$HOME/.config/systemd/user/${UNIT_NAME}"
+  # User service runs as the invoking user → data dir is their own ~/.openagi.
+  build_unit default.target "${HOME}/.openagi" > "$HOME/.config/systemd/user/${UNIT_NAME}"
   systemctl --user daemon-reload
   systemctl --user enable --now "${UNIT_NAME}"
   echo "Installed user service. Tail: journalctl --user -u openagi -f"
@@ -96,9 +97,13 @@ if ! id -u openagi &>/dev/null; then
   useradd --system --shell /usr/sbin/nologin --home-dir "${PROJECT_DIR}" openagi
   echo "Created system user 'openagi'."
 fi
+mkdir -p "${PROJECT_DIR}/.openagi"
 chown -R openagi:openagi "${PROJECT_DIR}/.openagi" 2>/dev/null || true
 
-build_unit multi-user.target > "/etc/systemd/system/${UNIT_NAME}"
+# System service runs as User=openagi, whose home is PROJECT_DIR, so its
+# data dir is the already-chowned ${PROJECT_DIR}/.openagi (NOT the root/sudo
+# invoker's ${HOME}, which the openagi user can't write).
+build_unit multi-user.target "${PROJECT_DIR}/.openagi" > "/etc/systemd/system/${UNIT_NAME}"
 # Pin User=openagi for system mode by appending — done inline so build_unit stays portable
 sed -i '/^\[Service\]/a User=openagi\nGroup=openagi' "/etc/systemd/system/${UNIT_NAME}"
 

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -79,6 +79,9 @@ fi
 if [[ "${MODE}" == "user" ]]; then
   mkdir -p "$HOME/.config/systemd/user"
   # User service runs as the invoking user → data dir is their own ~/.openagi.
+  # Create it up front: it's in ReadWritePaths and ProtectHome=read-only would
+  # otherwise stop the daemon from creating it on first run.
+  mkdir -p "$HOME/.openagi"
   build_unit default.target "${HOME}/.openagi" > "$HOME/.config/systemd/user/${UNIT_NAME}"
   systemctl --user daemon-reload
   systemctl --user enable --now "${UNIT_NAME}"

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -37,6 +37,7 @@ Type=simple
 ExecStart=${NODE_BIN} ${PROJECT_DIR}/examples/hosted-server.js
 WorkingDirectory=${PROJECT_DIR}
 EnvironmentFile=-${PROJECT_DIR}/.openagi/.env
+Environment=OPENAGI_DATA_DIR=${HOME}/.openagi
 Restart=on-failure
 RestartSec=10s
 StandardOutput=journal
@@ -47,7 +48,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=full
 ProtectHome=read-only
-ReadWritePaths=${PROJECT_DIR}/.openagi
+ReadWritePaths=${PROJECT_DIR}/.openagi ${HOME}/.openagi
 
 [Install]
 WantedBy=${1:-multi-user.target}

--- a/scripts/install-tunnel-launchd.sh
+++ b/scripts/install-tunnel-launchd.sh
@@ -10,8 +10,9 @@ set -euo pipefail
 
 LABEL="app.openagi.tunnel"
 PLIST="$HOME/Library/LaunchAgents/${LABEL}.plist"
-PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-LOG_DIR="${PROJECT_DIR}/.openagi"
+# Write tunnel.log where the tunnel-watcher looks for it: the OpenAGI data dir
+# (OPENAGI_DATA_DIR, default ~/.openagi) — NOT the project dir.
+LOG_DIR="${OPENAGI_DATA_DIR:-$HOME/.openagi}"
 CFD_BIN="${OPENAGI_CLOUDFLARED:-$(command -v cloudflared || true)}"
 
 if [[ "${1:-install}" == "uninstall" ]]; then
@@ -61,4 +62,4 @@ echo
 echo "Installed ${LABEL}."
 echo "  log:  ${LOG_DIR}/tunnel.log"
 echo "  Once cloudflared connects, the OpenAGI tunnel-watcher will pick up the URL"
-echo "  and auto-write it to OPENAGI_PUBLIC_URL in .openagi/.env."
+echo "  and auto-write it to OPENAGI_PUBLIC_URL in ${LOG_DIR}/.env."

--- a/src/abi-runtime.js
+++ b/src/abi-runtime.js
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { resolveDataDir } from "./data-dir.js";
 import { AgentHost } from "./agent-host.js";
 import { FileBackedAgentStore } from "./agent-store.js";
 import { CronScheduler, createDailyAdaptationReviewJob } from "./cron-scheduler.js";
@@ -890,7 +891,7 @@ export function createDefaultRuntime(options = {}) {
 }
 
 export function createDurableRuntime(options = {}) {
-  const dataDir = options.dataDir ?? path.join(process.cwd(), ".openagi");
+  const dataDir = options.dataDir ?? resolveDataDir();
   const mcpLogDir = path.join(dataDir, "mcp", "logs");
   const runtime = createDefaultRuntime({
     ...options,

--- a/src/abi-runtime.js
+++ b/src/abi-runtime.js
@@ -16,6 +16,7 @@ import { registerInboxWatcher } from "./integrations/inbox-watcher.js";
 import { registerIMessagePoller } from "./integrations/imessage-poller.js";
 import { registerBuildBetterTaskSource } from "./integrations/buildbetter-tasks.js";
 import { registerCalendarIntegration } from "./integrations/calendar.js";
+import { registerWebSearchTools } from "./integrations/web-search.js";
 import { createEmbedder } from "./embeddings.js";
 import { McpRegistry } from "./mcp-registry.js";
 import { MemoryCondenser } from "./memory-condenser.js";
@@ -381,6 +382,9 @@ export class AbiRuntime {
       // The source attaches to runtime even when disabled so the dashboard
       // can render the toggle + permission status.
       registerIMessagePoller(this);
+      // Web search tools (web_search / fetch_url). Always registered; web_search
+      // returns a clear "no provider configured" error until a key is set.
+      registerWebSearchTools(this);
     }
   }
 

--- a/src/abi-runtime.js
+++ b/src/abi-runtime.js
@@ -929,5 +929,13 @@ export function createDurableRuntime(options = {}) {
   });
   const mcpConfigPath = options.mcpConfigPath ?? path.join(dataDir, "mcp.json");
   runtime.mcp.loadConfigFile(mcpConfigPath);
+  // Reconnect previously-authorized MCP servers on boot, silently — servers
+  // with a cached OAuth token / bearer key / stdio command come back "live"
+  // instead of showing "idle" until someone clicks Connect. Never opens a
+  // browser: OAuth servers without a usable token just stay idle. Non-blocking
+  // and best-effort so a slow/dead server can't hold up startup.
+  if (options.autoConnectMcp !== false && runtime.mcp?.connectAll) {
+    Promise.resolve().then(() => runtime.mcp.connectAll({ silent: true })).catch(() => {});
+  }
   return runtime;
 }

--- a/src/agent-host.js
+++ b/src/agent-host.js
@@ -105,7 +105,7 @@ export class AgentHost {
         }
       })),
       messages: sessionBefore.messages,
-      instructions: this.instructionsForAgent(agent, output, intuitions, ambientContext),
+      instructions: this.instructionsForAgent(agent, output, intuitions, ambientContext, input.metadata?.screenContext ?? null),
       tools,
       toolRegistry,
       context: {
@@ -241,7 +241,7 @@ export class AgentHost {
     };
   }
 
-  instructionsForAgent(agent, output, intuitions = [], ambientContext = null) {
+  instructionsForAgent(agent, output, intuitions = [], ambientContext = null, screenContext = null) {
     const intuitionBlock = intuitions.length > 0
       ? `\nIntuitions (distilled long-term principles, may apply):\n${intuitions.map((i) => `- (${i.score.toFixed(2)}) ${i.text}`).join("\n")}\n`
       : "";
@@ -264,6 +264,8 @@ export class AgentHost {
       ambientBlock = lines.join("\n") + "\n";
     }
 
+    const screenBlock = formatScreenContextBlock(screenContext);
+
     return `${agent.systemPrompt ? `${agent.systemPrompt}\n\n` : ""}You are ${agent.name}, an always-on OpenAGI agent.
 
 Your job is to help through the ABI loop:
@@ -274,7 +276,7 @@ Your job is to help through the ABI loop:
 Current decision: ${output.scrutiny.action}
 Reasons:
 ${output.scrutiny.reasons.map((reason) => `- ${reason}`).join("\n")}
-${intuitionBlock}${ambientBlock}
+${intuitionBlock}${ambientBlock}${screenBlock}
 Answer the user plainly. If a specialist was created, mention its name and scope.`;
   }
 
@@ -307,6 +309,18 @@ Stay inside the bounded scope. If the user's request falls outside it, say so an
       sessions: this.store.listSessions()
     };
   }
+}
+
+// Format the fresh focused-window context the floating widget attaches to a
+// message (metadata.screenContext = { app, window, text }) into a labeled
+// prompt block. Returns "" when absent/empty. Pure + exported for testing.
+export function formatScreenContextBlock(screenContext) {
+  if (!screenContext || typeof screenContext.text !== "string" || !screenContext.text.trim()) return "";
+  const where = screenContext.window
+    ? `${screenContext.app || "?"} · ${screenContext.window}`
+    : (screenContext.app || "active window");
+  const body = screenContext.text.slice(0, 4000);
+  return `\nActive window the user is looking at right now (${where}):\n${body}\nGround your answer in this if it's relevant; don't quote it back verbatim.\n`;
 }
 
 // Maps a provider class to a short user-facing label. Avoids leaking

--- a/src/agent-store.js
+++ b/src/agent-store.js
@@ -2,6 +2,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { ensureDir, readJsonFile, safeFilename, writeJsonAtomic } from "./file-utils.js";
 import { createId, nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 export class InMemoryAgentStore {
   constructor(options = {}) {
@@ -75,7 +76,7 @@ export class InMemoryAgentStore {
 export class FileBackedAgentStore extends InMemoryAgentStore {
   constructor(options = {}) {
     super({ ensureDefault: false });
-    this.dir = options.dir ?? path.join(process.cwd(), ".openagi", "agent-host");
+    this.dir = options.dir ?? path.join(resolveDataDir(), "agent-host");
     this.agentsPath = path.join(this.dir, "agents.json");
     this.sessionsDir = path.join(this.dir, "sessions");
     ensureDir(this.sessionsDir);

--- a/src/budget-guard.js
+++ b/src/budget-guard.js
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { ensureDir, readJsonFile, writeJsonAtomic } from "./file-utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 const DEFAULT_PRICES = {
   "claude-sonnet-4-6": { in: 3, out: 15, cacheRead: 0.3, cacheWrite: 3.75 },
@@ -12,7 +13,7 @@ const DEFAULT_PRICES = {
 
 export class BudgetGuard {
   constructor(options = {}) {
-    this.storePath = options.storePath ?? path.join(process.cwd(), ".openagi", "budget", "usage.json");
+    this.storePath = options.storePath ?? path.join(resolveDataDir(), "budget", "usage.json");
     this.dailyUsdLimit = options.dailyUsdLimit ?? Number.parseFloat(process.env.OPENAGI_DAILY_USD_LIMIT ?? "10");
     this.prices = { ...DEFAULT_PRICES, ...(options.prices ?? {}) };
     ensureDir(path.dirname(this.storePath));

--- a/src/budget-guard.js
+++ b/src/budget-guard.js
@@ -1,6 +1,8 @@
 import path from "node:path";
 import { ensureDir, readJsonFile, writeJsonAtomic } from "./file-utils.js";
 import { resolveDataDir } from "./data-dir.js";
+import { nowIso } from "./utils.js";
+import { CreditLedger } from "./credit-ledger.js";
 
 const DEFAULT_PRICES = {
   "claude-sonnet-4-6": { in: 3, out: 15, cacheRead: 0.3, cacheWrite: 3.75 },
@@ -18,6 +20,7 @@ export class BudgetGuard {
     this.prices = { ...DEFAULT_PRICES, ...(options.prices ?? {}) };
     ensureDir(path.dirname(this.storePath));
     this.state = readJsonFile(this.storePath, { version: 1, days: {} });
+    this.ledger = options.ledger ?? new CreditLedger({ storePath: path.join(path.dirname(this.storePath), "ledger.jsonl") });
   }
 
   todayKey() {
@@ -54,7 +57,7 @@ export class BudgetGuard {
     }
   }
 
-  record(usage, model) {
+  record(usage, model, meta = {}) {
     if (!usage) return null;
     const today = this.todayKey();
     if (!this.state.days[today]) this.state.days[today] = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, usd: 0, calls: 0 };
@@ -74,6 +77,20 @@ export class BudgetGuard {
     day.cacheWrite += tokens.cacheWrite;
     day.usd += usd;
     day.calls += 1;
+
+    try {
+      this.ledger?.record({
+        at: nowIso(),
+        model,
+        tokens,
+        usd,
+        channel: meta.channel ?? null,
+        agentId: meta.agentId ?? null,
+        sessionId: meta.sessionId ?? null,
+        from: meta.from ?? null,
+        tools: Array.isArray(meta.tools) ? meta.tools : []
+      });
+    } catch { /* ledger is best-effort; never break a reply over it */ }
 
     this.persist();
     return { added: usd, today: day.usd, limit: this.dailyUsdLimit };

--- a/src/channels.js
+++ b/src/channels.js
@@ -1,12 +1,13 @@
 import { appendJsonLine, ensureDir, readJsonFile, writeJsonAtomic } from "./file-utils.js";
 import path from "node:path";
 import { nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 export class ChannelManager {
   constructor(options = {}) {
     this.agentHost = options.agentHost;
     this.runtime = options.runtime ?? options.agentHost?.runtime;
-    this.dir = options.dir ?? path.join(process.cwd(), ".openagi", "channels");
+    this.dir = options.dir ?? path.join(resolveDataDir(), "channels");
     ensureDir(this.dir);
     this.eventsPath = path.join(this.dir, "events.jsonl");
     this.telegram = new TelegramChannel({
@@ -94,7 +95,7 @@ export class TelegramChannel {
   constructor(options = {}) {
     this.agentHost = options.agentHost;
     this.token = options.token;
-    this.dir = options.dir ?? path.join(process.cwd(), ".openagi", "channels", "telegram");
+    this.dir = options.dir ?? path.join(resolveDataDir(), "channels", "telegram");
     this.statePath = path.join(this.dir, "state.json");
     this.eventsPath = path.join(this.dir, "events.jsonl");
     this.pollTimer = null;
@@ -200,7 +201,7 @@ export class SmsChannel {
     this.accountSid = options.accountSid;
     this.authToken = options.authToken;
     this.fromNumber = options.fromNumber;
-    this.dir = options.dir ?? path.join(process.cwd(), ".openagi", "channels", "sms");
+    this.dir = options.dir ?? path.join(resolveDataDir(), "channels", "sms");
     this.eventsPath = path.join(this.dir, "events.jsonl");
     ensureDir(this.dir);
   }

--- a/src/clarification-store.js
+++ b/src/clarification-store.js
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { ensureDir, writeJsonAtomic, readJsonFile } from "./file-utils.js";
 import { createId, nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 // The "ask me when you can't decide" queue — the trust valve for the
 // living todo. When task reconciliation (proactive-observer) lands in the
@@ -25,7 +26,7 @@ const VALID_ANSWERS = ["yes", "in_progress", "no", "dropped"];
 
 export class ClarificationStore {
   constructor({ dir, runtime } = {}) {
-    this.dir = dir ?? path.join(process.cwd(), ".openagi", "clarifications");
+    this.dir = dir ?? path.join(resolveDataDir(), "clarifications");
     this.runtime = runtime ?? null;
     ensureDir(this.dir);
     this.items = new Map();

--- a/src/computer-use-log.js
+++ b/src/computer-use-log.js
@@ -2,6 +2,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { ensureDir, writeJsonAtomic, readJsonFile, appendJsonLine } from "./file-utils.js";
 import { createId, nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 // Persistent record of every computer-use action the agent intends to take,
 // alongside the reasoning the model supplied for it. Each action belongs
@@ -20,7 +21,7 @@ import { createId, nowIso } from "./utils.js";
 
 export class ComputerUseLog {
   constructor({ dir } = {}) {
-    this.dir = dir ?? path.join(process.cwd(), ".openagi", "computer-use");
+    this.dir = dir ?? path.join(resolveDataDir(), "computer-use");
     ensureDir(this.dir);
     this.sessions = new Map();
     this.actions = new Map();

--- a/src/credit-ledger.js
+++ b/src/credit-ledger.js
@@ -21,6 +21,10 @@ export class CreditLedger {
     // compactBytes doesn't read+rewrite the whole file on every append.
     this._nextCompactBytes = this.compactBytes;
     ensureDir(path.dirname(this.storePath));
+    // The ledger holds attribution (from/sessionId/agentId/tools/spend) — not
+    // world-readable. New files are created 0600 (mode on append/write below);
+    // tighten an existing file once at startup in case it predates this.
+    try { if (fs.existsSync(this.storePath)) fs.chmodSync(this.storePath, 0o600); } catch { /* best effort */ }
   }
 
   // Calendar-day cutoff (UTC, matching BudgetGuard.todayKey): the start of the
@@ -57,7 +61,7 @@ export class CreditLedger {
       from: entry.from ?? null,
       tools: Array.isArray(entry.tools) ? entry.tools : []
     };
-    fs.appendFileSync(this.storePath, JSON.stringify(row) + "\n");
+    fs.appendFileSync(this.storePath, JSON.stringify(row) + "\n", { mode: 0o600 });
     this._maybeCompact(now);
     return row;
   }
@@ -68,7 +72,7 @@ export class CreditLedger {
     if (size < this._nextCompactBytes) return;
     const cutoff = this._cutoff(this.retentionDays, now);
     const kept = this._readAll().filter((r) => (r.at ?? "") >= cutoff);
-    fs.writeFileSync(this.storePath, kept.map((r) => JSON.stringify(r)).join("\n") + (kept.length ? "\n" : ""));
+    fs.writeFileSync(this.storePath, kept.map((r) => JSON.stringify(r)).join("\n") + (kept.length ? "\n" : ""), { mode: 0o600 });
     // Re-arm: only compact again after the file roughly doubles past the
     // retained size, so a large-but-legitimate window amortizes the rewrite
     // instead of compacting on every subsequent append.

--- a/src/credit-ledger.js
+++ b/src/credit-ledger.js
@@ -93,7 +93,11 @@ export class CreditLedger {
   }
 
   query({ days = this.retentionDays, now = new Date() } = {}) {
-    const cutoff = this._cutoff(days, now);
+    // Clamp to the retention window: the ledger only promises 30 days, and rows
+    // older than that may still be on disk (pruning runs lazily on record), so a
+    // wider days= must never surface aged-out attribution.
+    const window = Math.min(Math.max(1, days), this.retentionDays);
+    const cutoff = this._cutoff(window, now);
     return this._readAll()
       .filter((r) => (r.at ?? "") >= cutoff)
       .sort((a, b) => (b.at ?? "").localeCompare(a.at ?? ""));

--- a/src/credit-ledger.js
+++ b/src/credit-ledger.js
@@ -20,6 +20,7 @@ export class CreditLedger {
     // size so a ledger whose retained 30-day window legitimately exceeds
     // compactBytes doesn't read+rewrite the whole file on every append.
     this._nextCompactBytes = this.compactBytes;
+    this._lastPruneAt = 0; // epoch ms of the last retention prune (0 → prune on first record)
     ensureDir(path.dirname(this.storePath));
     // The ledger holds attribution (from/sessionId/agentId/tools/spend) — not
     // world-readable. New files are created 0600 (mode on append/write below);
@@ -62,20 +63,30 @@ export class CreditLedger {
       tools: Array.isArray(entry.tools) ? entry.tools : []
     };
     fs.appendFileSync(this.storePath, JSON.stringify(row) + "\n", { mode: 0o600 });
-    this._maybeCompact(now);
+    this._maybeMaintain(now);
     return row;
   }
 
-  _maybeCompact(now) {
+  // Prune to the retention window when the file has grown past the (re-armed)
+  // compaction threshold OR at least once a day — so rows older than the window
+  // are physically removed even on low-volume installs that never hit the size
+  // cap. This enforces the 30-day retention/privacy guarantee on disk, not just
+  // at read time. Appending stays O(1); this only does work when size- or
+  // time-triggered.
+  _maybeMaintain(now) {
     let size = 0;
     try { size = fs.statSync(this.storePath).size; } catch { return; }
-    if (size < this._nextCompactBytes) return;
+    const dueByTime = (now.getTime() - this._lastPruneAt) >= 86400 * 1000;
+    if (size < this._nextCompactBytes && !dueByTime) return;
     const cutoff = this._cutoff(this.retentionDays, now);
-    const kept = this._readAll().filter((r) => (r.at ?? "") >= cutoff);
-    fs.writeFileSync(this.storePath, kept.map((r) => JSON.stringify(r)).join("\n") + (kept.length ? "\n" : ""), { mode: 0o600 });
-    // Re-arm: only compact again after the file roughly doubles past the
-    // retained size, so a large-but-legitimate window amortizes the rewrite
-    // instead of compacting on every subsequent append.
+    const all = this._readAll();
+    const kept = all.filter((r) => (r.at ?? "") >= cutoff);
+    if (kept.length !== all.length) {
+      fs.writeFileSync(this.storePath, kept.map((r) => JSON.stringify(r)).join("\n") + (kept.length ? "\n" : ""), { mode: 0o600 });
+    }
+    this._lastPruneAt = now.getTime();
+    // Re-arm: only size-compact again after the file roughly doubles past the
+    // retained size, so a large-but-legitimate window amortizes the rewrite.
     let newSize = 0;
     try { newSize = fs.statSync(this.storePath).size; } catch { /* ignore */ }
     this._nextCompactBytes = Math.max(this.compactBytes, newSize * 2);

--- a/src/credit-ledger.js
+++ b/src/credit-ledger.js
@@ -1,0 +1,93 @@
+// src/credit-ledger.js
+import fs from "node:fs";
+import path from "node:path";
+import { ensureDir } from "./file-utils.js";
+import { resolveDataDir } from "./data-dir.js";
+
+const RETENTION_DAYS = 30;
+const COMPACT_BYTES = 4 * 1024 * 1024;
+
+// Append-only per-call credit (USD) ledger. record() is O(1) append (it runs in
+// the hot path of every LLM call); old entries are filtered out of query()/
+// analytics() by the rolling window, and the file is compacted only when it
+// grows large. Stores no message content — just cost + attribution.
+export class CreditLedger {
+  constructor(options = {}) {
+    this.storePath = options.storePath ?? path.join(resolveDataDir(), "budget", "ledger.jsonl");
+    this.retentionDays = options.retentionDays ?? RETENTION_DAYS;
+    this.compactBytes = options.compactBytes ?? COMPACT_BYTES;
+    ensureDir(path.dirname(this.storePath));
+  }
+
+  _cutoff(days, now) {
+    return new Date(now.getTime() - days * 86400 * 1000).toISOString();
+  }
+
+  _readAll() {
+    let text;
+    try { text = fs.readFileSync(this.storePath, "utf8"); } catch { return []; }
+    const out = [];
+    for (const line of text.split("\n")) {
+      if (!line.trim()) continue;
+      try { out.push(JSON.parse(line)); } catch { /* skip corrupt line */ }
+    }
+    return out;
+  }
+
+  record(entry = {}, { now = new Date() } = {}) {
+    const row = {
+      at: entry.at ?? now.toISOString(),
+      model: entry.model ?? null,
+      tokens: entry.tokens ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      usd: Number(entry.usd ?? 0),
+      channel: entry.channel ?? null,
+      agentId: entry.agentId ?? null,
+      sessionId: entry.sessionId ?? null,
+      from: entry.from ?? null,
+      tools: Array.isArray(entry.tools) ? entry.tools : []
+    };
+    fs.appendFileSync(this.storePath, JSON.stringify(row) + "\n");
+    this._maybeCompact(now);
+    return row;
+  }
+
+  _maybeCompact(now) {
+    let size = 0;
+    try { size = fs.statSync(this.storePath).size; } catch { return; }
+    if (size < this.compactBytes) return;
+    const cutoff = this._cutoff(this.retentionDays, now);
+    const kept = this._readAll().filter((r) => (r.at ?? "") >= cutoff);
+    fs.writeFileSync(this.storePath, kept.map((r) => JSON.stringify(r)).join("\n") + (kept.length ? "\n" : ""));
+  }
+
+  query({ days = this.retentionDays, now = new Date() } = {}) {
+    const cutoff = this._cutoff(days, now);
+    return this._readAll()
+      .filter((r) => (r.at ?? "") >= cutoff)
+      .sort((a, b) => (b.at ?? "").localeCompare(a.at ?? ""));
+  }
+
+  analytics({ days = this.retentionDays, now = new Date() } = {}) {
+    const rows = this.query({ days, now });
+    const byDay = {}, byModel = {}, byActivity = {};
+    let totalUsd = 0, totalCalls = 0;
+    for (const r of rows) {
+      const day = (r.at ?? "").slice(0, 10);
+      const model = r.model ?? "unknown";
+      const activity = r.channel ?? "unknown";
+      const usd = Number(r.usd ?? 0);
+      totalUsd += usd; totalCalls += 1;
+      (byDay[day] ??= { date: day, usd: 0, calls: 0 });        byDay[day].usd += usd; byDay[day].calls += 1;
+      (byModel[model] ??= { model, usd: 0, calls: 0 });        byModel[model].usd += usd; byModel[model].calls += 1;
+      (byActivity[activity] ??= { activity, usd: 0, calls: 0 }); byActivity[activity].usd += usd; byActivity[activity].calls += 1;
+    }
+    const round = (o) => ({ ...o, usd: Number(o.usd.toFixed(4)) });
+    return {
+      totalUsd: Number(totalUsd.toFixed(4)),
+      totalCalls,
+      byDay: Object.values(byDay).sort((a, b) => a.date.localeCompare(b.date)).map(round),
+      byModel: Object.values(byModel).sort((a, b) => b.usd - a.usd).map(round),
+      byActivity: Object.values(byActivity).sort((a, b) => b.usd - a.usd).map(round)
+    };
+  }
+}

--- a/src/credit-ledger.js
+++ b/src/credit-ledger.js
@@ -16,11 +16,22 @@ export class CreditLedger {
     this.storePath = options.storePath ?? path.join(resolveDataDir(), "budget", "ledger.jsonl");
     this.retentionDays = options.retentionDays ?? RETENTION_DAYS;
     this.compactBytes = options.compactBytes ?? COMPACT_BYTES;
+    // Next size at which compaction runs. Re-armed above the post-compaction
+    // size so a ledger whose retained 30-day window legitimately exceeds
+    // compactBytes doesn't read+rewrite the whole file on every append.
+    this._nextCompactBytes = this.compactBytes;
     ensureDir(path.dirname(this.storePath));
   }
 
+  // Calendar-day cutoff (UTC, matching BudgetGuard.todayKey): the start of the
+  // day that is (days-1) days before `now`. So days=1 means "today" (since UTC
+  // midnight), days=7 means "today + the previous 6 days" — not a rolling N×24h
+  // window, which would bleed yesterday's evening spend into a "today" query.
   _cutoff(days, now) {
-    return new Date(now.getTime() - days * 86400 * 1000).toISOString();
+    const d = new Date(now.getTime());
+    d.setUTCHours(0, 0, 0, 0);
+    d.setUTCDate(d.getUTCDate() - (days - 1));
+    return d.toISOString();
   }
 
   _readAll() {
@@ -54,10 +65,16 @@ export class CreditLedger {
   _maybeCompact(now) {
     let size = 0;
     try { size = fs.statSync(this.storePath).size; } catch { return; }
-    if (size < this.compactBytes) return;
+    if (size < this._nextCompactBytes) return;
     const cutoff = this._cutoff(this.retentionDays, now);
     const kept = this._readAll().filter((r) => (r.at ?? "") >= cutoff);
     fs.writeFileSync(this.storePath, kept.map((r) => JSON.stringify(r)).join("\n") + (kept.length ? "\n" : ""));
+    // Re-arm: only compact again after the file roughly doubles past the
+    // retained size, so a large-but-legitimate window amortizes the rewrite
+    // instead of compacting on every subsequent append.
+    let newSize = 0;
+    try { newSize = fs.statSync(this.storePath).size; } catch { /* ignore */ }
+    this._nextCompactBytes = Math.max(this.compactBytes, newSize * 2);
   }
 
   query({ days = this.retentionDays, now = new Date() } = {}) {

--- a/src/data-dir.js
+++ b/src/data-dir.js
@@ -10,9 +10,10 @@ let cached = null;
 // .app, launchd, and re-clones — the cause of "my keys got wiped").
 // OPENAGI_DATA_DIR overrides it (Docker sets /data; the Mac app sets ~/.openagi).
 export function resolveDataDir() {
-  if (cached) return cached;
+  if (cached !== null) return cached;
   const override = process.env.OPENAGI_DATA_DIR;
-  cached = override ? path.resolve(override) : path.join(os.homedir(), ".openagi");
+  const trimmed = override && override.trim();
+  cached = trimmed ? path.resolve(trimmed) : path.join(os.homedir(), ".openagi");
   return cached;
 }
 

--- a/src/data-dir.js
+++ b/src/data-dir.js
@@ -1,0 +1,22 @@
+// src/data-dir.js
+import os from "node:os";
+import path from "node:path";
+
+let cached = null;
+
+// Single source of truth for where OpenAGI keeps config + state.
+// Default is an ABSOLUTE ~/.openagi so it never depends on the process's
+// current working directory (which differs between `npm run serve`, the
+// .app, launchd, and re-clones — the cause of "my keys got wiped").
+// OPENAGI_DATA_DIR overrides it (Docker sets /data; the Mac app sets ~/.openagi).
+export function resolveDataDir() {
+  if (cached) return cached;
+  const override = process.env.OPENAGI_DATA_DIR;
+  cached = override ? path.resolve(override) : path.join(os.homedir(), ".openagi");
+  return cached;
+}
+
+// Test seam: drop the memoized value after mutating env in tests.
+export function _resetDataDirCache() {
+  cached = null;
+}

--- a/src/draft-store.js
+++ b/src/draft-store.js
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { ensureDir, writeJsonAtomic, readJsonFile } from "./file-utils.js";
 import { createId, nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 // Where the agent's draft-only work lands for human review — the surface
 // that makes "a drafted email is waiting for you" real instead of buried
@@ -23,7 +24,7 @@ export const DRAFT_KINDS = ["email", "message", "doc", "outline", "reply", "othe
 
 export class DraftStore {
   constructor({ dir, runtime } = {}) {
-    this.dir = dir ?? path.join(process.cwd(), ".openagi", "drafts");
+    this.dir = dir ?? path.join(resolveDataDir(), "drafts");
     this.runtime = runtime ?? null;
     ensureDir(this.dir);
     this.items = new Map();

--- a/src/file-backed-cron-scheduler.js
+++ b/src/file-backed-cron-scheduler.js
@@ -2,11 +2,12 @@ import path from "node:path";
 import { CronScheduler } from "./cron-scheduler.js";
 import { ensureDir, readJsonFile, writeJsonAtomic } from "./file-utils.js";
 import { nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 export class FileBackedCronScheduler extends CronScheduler {
   constructor(options = {}) {
     super();
-    this.storePath = options.storePath ?? path.join(process.cwd(), ".openagi", "cron", "jobs.json");
+    this.storePath = options.storePath ?? path.join(resolveDataDir(), "cron", "jobs.json");
     ensureDir(path.dirname(this.storePath));
     if (options.autoLoad !== false) this.load();
   }

--- a/src/file-backed-memory-system.js
+++ b/src/file-backed-memory-system.js
@@ -2,11 +2,12 @@ import path from "node:path";
 import { appendJsonLine, ensureDir, readJsonFile, writeJsonAtomic, writeTextAtomic } from "./file-utils.js";
 import { MemorySystem } from "./memory-system.js";
 import { nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 export class FileBackedMemorySystem extends MemorySystem {
   constructor(options = {}) {
     super(options);
-    this.dir = options.dir ?? path.join(process.cwd(), ".openagi", "memory");
+    this.dir = options.dir ?? path.join(resolveDataDir(), "memory");
     this.snapshotPath = options.snapshotPath ?? path.join(this.dir, "memory-state.json");
     this.eventsPath = options.eventsPath ?? path.join(this.dir, "memory-events.jsonl");
     ensureDir(this.dir);

--- a/src/file-backed-propagation-controller.js
+++ b/src/file-backed-propagation-controller.js
@@ -2,11 +2,12 @@ import path from "node:path";
 import { ensureDir, readJsonFile, safeFilename, writeJsonAtomic, writeTextAtomic } from "./file-utils.js";
 import { PropagationController } from "./propagation-controller.js";
 import { nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 export class FileBackedPropagationController extends PropagationController {
   constructor(options = {}) {
     super(options);
-    this.storePath = options.storePath ?? path.join(process.cwd(), ".openagi", "agents", "specialists.json");
+    this.storePath = options.storePath ?? path.join(resolveDataDir(), "agents", "specialists.json");
     this.workspaceRoot = options.workspaceRoot ?? path.join(path.dirname(this.storePath), "workspaces");
     this.vectorStore = options.vectorStore ?? null;
     ensureDir(path.dirname(this.storePath));

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -836,11 +836,12 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
             ]
           },
         ];
-        // featured ids already shown as full multi-path cards above —
-        // skip them in the browse-catalog section to avoid duplication.
+        // Featured integrations (BuildBetter, Linear, Rize, …) are ALSO listed
+        // in the browse catalog below — intentionally a duplicate, flagged so
+        // the UI can say "this is the MCP version of an integration you also
+        // have a non-MCP (API) path for above".
         const featuredIds = new Set(integrations.map((i) => i.id));
         const catalog = MCP_CATALOG
-          .filter((entry) => !featuredIds.has(entry.id))
           .map((entry) => ({
             id: entry.id,
             name: entry.name,
@@ -852,7 +853,8 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
             apiKeyHelp: entry.apiKeyHelp ?? null,
             apiKeyConfigured: entry.apiKeyEnvVar ? Boolean(process.env[entry.apiKeyEnvVar]) : true,
             connectable: entry.status === "available" && Boolean(entry.register),
-            configured: mcpInCatalog(entry.id)
+            configured: mcpInCatalog(entry.id),
+            featured: featuredIds.has(entry.id)
           }));
         return sendJson(res, 200, { integrations, catalog, categories: CATEGORIES });
       }
@@ -2692,6 +2694,10 @@ function renderSkillDetail(skill) {
 
 async function refreshMcp() {
   const servers = await fetchJson("/mcp");
+  // Preserve scroll position across the full rebuild below — otherwise every
+  // SSE "mcp" event (e.g. a connect finishing) snaps the list back to the top.
+  const mcpScroller = sidebarList.scrollHeight > sidebarList.clientHeight ? sidebarList : sidebarList.parentElement;
+  const mcpSavedScroll = mcpScroller ? mcpScroller.scrollTop : 0;
   sidebarList.innerHTML = "";
   // Always-visible Register button at the top of the MCP sidebar so the
   // user has an unambiguous entry point — separate from the magical
@@ -2727,6 +2733,8 @@ async function refreshMcp() {
     li.addEventListener("click", () => renderMcpDetail(s));
     sidebarList.appendChild(li);
   }
+  // Restore the pre-rebuild scroll position now that the list is repopulated.
+  if (mcpScroller) mcpScroller.scrollTop = mcpSavedScroll;
   // Show a hero "Register your first MCP" CTA in the main pane when empty.
   if (servers.length === 0) {
     main.innerHTML = \`
@@ -3635,8 +3643,9 @@ async function renderIntegrations() {
       <div class="ui-card" style="display: flex; flex-direction: column; gap: var(--space-2);">
         <div style="display: flex; align-items: flex-start; gap: var(--space-2);">
           <div class="ui-grow">
-            <div style="font-weight: 600; font-size: 13px;">\${escapeHtml(e.name)}</div>
+            <div style="font-weight: 600; font-size: 13px; display:flex; align-items:center; gap:6px;"><span>\${escapeHtml(e.name)}</span><span class="badge" style="background:rgba(96,165,250,.16); color:#7fb3ff; border-color:rgba(96,165,250,.35); font-size:9px;">MCP</span></div>
             <div class="ui-meta" style="margin-top: 2px;">\${escapeHtml(e.description ?? "")}</div>
+            \${e.featured ? '<div class="ui-meta" style="margin-top:3px; opacity:.85;">↑ Also available as a non-MCP (direct API) integration above</div>' : ""}
           </div>
           \${badge}
         </div>
@@ -3656,6 +3665,11 @@ async function renderIntegrations() {
     const envBlock = p.envKeys?.length > 0
       ? \`<div class="muted" style="font-size:11px; margin-top:4px;">env: <code>\${p.envKeys.map(escapeHtml).join("</code> · <code>")}</code></div>\`
       : "";
+    // Make the integration TYPE unmistakable: an MCP path vs a non-MCP
+    // (direct API / file-drop) path. Two integrations can offer both.
+    const kindBadge = p.kind === "mcp"
+      ? '<span class="badge" style="background:rgba(96,165,250,.16); color:#7fb3ff; border-color:rgba(96,165,250,.35);">MCP</span>'
+      : '<span class="badge" style="opacity:.65;">non-MCP</span>';
     let actions = "";
     let editForm = "";
     if (p.kind === "api" && p.envKeys?.length > 0) {
@@ -3688,7 +3702,7 @@ async function renderIntegrations() {
       <div style="border:1px solid var(--line); border-radius:6px; padding:10px 12px; margin-top:6px;">
         <div class="row between" style="align-items:center; gap:8px;">
           <div style="flex:1; min-width:0;">
-            <div style="font-weight:500; font-size:13px;">\${escapeHtml(p.label)}</div>
+            <div style="font-weight:500; font-size:13px; display:flex; align-items:center; gap:6px;">\${kindBadge}<span>\${escapeHtml(p.label)}</span></div>
             \${p.detail ? \`<div class="muted" style="font-size:11px; margin-top:2px;">\${escapeHtml(p.detail)}</div>\` : ""}
             \${envBlock}
             \${lastSync}

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -341,8 +341,12 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
       if (method === "GET" && pathname === "/budget/ledger") {
         const ledger = runtime.budget?.ledger;
         if (!ledger) return sendJson(res, 200, { error: "no-ledger" });
-        const days = Math.max(1, Math.min(90, Number.parseInt(url.searchParams.get("days") ?? "30", 10) || 30));
-        return sendJson(res, 200, { days, entries: ledger.query({ days }), analytics: ledger.analytics({ days }) });
+        // Cap at the ledger's retention window so the reported `days` always
+        // matches the data actually returned (query/analytics clamp the same way).
+        const maxDays = ledger.retentionDays ?? 30;
+        const requested = Math.max(1, Number.parseInt(url.searchParams.get("days") ?? "30", 10) || 30);
+        const days = Math.min(maxDays, requested);
+        return sendJson(res, 200, { days, requestedDays: requested, retentionDays: maxDays, entries: ledger.query({ days }), analytics: ledger.analytics({ days }) });
       }
 
       // ─── Ambient capture / observations ─────────────────────────────────

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -4335,7 +4335,11 @@ function renderActivityResults(results) {
   list.innerHTML = results.map((r) => {
     const meta = [r.app, r.window].filter(Boolean).map(escapeHtml).join(" · ");
     const when = r.at ? new Date(r.at).toLocaleString() : "";
-    const snippet = r.snippet || r.text || r.window || r.event || "";
+    const rawSnippet = r.snippet || r.text || r.window || r.event || "";
+    // Stored observation text (BuildBetter transcripts, OCR of viewed pages)
+    // is untrusted — escape it before innerHTML, but keep the FTS <mark>
+    // highlight tags the search injects.
+    const snippet = escapeHtml(rawSnippet).replaceAll("&lt;mark&gt;", "<mark>").replaceAll("&lt;/mark&gt;", "</mark>");
     return \`<div class="card">
       <div class="row between"><span class="name">\${escapeHtml(meta) || "(no app)"}</span><span class="muted" style="font-size:11px;">\${escapeHtml(when)}</span></div>
       <div class="desc" style="margin-top:6px;line-height:1.5;">\${snippet}</div>

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -1203,17 +1203,21 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
         // Fire-and-forget so the OAuth dance doesn't block the HTTP response.
         // Dashboard polls /mcp and listens for SSE 'mcp' events to learn when
         // it's done (or if an OAuth URL needs to be opened).
-        if (!runtime.mcp.isConnecting?.(name)) {
-          runtime.mcp.connect(name)
-            .then((status) => {
-              pendingOauth.delete(name);
-              events.emit("mcp", { op: "connected", name, tools: status?.tools ?? [] });
-            })
-            .catch((error) => {
-              events.emit("mcp", { op: "connect-error", name, error: error.message });
-            });
-          events.emit("mcp", { op: "connecting", name });
-        }
+        //
+        // Always call connect(): the registry dedups in-flight attempts itself,
+        // and a manual (interactive) connect made while a silent boot reconnect
+        // is in flight must chain an interactive attempt after it — the silent
+        // attempt can't open a browser and fails OAUTH_INTERACTIVE_REQUIRED,
+        // which used to leave the Connect click doing nothing.
+        runtime.mcp.connect(name)
+          .then((status) => {
+            pendingOauth.delete(name);
+            events.emit("mcp", { op: "connected", name, tools: status?.tools ?? [] });
+          })
+          .catch((error) => {
+            events.emit("mcp", { op: "connect-error", name, error: error.message });
+          });
+        events.emit("mcp", { op: "connecting", name });
         return sendJson(res, 202, { name, status: "connecting" });
       }
       if (method === "POST" && pathname.match(/^\/mcp\/clear-auth\/[^/]+$/)) {

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -295,7 +295,13 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
         if (!bb.ok) return sendJson(res, 401, { error: "unauthorized", reason: bb.reason });
         await readJson(req).catch(() => ({})); // drain body; we don't trust it for ingestion
         const source = runtime.buildBetterTaskSource;
-        if (!source?.triggerSync) return sendJson(res, 503, { error: "buildbetter source not configured" });
+        // The source is always registered (so a mid-session MCP login works
+        // without restart), so also check it's actually configured — otherwise
+        // a sync would no-op. Returning 503 (not a false 202) lets BuildBetter
+        // retry the delivery once credentials land.
+        if (!source?.triggerSync || !source.isConfigured?.()) {
+          return sendJson(res, 503, { error: "buildbetter source not configured" });
+        }
         // Don't block the webhook response on the full sync — ack fast,
         // sync in the background (BuildBetter expects a quick 200).
         source.triggerSync().then(
@@ -1631,6 +1637,8 @@ function renderApp() {
     .badge.ok { color: var(--accent); }
     .badge.warn { color: var(--warn); }
     .badge.err { color: var(--err); }
+    .badge.mcp { background: rgba(96,165,250,.16); color: #7fb3ff; border-color: rgba(96,165,250,.35); }
+    .badge.muted { opacity: .65; }
     pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; color: var(--text); }
     input, select, textarea {
       background: var(--bg); color: var(--text); border: 1px solid var(--line);
@@ -3643,7 +3651,7 @@ async function renderIntegrations() {
       <div class="ui-card" style="display: flex; flex-direction: column; gap: var(--space-2);">
         <div style="display: flex; align-items: flex-start; gap: var(--space-2);">
           <div class="ui-grow">
-            <div style="font-weight: 600; font-size: 13px; display:flex; align-items:center; gap:6px;"><span>\${escapeHtml(e.name)}</span><span class="badge" style="background:rgba(96,165,250,.16); color:#7fb3ff; border-color:rgba(96,165,250,.35); font-size:9px;">MCP</span></div>
+            <div style="font-weight: 600; font-size: 13px; display:flex; align-items:center; gap:6px;"><span>\${escapeHtml(e.name)}</span><span class="badge mcp" style="font-size:9px;">MCP</span></div>
             <div class="ui-meta" style="margin-top: 2px;">\${escapeHtml(e.description ?? "")}</div>
             \${e.featured ? '<div class="ui-meta" style="margin-top:3px; opacity:.85;">↑ Also available as a non-MCP (direct API) integration above</div>' : ""}
           </div>
@@ -3668,8 +3676,8 @@ async function renderIntegrations() {
     // Make the integration TYPE unmistakable: an MCP path vs a non-MCP
     // (direct API / file-drop) path. Two integrations can offer both.
     const kindBadge = p.kind === "mcp"
-      ? '<span class="badge" style="background:rgba(96,165,250,.16); color:#7fb3ff; border-color:rgba(96,165,250,.35);">MCP</span>'
-      : '<span class="badge" style="opacity:.65;">non-MCP</span>';
+      ? '<span class="badge mcp">MCP</span>'
+      : '<span class="badge muted">non-MCP</span>';
     let actions = "";
     let editForm = "";
     if (p.kind === "api" && p.envKeys?.length > 0) {

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -338,6 +338,12 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
       }
 
       if (method === "GET" && pathname === "/budget") return sendJson(res, 200, runtime.budget?.status?.() ?? { error: "no-budget" });
+      if (method === "GET" && pathname === "/budget/ledger") {
+        const ledger = runtime.budget?.ledger;
+        if (!ledger) return sendJson(res, 200, { error: "no-ledger" });
+        const days = Math.max(1, Math.min(90, Number.parseInt(url.searchParams.get("days") ?? "30", 10) || 30));
+        return sendJson(res, 200, { days, entries: ledger.query({ days }), analytics: ledger.analytics({ days }) });
+      }
 
       // ─── Ambient capture / observations ─────────────────────────────────
       if (method === "POST" && pathname === "/observations") {

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -3,6 +3,7 @@ import fsSync from "node:fs";
 import path from "node:path";
 import { EventEmitter } from "node:events";
 import { createDefaultRuntime } from "./abi-runtime.js";
+import { resolveDataDir } from "./data-dir.js";
 import {
   buildSetCookie,
   checkAuth,
@@ -186,7 +187,7 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
       }
       if (method === "POST" && pathname === "/setup/save") {
         const body = await readJson(req);
-        const dataDir = process.env.OPENAGI_DATA_DIR ?? ".openagi";
+        const dataDir = resolveDataDir();
         const result = saveEnv({ dataDir, values: body });
         try {
           const { createModelProvider } = await import("./model-provider.js");
@@ -561,7 +562,7 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
             const existing = process.env[entry.apiKeyEnvVar] ?? "";
             if (incoming) {
               const { saveEnv } = await import("./setup-wizard.js");
-              const dataDir = process.env.OPENAGI_DATA_DIR ?? path.join(process.cwd(), ".openagi");
+              const dataDir = resolveDataDir();
               saveEnv({ dataDir, values: { [entry.apiKeyEnvVar]: incoming } });
             } else if (!existing) {
               return sendJson(res, 400, {
@@ -644,7 +645,7 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
         const enable = Boolean(body.enable);
         const { saveEnv } = await import("./setup-wizard.js");
         const { registerComputerUseTools, unregisterComputerUseTools } = await import("./integrations/computer-use.js");
-        const dataDir = process.env.OPENAGI_DATA_DIR ?? path.join(process.cwd(), ".openagi");
+        const dataDir = resolveDataDir();
         // saveEnv writes only allowlisted keys; OPENAGI_COMPUTER_USE has
         // to be in WIZARD_FIELDS (added in this commit) for the write to
         // land in .env.
@@ -1212,7 +1213,7 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
         pendingOauth.delete(name);
         // Wipe cached OAuth tokens so the next connect starts a fresh flow.
         try {
-          const authPath = path.join(process.env.OPENAGI_DATA_DIR ?? ".openagi", "mcp", "auth", `${name}.json`);
+          const authPath = path.join(resolveDataDir(), "mcp", "auth", `${name}.json`);
           if (fsSync.existsSync(authPath)) fsSync.unlinkSync(authPath);
         } catch { /* ignore */ }
         return sendJson(res, 200, { ok: true });

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -1833,7 +1833,7 @@ function renderApp() {
             <button data-tab="today" title="What you got done today — completed tasks, skills run, actions approved, time tracked, themes.">Today</button>
             <button data-tab="activity" title="Ambient capture log — what you were doing on screen (if capture is enabled).">Activity</button>
             <button data-tab="computer-use" title="Computer use (beta) — every action the agent intended to take, with the reasoning it gave.">Computer Use</button>
-            <button data-tab="budget" title="Today's LLM spend + 14-day history.">Budget</button>
+            <button data-tab="budget" title="Today's LLM spend + 14-day history.">Credits</button>
             <button data-tab="outcomes" title="Quality scores for completed agent work, 7d + 30d rolling.">Outcomes</button>
             <button data-tab="health" title="Memory saturation, specialist health, MCP status, upcoming cron.">Health</button>
             <button data-tab="scrutiny" title="Directional Adaptive Scrutiny — the 7-axis scorer's calibration + recent verdicts.">Scrutiny</button>
@@ -3136,7 +3136,7 @@ async function renderBudget() {
   const stateClass = pct > 90 ? "err" : pct > 70 ? "warn" : "ok";
   main.innerHTML = \`
     <div class="pane">
-      <h2>Budget</h2>
+      <h2>Credits</h2>
       <div class="card">
         <div class="row between" style="align-items:center;">
           <span class="name">Today · \${escapeHtml(b.today)}</span>
@@ -3162,6 +3162,14 @@ async function renderBudget() {
       <h3>Last 14 days</h3>
       <div id="budgetHistory" class="grid"></div>
       <p class="desc" style="margin-top:12px;">Limit is set via <code>OPENAGI_DAILY_USD_LIMIT</code> in <code>.openagi/.env</code>.</p>
+      <h3>Spend over time (30 days)</h3>
+      <div id="creditChart" class="card"></div>
+      <h3>By activity (30 days)</h3>
+      <div id="creditByActivity" class="grid"></div>
+      <h3>By model (30 days)</h3>
+      <div id="creditByModel" class="grid"></div>
+      <h3>Audit log</h3>
+      <div id="creditLog"></div>
     </div>
   \`;
   const hist = $("budgetHistory");
@@ -3170,6 +3178,43 @@ async function renderBudget() {
     c.className = "card";
     c.innerHTML = \`<div class="row between"><span class="name">\${escapeHtml(d.date)}</span><span class="muted">\${d.calls} call\${d.calls===1?"":"s"}</span></div><div class="stat-value">$\${d.usd.toFixed(4)}</div>\`;
     hist.appendChild(c);
+  }
+  const led = await fetchJson("/budget/ledger?days=30").catch(() => null);
+  if (led && !led.error) {
+    const days = led.analytics.byDay;
+    const maxUsd = Math.max(0.0001, ...days.map((d) => d.usd));
+    const bw = 100 / Math.max(days.length, 1);
+    const bars = days.map((d, i) => {
+      const h = Math.max(1, (d.usd / maxUsd) * 90);
+      return \`<rect x="\${(i * bw).toFixed(2)}" y="\${(100 - h).toFixed(2)}" width="\${(bw * 0.8).toFixed(2)}" height="\${h.toFixed(2)}"><title>\${escapeHtml(d.date)}: $\${d.usd.toFixed(4)} (\${d.calls})</title></rect>\`;
+    }).join("");
+    $("creditChart").innerHTML = \`<svg viewBox="0 0 100 100" preserveAspectRatio="none" style="width:100%;height:120px;fill:var(--accent);">\${bars}</svg>\`;
+
+    const fill = (id, items, key) => {
+      const el = $(id); el.innerHTML = "";
+      for (const it of items) {
+        const c = document.createElement("div"); c.className = "card";
+        c.innerHTML = \`<div class="row between"><span class="name">\${escapeHtml(String(it[key]))}</span><span class="muted">\${it.calls} call\${it.calls === 1 ? "" : "s"}</span></div><div class="stat-value">$\${it.usd.toFixed(4)}</div>\`;
+        el.appendChild(c);
+      }
+    };
+    fill("creditByActivity", led.analytics.byActivity, "activity");
+    fill("creditByModel", led.analytics.byModel, "model");
+
+    const log = $("creditLog");
+    log.innerHTML = "";
+    for (const e of led.entries.slice(0, 200)) {
+      const t = (e.at || "").slice(0, 16).replace("T", " ");
+      const tools = (e.tools || []).join(", ");
+      const row = document.createElement("div"); row.className = "card";
+      row.innerHTML = \`<div class="row between"><span class="name">\${escapeHtml(e.model || "?")}</span><span class="stat-value">$\${Number(e.usd || 0).toFixed(4)}</span></div><div class="muted" style="font-size:11px;">\${escapeHtml(t)} · \${escapeHtml(e.channel || "?")}\${e.agentId ? " · " + escapeHtml(e.agentId) : ""}\${tools ? " · " + escapeHtml(tools) : ""}</div>\`;
+      log.appendChild(row);
+    }
+    if (led.entries.length > 200) {
+      const more = document.createElement("p"); more.className = "desc";
+      more.textContent = "Showing the most recent 200 of " + led.entries.length + " calls.";
+      log.appendChild(more);
+    }
   }
 }
 

--- a/src/integrations/buildbetter-tasks.js
+++ b/src/integrations/buildbetter-tasks.js
@@ -93,25 +93,20 @@ export class BuildBetterTaskSource {
     }
   }
 
-  // Silently obtain a Bearer token from the cached OAuth connection. Never
-  // triggers the interactive browser flow — if there's no cache, returns null
-  // so a headless poller degrades gracefully instead of hanging on consent.
+  // Silently obtain a Bearer token from the cached OAuth connection. Delegates
+  // to the canonical token lifecycle in McpOAuthClient (cached-or-refresh, no
+  // browser): ensureToken({interactive:false}) returns a valid token or throws
+  // OAUTH_INTERACTIVE_REQUIRED / a refresh error, both of which mean "no token"
+  // for a headless poller. Sharing this keeps us from drifting from how the
+  // live MCP client refreshes the same cache.
   async _oauthToken() {
     const client = this._oauth();
     if (!client) return null;
-    let cache;
-    try { cache = client.loadCache(); } catch { return null; }
-    if (!cache) return null;
     try {
-      if (cache.access_token && !client.isExpired(cache)) return cache.access_token;
-      if (cache.refresh_token && cache.discovery && cache.client) {
-        await client.refresh(cache);
-        return client.loadCache()?.access_token ?? null;
-      }
+      return await client.ensureToken({ interactive: false });
     } catch {
-      // refresh failed (revoked / network) — treat OAuth as unavailable.
+      return null;
     }
-    return null;
   }
 
   // Resolve auth headers: API key wins (preserves existing setups), else the
@@ -323,6 +318,11 @@ export class BuildBetterTaskSource {
   async syncTranscripts({ now = new Date() } = {}) {
     if (!(await this.authHeaders())) return { skipped: true, reason: "no BuildBetter auth (set BUILDBETTER_API_KEY or connect BuildBetter via MCP)" };
     if (!this.runtime?.observations?.record) return { skipped: true, reason: "no observation store" };
+    // Transcripts are filtered to calls YOU attended, so without an identity
+    // getRecentCalls matches nothing — skip with a clear reason instead of
+    // silently recording zero transcripts (mirrors syncSignals).
+    await this.ensureIdentity();
+    if (!this.userEmail && !this.userName) return { skipped: true, reason: "could not determine your BuildBetter identity (set BUILDBETTER_USER_EMAIL or BUILDBETTER_USER_NAME)" };
 
     const sinceIso = new Date(now.getTime() - LOOKBACK_DAYS * 86400 * 1000).toISOString();
     let calls;

--- a/src/integrations/buildbetter-tasks.js
+++ b/src/integrations/buildbetter-tasks.js
@@ -26,6 +26,8 @@ export class BuildBetterTaskSource {
     // that one more run is owed, and run it once when the current finishes.
     this._syncing = false;
     this._syncPending = false;
+    const mode = (options.ingestMode ?? process.env.BUILDBETTER_INGEST_MODE ?? "signals").toLowerCase();
+    this.ingestMode = ["signals", "transcripts", "both"].includes(mode) ? mode : "signals";
   }
 
   isConfigured() {
@@ -114,7 +116,7 @@ export class BuildBetterTaskSource {
   /**
    * Run one sync pass. Returns { created, updated, scanned } or skip reason.
    */
-  async sync({ now = new Date() } = {}) {
+  async syncSignals({ now = new Date() } = {}) {
     if (!this.apiKey) return { skipped: true, reason: "BUILDBETTER_API_KEY not set" };
     if (!this.userEmail && !this.userName) return { skipped: true, reason: "BUILDBETTER_USER_EMAIL or BUILDBETTER_USER_NAME required" };
     if (!this.runtime?.tasks?.add) return { skipped: true, reason: "task store not available" };
@@ -176,6 +178,83 @@ export class BuildBetterTaskSource {
 
     this.lastSyncedAt = now.toISOString();
     return { scanned: extractions.length, calls: calls.length, created };
+  }
+
+  // Fetch the full transcript text for a call, using the verified
+  // interview → monologues schema. Returns "" when no transcript exists.
+  async getTranscript(callId) {
+    const query = `
+      query Transcript($id: bigint!) {
+        interview(where: { id: { _eq: $id } }, limit: 1) {
+          id
+          transcript_status
+          monologues(order_by: { start_sec: asc }) {
+            speaker
+            text
+            attendee { person { first_name last_name } }
+          }
+        }
+      }
+    `;
+    const data = await this.query(query, { id: Number(callId) });
+    const iv = data?.interview?.[0];
+    const rows = iv?.monologues ?? [];
+    if (!rows.length) return "";
+    return rows.map((m) => {
+      const p = m.attendee?.person;
+      const name = p ? [p.first_name, p.last_name].filter(Boolean).join(" ").trim() : "";
+      const speaker = name || `Speaker ${m.speaker}`;
+      return `${speaker}: ${m.text ?? ""}`.trim();
+    }).filter(Boolean).join("\n");
+  }
+
+  // Record one transcript observation per recent call, deduped by ref.
+  async syncTranscripts({ now = new Date() } = {}) {
+    if (!this.apiKey) return { skipped: true, reason: "BUILDBETTER_API_KEY not set" };
+    if (!this.runtime?.observations?.record) return { skipped: true, reason: "no observation store" };
+
+    const sinceIso = new Date(now.getTime() - LOOKBACK_DAYS * 86400 * 1000).toISOString();
+    let calls;
+    try {
+      calls = await this.getRecentCalls(sinceIso);
+    } catch (err) {
+      return { skipped: true, reason: `recent calls: ${err.message}` };
+    }
+
+    let created = 0;
+    for (const call of calls) {
+      const ref = `buildbetter:call:${call.id}`;
+      if (await this.runtime.observations.existsRef(ref)) continue;
+      let text;
+      try {
+        text = await this.getTranscript(call.id);
+      } catch (err) {
+        continue; // skip this call; retry next sweep
+      }
+      if (!text) continue;
+      await this.runtime.observations.record({
+        kind: "transcript",
+        at: call.started_at ?? now.toISOString(),
+        app: "BuildBetter",
+        window: call.name ?? "Call",
+        text,
+        ref
+      });
+      created += 1;
+    }
+    return { scanned: calls.length, created };
+  }
+
+  // Mode-aware dispatcher invoked by the cron handler and triggerSync().
+  async sync({ now = new Date() } = {}) {
+    const out = {};
+    if (this.ingestMode === "signals" || this.ingestMode === "both") {
+      out.signals = await this.syncSignals({ now });
+    }
+    if (this.ingestMode === "transcripts" || this.ingestMode === "both") {
+      out.transcripts = await this.syncTranscripts({ now });
+    }
+    return out;
   }
 
   // Webhook entry point: coalesce concurrent pings into a single in-flight

--- a/src/integrations/buildbetter-tasks.js
+++ b/src/integrations/buildbetter-tasks.js
@@ -402,12 +402,15 @@ export function registerBuildBetterTaskSource(runtime, options = {}) {
     oauthResourceUrl: rec?.resourceUrl ?? (rec?.url ? originOf(rec.url) : undefined),
     ...options
   });
-  if (!source.isConfigured()) {
-    return {
-      registered: false,
-      reason: "no BuildBetter auth — set BUILDBETTER_API_KEY or connect BuildBetter from the MCP tab"
-    };
-  }
+  // Register the source + cron even when no credentials exist yet. Auth can
+  // arrive mid-session — the user connects BuildBetter from the MCP tab and an
+  // OAuth token cache appears — and the poller + webhook must start working
+  // without a daemon restart. sync() self-gates on authHeaders(), so an
+  // unconfigured source just no-ops each tick (a cheap cache check) until
+  // credentials show up. Previously this returned early and left
+  // runtime.buildBetterTaskSource unset, so a later MCP login was ignored
+  // until restart (the cron reported "no buildbetter source", webhook 503'd).
+  runtime.buildBetterTaskSource = source;
   if (runtime.cron?.addJob) {
     runtime.cron.addJob({
       id: "buildbetter-task-sync",
@@ -417,8 +420,7 @@ export function registerBuildBetterTaskSource(runtime, options = {}) {
       intervalMs: POLL_INTERVAL_MS
     });
   }
-  runtime.buildBetterTaskSource = source;
-  return { registered: true };
+  return { registered: true, idle: !source.isConfigured() };
 }
 
 // Origin (scheme + host) of an MCP server URL, for the OAuth resource id.

--- a/src/integrations/buildbetter-tasks.js
+++ b/src/integrations/buildbetter-tasks.js
@@ -187,7 +187,6 @@ export class BuildBetterTaskSource {
       query Transcript($id: bigint!) {
         interview(where: { id: { _eq: $id } }, limit: 1) {
           id
-          transcript_status
           monologues(order_by: { start_sec: asc }) {
             speaker
             text
@@ -222,6 +221,7 @@ export class BuildBetterTaskSource {
     }
 
     let created = 0;
+    let failed = 0;
     for (const call of calls) {
       const ref = `buildbetter:call:${call.id}`;
       if (await this.runtime.observations.existsRef(ref)) continue;
@@ -229,6 +229,7 @@ export class BuildBetterTaskSource {
       try {
         text = await this.getTranscript(call.id);
       } catch (err) {
+        failed += 1;
         continue; // skip this call; retry next sweep
       }
       if (!text) continue;
@@ -242,7 +243,7 @@ export class BuildBetterTaskSource {
       });
       created += 1;
     }
-    return { scanned: calls.length, created };
+    return { scanned: calls.length, created, failed };
   }
 
   // Mode-aware dispatcher invoked by the cron handler and triggerSync().

--- a/src/integrations/buildbetter-tasks.js
+++ b/src/integrations/buildbetter-tasks.js
@@ -1,16 +1,33 @@
 // BuildBetter → TaskStore source. Pulls action items / commitments /
 // follow-ups from the user's recent calls (extractions tagged action_item,
 // follow_up, task, commitment, priority). Polls every 15 min.
-// Env-gated — silently no-ops if BUILDBETTER_API_KEY is unset.
 //
-// User identity (whose attendee the action item is "for") comes from
-// BUILDBETTER_USER_EMAIL or BUILDBETTER_USER_NAME. If neither is set,
-// the integration registers but warns once and stays idle.
+// Auth — two paths, in precedence order:
+//   1. BUILDBETTER_API_KEY  → X-BuildBetter-Api-Key header.
+//   2. The BuildBetter MCP OAuth connection (from the dashboard MCP tab) →
+//      Authorization: Bearer <token>, silently refreshed, no browser needed.
+//      With no API key set at all, connecting BuildBetter once via MCP is
+//      enough for this poller to run.
+//
+// User identity (whose attendee the action item is "for") is auto-derived
+// from the API key / OAuth session via the `me` GraphQL query. It only falls
+// back to BUILDBETTER_USER_EMAIL / BUILDBETTER_USER_NAME when `me` can't
+// pinpoint a single user (e.g. an org-scoped key).
 //
 // Adapted from autolist's apps/api/src/lib/integrations/buildbetter.ts
 // to OpenAGI's task store + integration registry pattern.
 
+import { McpOAuthClient } from "../mcp-oauth.js";
+import { resolveDataDir } from "../data-dir.js";
+
 const BUILDBETTER_ENDPOINT = "https://api.buildbetter.app/v1/graphql";
+// Origin of the BuildBetter MCP server, used to build the OAuth client that
+// reads the token cached under <dataDir>/mcp/auth/buildbetter.json. The actual
+// silent refresh uses the discovery metadata stored in that cache, so this
+// only needs to be correct enough to satisfy the constructor — prod and
+// staging tokens both refresh fine once the cache exists.
+const BUILDBETTER_MCP_RESOURCE_URL = "https://mcp.buildbetter.app";
+const ME_QUERY = "query Me { me { person { first_name last_name email } } }";
 const POLL_INTERVAL_MS = 15 * 60 * 1000;
 const LOOKBACK_DAYS = 7;
 
@@ -20,6 +37,17 @@ export class BuildBetterTaskSource {
     this.apiKey = options.apiKey ?? process.env.BUILDBETTER_API_KEY ?? null;
     this.userEmail = options.userEmail ?? process.env.BUILDBETTER_USER_EMAIL ?? null;
     this.userName = options.userName ?? process.env.BUILDBETTER_USER_NAME ?? null;
+    // OAuth fallback (option 2): reuse the BuildBetter MCP connection. The
+    // client is built lazily so we never touch the filesystem / construct it
+    // when an API key is set. dataDir + resourceUrl come from the MCP registry
+    // when available so we read the exact same token cache the MCP client wrote.
+    this.dataDir = options.dataDir ?? resolveDataDir();
+    this.oauthResourceUrl = options.oauthResourceUrl ?? BUILDBETTER_MCP_RESOURCE_URL;
+    this.oauthClient = options.oauthClient ?? null;
+    this._oauthTried = false;
+    // Identity auto-derivation (option 1): once we've successfully asked `me`,
+    // don't ask again this process — even if it returned no user.
+    this._identityResolved = false;
     this.lastSyncedAt = null;
     // Coalescing state for webhook-triggered syncs: if a sync is already
     // running when a ping arrives, we don't start a second — we just flag
@@ -31,17 +59,98 @@ export class BuildBetterTaskSource {
   }
 
   isConfigured() {
-    return Boolean(this.apiKey) && Boolean(this.userEmail || this.userName);
+    // Identity is auto-derived now, so auth alone is enough: an API key, or a
+    // previously-completed BuildBetter MCP OAuth connection.
+    return Boolean(this.apiKey) || this._hasOAuthCache();
+  }
+
+  // Lazily build the OAuth client. Returns null if it can't be constructed.
+  _oauth() {
+    if (this.oauthClient) return this.oauthClient;
+    if (this._oauthTried) return null;
+    this._oauthTried = true;
+    try {
+      this.oauthClient = new McpOAuthClient({
+        name: "buildbetter",
+        resourceUrl: this.oauthResourceUrl,
+        dataDir: this.dataDir
+      });
+    } catch {
+      this.oauthClient = null;
+    }
+    return this.oauthClient;
+  }
+
+  // Sync probe: is there a usable cached OAuth token/refresh token on disk?
+  _hasOAuthCache() {
+    const client = this._oauth();
+    if (!client) return false;
+    try {
+      const cache = client.loadCache();
+      return Boolean(cache?.access_token || cache?.refresh_token);
+    } catch {
+      return false;
+    }
+  }
+
+  // Silently obtain a Bearer token from the cached OAuth connection. Never
+  // triggers the interactive browser flow — if there's no cache, returns null
+  // so a headless poller degrades gracefully instead of hanging on consent.
+  async _oauthToken() {
+    const client = this._oauth();
+    if (!client) return null;
+    let cache;
+    try { cache = client.loadCache(); } catch { return null; }
+    if (!cache) return null;
+    try {
+      if (cache.access_token && !client.isExpired(cache)) return cache.access_token;
+      if (cache.refresh_token && cache.discovery && cache.client) {
+        await client.refresh(cache);
+        return client.loadCache()?.access_token ?? null;
+      }
+    } catch {
+      // refresh failed (revoked / network) — treat OAuth as unavailable.
+    }
+    return null;
+  }
+
+  // Resolve auth headers: API key wins (preserves existing setups), else the
+  // reused MCP OAuth token. Returns null when neither is available.
+  async authHeaders() {
+    // BuildBetter's exact header spelling per their docs.
+    if (this.apiKey) return { "X-BuildBetter-Api-Key": this.apiKey };
+    const token = await this._oauthToken();
+    if (token) return { authorization: `Bearer ${token}` };
+    return null;
+  }
+
+  // Best-effort: fill userEmail / userName from the authenticated session via
+  // the `me` query. No-op once we already have an identity, or once we've
+  // asked successfully (an org-scoped key legitimately returns no user — we
+  // don't keep re-asking, we just fall back to the env-provided identity).
+  async ensureIdentity() {
+    if (this.userEmail || this.userName) return;
+    if (this._identityResolved) return;
+    try {
+      const data = await this.query(ME_QUERY);
+      this._identityResolved = true; // we successfully asked; don't repeat
+      const p = data?.me?.person;
+      if (p?.email) this.userEmail = p.email;
+      const fullName = [p?.first_name, p?.last_name].filter(Boolean).join(" ").trim();
+      if (!this.userEmail && fullName) this.userName = fullName;
+    } catch {
+      // transient (network / auth) — leave unresolved so we retry next sync.
+    }
   }
 
   async query(graphql, variables = {}) {
+    const auth = await this.authHeaders();
+    if (!auth) {
+      throw new Error("BuildBetter: no auth (set BUILDBETTER_API_KEY or connect BuildBetter from the MCP tab)");
+    }
     const res = await fetch(BUILDBETTER_ENDPOINT, {
       method: "POST",
-      headers: {
-        "content-type": "application/json",
-        // BuildBetter's exact header spelling per their docs.
-        "X-BuildBetter-Api-Key": this.apiKey
-      },
+      headers: { "content-type": "application/json", ...auth },
       body: JSON.stringify({ query: graphql, variables })
     });
     if (!res.ok) throw new Error(`BuildBetter API ${res.status}`);
@@ -52,6 +161,8 @@ export class BuildBetterTaskSource {
 
   // Step 1: find recent calls the user attended.
   async getRecentCalls(sinceIso) {
+    // Auto-derive who "you" are before filtering by attendee.
+    await this.ensureIdentity();
     const query = `
       query RecentCalls($since: timestamptz!, $limit: Int!) {
         interview(
@@ -117,9 +228,10 @@ export class BuildBetterTaskSource {
    * Run one sync pass. Returns { created, updated, scanned } or skip reason.
    */
   async syncSignals({ now = new Date() } = {}) {
-    if (!this.apiKey) return { skipped: true, reason: "BUILDBETTER_API_KEY not set" };
-    if (!this.userEmail && !this.userName) return { skipped: true, reason: "BUILDBETTER_USER_EMAIL or BUILDBETTER_USER_NAME required" };
+    if (!(await this.authHeaders())) return { skipped: true, reason: "no BuildBetter auth (set BUILDBETTER_API_KEY or connect BuildBetter via MCP)" };
     if (!this.runtime?.tasks?.add) return { skipped: true, reason: "task store not available" };
+    await this.ensureIdentity();
+    if (!this.userEmail && !this.userName) return { skipped: true, reason: "could not determine your BuildBetter identity (set BUILDBETTER_USER_EMAIL or BUILDBETTER_USER_NAME)" };
 
     const sinceIso = new Date(now.getTime() - LOOKBACK_DAYS * 86400 * 1000).toISOString();
 
@@ -209,7 +321,7 @@ export class BuildBetterTaskSource {
 
   // Record one transcript observation per recent call, deduped by ref.
   async syncTranscripts({ now = new Date() } = {}) {
-    if (!this.apiKey) return { skipped: true, reason: "BUILDBETTER_API_KEY not set" };
+    if (!(await this.authHeaders())) return { skipped: true, reason: "no BuildBetter auth (set BUILDBETTER_API_KEY or connect BuildBetter via MCP)" };
     if (!this.runtime?.observations?.record) return { skipped: true, reason: "no observation store" };
 
     const sinceIso = new Date(now.getTime() - LOOKBACK_DAYS * 86400 * 1000).toISOString();
@@ -281,13 +393,19 @@ export class BuildBetterTaskSource {
 }
 
 export function registerBuildBetterTaskSource(runtime, options = {}) {
-  const source = options.source ?? new BuildBetterTaskSource({ runtime, ...options });
+  // Reuse the MCP registry's view of the BuildBetter server (if connected) so
+  // the OAuth fallback reads the exact token cache the MCP client wrote.
+  const rec = runtime?.mcp?.servers?.get?.("buildbetter");
+  const source = options.source ?? new BuildBetterTaskSource({
+    runtime,
+    dataDir: runtime?.mcp?.dataDir,
+    oauthResourceUrl: rec?.resourceUrl ?? (rec?.url ? originOf(rec.url) : undefined),
+    ...options
+  });
   if (!source.isConfigured()) {
     return {
       registered: false,
-      reason: source.apiKey
-        ? "BUILDBETTER_USER_EMAIL or BUILDBETTER_USER_NAME required"
-        : "BUILDBETTER_API_KEY not set"
+      reason: "no BuildBetter auth — set BUILDBETTER_API_KEY or connect BuildBetter from the MCP tab"
     };
   }
   if (runtime.cron?.addJob) {
@@ -301,4 +419,9 @@ export function registerBuildBetterTaskSource(runtime, options = {}) {
   }
   runtime.buildBetterTaskSource = source;
   return { registered: true };
+}
+
+// Origin (scheme + host) of an MCP server URL, for the OAuth resource id.
+function originOf(u) {
+  try { return new URL(u).origin; } catch { return BUILDBETTER_MCP_RESOURCE_URL; }
 }

--- a/src/integrations/buildbetter-tasks.js
+++ b/src/integrations/buildbetter-tasks.js
@@ -17,16 +17,12 @@
 // Adapted from autolist's apps/api/src/lib/integrations/buildbetter.ts
 // to OpenAGI's task store + integration registry pattern.
 
-import { McpOAuthClient } from "../mcp-oauth.js";
-import { resolveDataDir } from "../data-dir.js";
-
 const BUILDBETTER_ENDPOINT = "https://api.buildbetter.app/v1/graphql";
-// Origin of the BuildBetter MCP server, used to build the OAuth client that
-// reads the token cached under <dataDir>/mcp/auth/buildbetter.json. The actual
-// silent refresh uses the discovery metadata stored in that cache, so this
-// only needs to be correct enough to satisfy the constructor — prod and
-// staging tokens both refresh fine once the cache exists.
-const BUILDBETTER_MCP_RESOURCE_URL = "https://mcp.buildbetter.app";
+// The MCP server id this integration reuses for OAuth (option 2): when no API
+// key is set, the poller borrows the token the user already granted to the
+// BuildBetter MCP server, via the shared registry primitives
+// runtime.mcp.silentTokenFor() / hasOAuthToken().
+const BUILDBETTER_MCP_ID = "buildbetter";
 const ME_QUERY = "query Me { me { person { first_name last_name email } } }";
 const POLL_INTERVAL_MS = 15 * 60 * 1000;
 const LOOKBACK_DAYS = 7;
@@ -37,14 +33,6 @@ export class BuildBetterTaskSource {
     this.apiKey = options.apiKey ?? process.env.BUILDBETTER_API_KEY ?? null;
     this.userEmail = options.userEmail ?? process.env.BUILDBETTER_USER_EMAIL ?? null;
     this.userName = options.userName ?? process.env.BUILDBETTER_USER_NAME ?? null;
-    // OAuth fallback (option 2): reuse the BuildBetter MCP connection. The
-    // client is built lazily so we never touch the filesystem / construct it
-    // when an API key is set. dataDir + resourceUrl come from the MCP registry
-    // when available so we read the exact same token cache the MCP client wrote.
-    this.dataDir = options.dataDir ?? resolveDataDir();
-    this.oauthResourceUrl = options.oauthResourceUrl ?? BUILDBETTER_MCP_RESOURCE_URL;
-    this.oauthClient = options.oauthClient ?? null;
-    this._oauthTried = false;
     // Identity auto-derivation (option 1): once we've successfully asked `me`,
     // don't ask again this process — even if it returned no user.
     this._identityResolved = false;
@@ -60,61 +48,18 @@ export class BuildBetterTaskSource {
 
   isConfigured() {
     // Identity is auto-derived now, so auth alone is enough: an API key, or a
-    // previously-completed BuildBetter MCP OAuth connection.
-    return Boolean(this.apiKey) || this._hasOAuthCache();
-  }
-
-  // Lazily build the OAuth client. Returns null if it can't be constructed.
-  _oauth() {
-    if (this.oauthClient) return this.oauthClient;
-    if (this._oauthTried) return null;
-    this._oauthTried = true;
-    try {
-      this.oauthClient = new McpOAuthClient({
-        name: "buildbetter",
-        resourceUrl: this.oauthResourceUrl,
-        dataDir: this.dataDir
-      });
-    } catch {
-      this.oauthClient = null;
-    }
-    return this.oauthClient;
-  }
-
-  // Sync probe: is there a usable cached OAuth token/refresh token on disk?
-  _hasOAuthCache() {
-    const client = this._oauth();
-    if (!client) return false;
-    try {
-      const cache = client.loadCache();
-      return Boolean(cache?.access_token || cache?.refresh_token);
-    } catch {
-      return false;
-    }
-  }
-
-  // Silently obtain a Bearer token from the cached OAuth connection. Delegates
-  // to the canonical token lifecycle in McpOAuthClient (cached-or-refresh, no
-  // browser): ensureToken({interactive:false}) returns a valid token or throws
-  // OAUTH_INTERACTIVE_REQUIRED / a refresh error, both of which mean "no token"
-  // for a headless poller. Sharing this keeps us from drifting from how the
-  // live MCP client refreshes the same cache.
-  async _oauthToken() {
-    const client = this._oauth();
-    if (!client) return null;
-    try {
-      return await client.ensureToken({ interactive: false });
-    } catch {
-      return null;
-    }
+    // previously-completed BuildBetter MCP OAuth connection (token cached on
+    // disk, probed via the shared registry primitive).
+    return Boolean(this.apiKey) || Boolean(this.runtime?.mcp?.hasOAuthToken?.(BUILDBETTER_MCP_ID));
   }
 
   // Resolve auth headers: API key wins (preserves existing setups), else the
-  // reused MCP OAuth token. Returns null when neither is available.
+  // BuildBetter MCP OAuth token reused via the registry (silent, never opens a
+  // browser). Returns null when neither is available.
   async authHeaders() {
     // BuildBetter's exact header spelling per their docs.
     if (this.apiKey) return { "X-BuildBetter-Api-Key": this.apiKey };
-    const token = await this._oauthToken();
+    const token = await this.runtime?.mcp?.silentTokenFor?.(BUILDBETTER_MCP_ID);
     if (token) return { authorization: `Bearer ${token}` };
     return null;
   }
@@ -393,15 +338,7 @@ export class BuildBetterTaskSource {
 }
 
 export function registerBuildBetterTaskSource(runtime, options = {}) {
-  // Reuse the MCP registry's view of the BuildBetter server (if connected) so
-  // the OAuth fallback reads the exact token cache the MCP client wrote.
-  const rec = runtime?.mcp?.servers?.get?.("buildbetter");
-  const source = options.source ?? new BuildBetterTaskSource({
-    runtime,
-    dataDir: runtime?.mcp?.dataDir,
-    oauthResourceUrl: rec?.resourceUrl ?? (rec?.url ? originOf(rec.url) : undefined),
-    ...options
-  });
+  const source = options.source ?? new BuildBetterTaskSource({ runtime, ...options });
   // Register the source + cron even when no credentials exist yet. Auth can
   // arrive mid-session — the user connects BuildBetter from the MCP tab and an
   // OAuth token cache appears — and the poller + webhook must start working
@@ -420,10 +357,5 @@ export function registerBuildBetterTaskSource(runtime, options = {}) {
       intervalMs: POLL_INTERVAL_MS
     });
   }
-  return { registered: true, idle: !source.isConfigured() };
-}
-
-// Origin (scheme + host) of an MCP server URL, for the OAuth resource id.
-function originOf(u) {
-  try { return new URL(u).origin; } catch { return BUILDBETTER_MCP_RESOURCE_URL; }
+  return { registered: true };
 }

--- a/src/integrations/imessage-poller.js
+++ b/src/integrations/imessage-poller.js
@@ -24,6 +24,7 @@ import path from "node:path";
 import os from "node:os";
 import fs from "node:fs";
 import { ensureDir, writeJsonAtomic, readJsonFile } from "../file-utils.js";
+import { resolveDataDir } from "../data-dir.js";
 
 const DEFAULT_INTERVAL_MS = 60 * 1000;
 const DEFAULT_DB_PATH = path.join(os.homedir(), "Library", "Messages", "chat.db");
@@ -42,7 +43,7 @@ async function loadSqlite() {
 export class IMessagePollerSource {
   constructor(options = {}) {
     this.runtime = options.runtime;
-    this.dataDir = options.dataDir ?? path.join(process.cwd(), ".openagi");
+    this.dataDir = options.dataDir ?? resolveDataDir();
     this.dbPath = options.dbPath ?? process.env.IMESSAGE_DB_PATH ?? DEFAULT_DB_PATH;
     this.selfHandle = options.selfHandle ?? process.env.IMESSAGE_SELF_HANDLE ?? null;
     this.intervalMs = options.intervalMs ?? (Number(process.env.IMESSAGE_INTERVAL_MS) || DEFAULT_INTERVAL_MS);

--- a/src/integrations/inbox-watcher.js
+++ b/src/integrations/inbox-watcher.js
@@ -20,13 +20,14 @@ import path from "node:path";
 import fs from "node:fs";
 import { ensureDir } from "../file-utils.js";
 import { nowIso } from "../utils.js";
+import { resolveDataDir } from "../data-dir.js";
 
 const POLL_INTERVAL_MS = 30 * 1000;
 
 export class InboxWatcher {
   constructor(options = {}) {
     this.runtime = options.runtime;
-    this.dataDir = options.dataDir ?? process.env.OPENAGI_DATA_DIR ?? ".openagi";
+    this.dataDir = options.dataDir ?? resolveDataDir();
     this.inboxDir = path.join(this.dataDir, "inbox");
     this.processedDir = path.join(this.inboxDir, "processed");
     ensureDir(this.inboxDir);

--- a/src/integrations/web-search-providers.js
+++ b/src/integrations/web-search-providers.js
@@ -1,0 +1,160 @@
+// src/integrations/web-search-providers.js
+// Provider adapters for web_search/fetch_url. Each adapter is independent and
+// env-gated. Responses are mapped to a NormalizedResult:
+//   { title, url, snippet, publishedDate?, content? }
+
+const TIMEOUT_MS = 15_000;
+
+async function postJson(url, { headers = {}, body, apiKey } = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify(body),
+      signal: controller.signal
+    });
+    if (!res.ok) throw new Error(`${url} -> ${res.status}`);
+    return await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function getJson(url, { headers = {} } = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { headers, signal: controller.signal });
+    if (!res.ok) throw new Error(`${url} -> ${res.status}`);
+    return await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const str = (v) => (typeof v === "string" ? v : "");
+
+export const exa = {
+  name: "exa",
+  isConfigured: () => Boolean(process.env.EXA_API_KEY),
+  async search(query, opts = {}) {
+    const apiKey = opts.apiKey ?? process.env.EXA_API_KEY;
+    const data = await postJson("https://api.exa.ai/search", {
+      headers: { "x-api-key": apiKey },
+      body: { query, numResults: opts.numResults ?? 5, contents: { text: true } }
+    });
+    return (data.results ?? []).map((r) => ({
+      title: str(r.title), url: str(r.url), snippet: str(r.text).slice(0, 400),
+      publishedDate: r.publishedDate ?? undefined, content: r.text ?? undefined
+    }));
+  }
+};
+
+export const tavily = {
+  name: "tavily",
+  isConfigured: () => Boolean(process.env.TAVILY_API_KEY),
+  async search(query, opts = {}) {
+    const apiKey = opts.apiKey ?? process.env.TAVILY_API_KEY;
+    const data = await postJson("https://api.tavily.com/search", {
+      headers: { authorization: `Bearer ${apiKey}` },
+      body: { query, max_results: opts.numResults ?? 5, search_depth: "basic", include_answer: false }
+    });
+    return (data.results ?? []).map((r) => ({
+      title: str(r.title), url: str(r.url), snippet: str(r.content).slice(0, 400),
+      publishedDate: r.published_date ?? undefined, content: r.raw_content ?? undefined
+    }));
+  }
+};
+
+export const firecrawl = {
+  name: "firecrawl",
+  isConfigured: () => Boolean(process.env.FIRECRAWL_API_KEY),
+  async search(query, opts = {}) {
+    const apiKey = opts.apiKey ?? process.env.FIRECRAWL_API_KEY;
+    const data = await postJson("https://api.firecrawl.dev/v2/search", {
+      headers: { authorization: `Bearer ${apiKey}` },
+      body: { query, limit: opts.numResults ?? 5 }
+    });
+    // v2 returns { data: { web: [...] } } or { data: [...] } depending on sources.
+    const rows = Array.isArray(data.data) ? data.data : (data.data?.web ?? []);
+    return rows.map((r) => ({
+      title: str(r.title), url: str(r.url),
+      snippet: str(r.description || r.snippet).slice(0, 400),
+      content: r.markdown ?? undefined
+    }));
+  },
+  async fetch(url, opts = {}) {
+    const apiKey = opts.apiKey ?? process.env.FIRECRAWL_API_KEY;
+    const data = await postJson("https://api.firecrawl.dev/v2/scrape", {
+      headers: { authorization: `Bearer ${apiKey}` },
+      body: { url, formats: ["markdown"] }
+    });
+    return str(data.data?.markdown);
+  }
+};
+
+export const brave = {
+  name: "brave",
+  isConfigured: () => Boolean(process.env.BRAVE_API_KEY),
+  async search(query, opts = {}) {
+    const apiKey = opts.apiKey ?? process.env.BRAVE_API_KEY;
+    const count = opts.numResults ?? 5;
+    const data = await getJson(
+      `https://api.search.brave.com/res/v1/web/search?q=${encodeURIComponent(query)}&count=${count}`,
+      { headers: { accept: "application/json", "x-subscription-token": apiKey } }
+    );
+    return (data.web?.results ?? []).map((r) => ({
+      title: str(r.title), url: str(r.url), snippet: str(r.description).slice(0, 400),
+      publishedDate: r.age ?? undefined
+    }));
+  }
+};
+
+export const perplexity = {
+  name: "perplexity",
+  isConfigured: () => Boolean(process.env.PERPLEXITY_API_KEY),
+  async search(query, opts = {}) {
+    const apiKey = opts.apiKey ?? process.env.PERPLEXITY_API_KEY;
+    const data = await postJson("https://api.perplexity.ai/chat/completions", {
+      headers: { authorization: `Bearer ${apiKey}` },
+      body: { model: "sonar", messages: [{ role: "user", content: query }] }
+    });
+    const answer = str(data.choices?.[0]?.message?.content);
+    const citations = Array.isArray(data.citations) ? data.citations : [];
+    const out = [];
+    if (answer) out.push({ title: "Perplexity answer", url: citations[0] ?? "", snippet: answer.slice(0, 400), content: answer });
+    for (const c of citations) out.push({ title: c, url: c, snippet: "" });
+    return out.slice(0, (opts.numResults ?? 5) + 1);
+  }
+};
+
+export const serpapi = {
+  name: "serpapi",
+  isConfigured: () => Boolean(process.env.SERPAPI_API_KEY) || Boolean(process.env.GOOGLE_API_KEY && process.env.GOOGLE_CSE_ID),
+  async search(query, opts = {}) {
+    const num = opts.numResults ?? 5;
+    if (process.env.SERPAPI_API_KEY || opts.apiKey) {
+      const key = opts.apiKey ?? process.env.SERPAPI_API_KEY;
+      const data = await getJson(
+        `https://serpapi.com/search.json?engine=google&q=${encodeURIComponent(query)}&num=${num}&api_key=${encodeURIComponent(key)}`
+      );
+      return (data.organic_results ?? []).map((r) => ({
+        title: str(r.title), url: str(r.link), snippet: str(r.snippet).slice(0, 400),
+        publishedDate: r.date ?? undefined
+      }));
+    }
+    // Google Programmable Search fallback.
+    const data = await getJson(
+      `https://www.googleapis.com/customsearch/v1?key=${encodeURIComponent(process.env.GOOGLE_API_KEY)}&cx=${encodeURIComponent(process.env.GOOGLE_CSE_ID)}&q=${encodeURIComponent(query)}&num=${num}`
+    );
+    return (data.items ?? []).map((r) => ({
+      title: str(r.title), url: str(r.link), snippet: str(r.snippet).slice(0, 400)
+    }));
+  }
+};
+
+// Default priority order (spec): exa -> tavily -> brave -> serpapi -> firecrawl -> perplexity.
+export const PROVIDERS = [exa, tavily, brave, serpapi, firecrawl, perplexity];
+export const PROVIDER_BY_NAME = Object.fromEntries(PROVIDERS.map((p) => [p.name, p]));

--- a/src/integrations/web-search-providers.js
+++ b/src/integrations/web-search-providers.js
@@ -5,7 +5,10 @@
 
 const TIMEOUT_MS = 15_000;
 
-async function postJson(url, { headers = {}, body, apiKey } = {}) {
+// Strip credential query params so they never reach error messages / logs.
+const sanitizeUrl = (url) => String(url).replace(/([?&](?:api_key|key)=)[^&]*/gi, "$1[REDACTED]");
+
+async function postJson(url, { headers = {}, body } = {}) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
@@ -15,7 +18,7 @@ async function postJson(url, { headers = {}, body, apiKey } = {}) {
       body: JSON.stringify(body),
       signal: controller.signal
     });
-    if (!res.ok) throw new Error(`${url} -> ${res.status}`);
+    if (!res.ok) throw new Error(`${sanitizeUrl(url)} -> ${res.status}`);
     return await res.json();
   } finally {
     clearTimeout(timer);
@@ -27,7 +30,7 @@ async function getJson(url, { headers = {} } = {}) {
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
     const res = await fetch(url, { headers, signal: controller.signal });
-    if (!res.ok) throw new Error(`${url} -> ${res.status}`);
+    if (!res.ok) throw new Error(`${sanitizeUrl(url)} -> ${res.status}`);
     return await res.json();
   } finally {
     clearTimeout(timer);
@@ -107,7 +110,7 @@ export const brave = {
     );
     return (data.web?.results ?? []).map((r) => ({
       title: str(r.title), url: str(r.url), snippet: str(r.description).slice(0, 400),
-      publishedDate: r.age ?? undefined
+      publishedDate: r.page_age ?? undefined
     }));
   }
 };

--- a/src/integrations/web-search-providers.js
+++ b/src/integrations/web-search-providers.js
@@ -148,9 +148,11 @@ export const serpapi = {
         publishedDate: r.date ?? undefined
       }));
     }
-    // Google Programmable Search fallback.
+    // Google Programmable Search fallback. cse.list caps `num` at 10 (1–10);
+    // a higher value (the tool schema allows up to 20) returns a 400.
+    const cseNum = Math.min(10, Math.max(1, num));
     const data = await getJson(
-      `https://www.googleapis.com/customsearch/v1?key=${encodeURIComponent(process.env.GOOGLE_API_KEY)}&cx=${encodeURIComponent(process.env.GOOGLE_CSE_ID)}&q=${encodeURIComponent(query)}&num=${num}`
+      `https://www.googleapis.com/customsearch/v1?key=${encodeURIComponent(process.env.GOOGLE_API_KEY)}&cx=${encodeURIComponent(process.env.GOOGLE_CSE_ID)}&q=${encodeURIComponent(query)}&num=${cseNum}`
     );
     return (data.items ?? []).map((r) => ({
       title: str(r.title), url: str(r.link), snippet: str(r.snippet).slice(0, 400)

--- a/src/integrations/web-search.js
+++ b/src/integrations/web-search.js
@@ -1,5 +1,6 @@
 // src/integrations/web-search.js
 import { PROVIDERS, PROVIDER_BY_NAME, firecrawl } from "./web-search-providers.js";
+import { assertSafePublicUrl, safeFetch } from "../url-guard.js";
 
 const PROVIDER_NAMES = PROVIDERS.map((p) => p.name);
 
@@ -66,7 +67,14 @@ export function registerWebSearchTools(runtime, opts = {}) {
       additionalProperties: false
     },
     handler: async (args) => {
-      const format = args.format ?? "markdown";
+      // SSRF guard: reject loopback / private / link-local / metadata hosts and
+      // non-http(s) protocols before touching the network. Done up front so the
+      // Firecrawl path can't be used to reach internal hosts either.
+      try {
+        assertSafePublicUrl(args.url, "fetch_url url");
+      } catch (err) {
+        return { error: err.message };
+      }
       if (firecrawl.isConfigured()) {
         try {
           const content = await firecrawl.fetch(args.url);
@@ -76,7 +84,9 @@ export function registerWebSearchTools(runtime, opts = {}) {
         }
       }
       try {
-        const res = await fetch(args.url, { headers: { "user-agent": "OpenAGI/1.0" } });
+        // safeFetch re-validates the host on every redirect hop so a public URL
+        // can't 30x-redirect into an internal address.
+        const res = await safeFetch(args.url, { headers: { "user-agent": "OpenAGI/1.0" } }, { label: "fetch_url url" });
         if (!res.ok) return { error: `${args.url} -> ${res.status}` };
         const html = await res.text();
         const text = html

--- a/src/integrations/web-search.js
+++ b/src/integrations/web-search.js
@@ -1,0 +1,96 @@
+// src/integrations/web-search.js
+import { PROVIDERS, PROVIDER_BY_NAME, firecrawl } from "./web-search-providers.js";
+
+const PROVIDER_NAMES = PROVIDERS.map((p) => p.name);
+
+// opts.providers is a test seam; production uses the real PROVIDERS list.
+export function registerWebSearchTools(runtime, opts = {}) {
+  const providers = opts.providers ?? PROVIDERS;
+  const byName = opts.providers
+    ? Object.fromEntries(opts.providers.map((p) => [p.name, p]))
+    : PROVIDER_BY_NAME;
+
+  runtime.tools.register({
+    name: "web_search",
+    description: "Search the live web. Returns a list of results (title, url, snippet, and often page content). Picks a configured provider automatically; pass `provider` to force one.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "The search query." },
+        provider: { type: "string", enum: PROVIDER_NAMES, description: "Force a specific provider. Omit to auto-select." },
+        num_results: { type: "integer", minimum: 1, maximum: 20, description: "Max results (default 5)." },
+        recency: { type: "string", enum: ["day", "week", "month", "year"], description: "Optional recency hint." }
+      },
+      required: ["query"],
+      additionalProperties: false
+    },
+    handler: async (args) => {
+      const numResults = args.num_results ?? 5;
+      // Resolution order: explicit arg -> WEB_SEARCH_PROVIDER -> priority list.
+      let order = [];
+      if (args.provider) {
+        const p = byName[args.provider];
+        if (!p) return { error: `Unknown provider: ${args.provider}` };
+        if (!p.isConfigured()) return { error: `Provider ${args.provider} is not configured (missing API key).` };
+        order = [p];
+      } else {
+        const envDefault = process.env.WEB_SEARCH_PROVIDER && byName[process.env.WEB_SEARCH_PROVIDER];
+        const configured = providers.filter((p) => p.isConfigured());
+        order = envDefault && envDefault.isConfigured() ? [envDefault, ...configured.filter((p) => p !== envDefault)] : configured;
+      }
+      if (order.length === 0) return { error: "No web search provider configured. Set EXA_API_KEY, TAVILY_API_KEY, BRAVE_API_KEY, SERPAPI_API_KEY, FIRECRAWL_API_KEY, or PERPLEXITY_API_KEY in ~/.openagi/.env." };
+
+      const errors = [];
+      for (const p of order) {
+        try {
+          const results = await p.search(args.query, { numResults, recency: args.recency });
+          return { provider: p.name, count: results.length, results };
+        } catch (err) {
+          errors.push(`${p.name}: ${err.message}`);
+        }
+      }
+      return { error: `All providers failed. ${errors.join("; ")}` };
+    }
+  });
+
+  runtime.tools.register({
+    name: "fetch_url",
+    description: "Fetch the contents of a web page as markdown/text. Uses Firecrawl when configured, otherwise a plain fetch.",
+    parameters: {
+      type: "object",
+      properties: {
+        url: { type: "string", description: "The URL to fetch." },
+        format: { type: "string", enum: ["markdown", "text"], description: "Output format (default markdown)." }
+      },
+      required: ["url"],
+      additionalProperties: false
+    },
+    handler: async (args) => {
+      const format = args.format ?? "markdown";
+      if (firecrawl.isConfigured()) {
+        try {
+          const content = await firecrawl.fetch(args.url);
+          if (content) return { url: args.url, format: "markdown", content };
+        } catch (err) {
+          // fall through to plain fetch
+        }
+      }
+      try {
+        const res = await fetch(args.url, { headers: { "user-agent": "OpenAGI/1.0" } });
+        if (!res.ok) return { error: `${args.url} -> ${res.status}` };
+        const html = await res.text();
+        const text = html
+          .replace(/<script[\s\S]*?<\/script>/gi, " ")
+          .replace(/<style[\s\S]*?<\/style>/gi, " ")
+          .replace(/<[^>]+>/g, " ")
+          .replace(/\s+/g, " ")
+          .trim();
+        return { url: args.url, format: "text", content: text.slice(0, 20_000) };
+      } catch (err) {
+        return { error: `fetch_url failed: ${err.message}` };
+      }
+    }
+  });
+
+  return { registered: true };
+}

--- a/src/mcp-http-client.js
+++ b/src/mcp-http-client.js
@@ -55,11 +55,10 @@ export class McpHttpClient {
 
   async connect({ interactive = true } = {}) {
     if (this.connected) return { tools: this.tools, serverInfo: this.serverInfo };
-    // Applies for the duration of this connect's requests; controls whether an
-    // OAuth token miss may open a browser (true) or must fail fast (false).
-    this._interactiveAuth = interactive;
     if (this.logDir) ensureDir(this.logDir);
     try {
+      // `interactive` is threaded per-request (not latched on the instance) so
+      // a silent boot connect can't leave later tool calls unable to re-auth.
       this.serverInfo = await this.request(
         "initialize",
         {
@@ -67,11 +66,11 @@ export class McpHttpClient {
           capabilities: { tools: {} },
           clientInfo: { name: "openagi", version: "0.2.0" }
         },
-        { timeoutMs: this.initializeTimeoutMs }
+        { timeoutMs: this.initializeTimeoutMs, interactive }
       );
       // notifications/initialized has no response.
-      await this.notify("notifications/initialized", {});
-      const list = await this.request("tools/list", {});
+      await this.notify("notifications/initialized", {}, { interactive });
+      const list = await this.request("tools/list", {}, { interactive });
       this.tools = list?.tools ?? [];
       this.connected = true;
       this.lastError = null;
@@ -94,21 +93,21 @@ export class McpHttpClient {
     return this.request("tools/call", { name: toolName, arguments: args });
   }
 
-  notify(method, params) {
-    return this.send({ jsonrpc: "2.0", method, params }, { isNotification: true });
+  notify(method, params, options = {}) {
+    return this.send({ jsonrpc: "2.0", method, params }, { isNotification: true, interactive: options.interactive });
   }
 
   async request(method, params, options = {}) {
     const id = this.nextId++;
     const message = { jsonrpc: "2.0", id, method, params };
-    return this.send(message, { timeoutMs: options.timeoutMs });
+    return this.send(message, { timeoutMs: options.timeoutMs, interactive: options.interactive });
   }
 
   /**
    * Send a JSON-RPC message. Awaits response unless `isNotification` is set.
    * On 401 with an oauth client: refresh once, retry once.
    */
-  async send(message, { isNotification = false, timeoutMs = this.timeoutMs, retried = false } = {}) {
+  async send(message, { isNotification = false, timeoutMs = this.timeoutMs, retried = false, interactive = true } = {}) {
     const headers = {
       "content-type": "application/json",
       accept: "application/json, text/event-stream",
@@ -116,7 +115,7 @@ export class McpHttpClient {
     };
     if (this.bearerToken) headers.authorization = `Bearer ${this.bearerToken}`;
     if (this.oauth) {
-      const token = await this.oauth.ensureToken({ interactive: this._interactiveAuth ?? true });
+      const token = await this.oauth.ensureToken({ interactive });
       headers.authorization = `Bearer ${token}`;
     }
     if (this.sessionId) headers["mcp-session-id"] = this.sessionId;
@@ -146,7 +145,7 @@ export class McpHttpClient {
       // Force a re-auth on next call.
       const cache = this.oauth.loadCache();
       if (cache) this.oauth.saveCache({ ...cache, access_token: null, expires_at: 0 });
-      return this.send(message, { isNotification, timeoutMs, retried: true });
+      return this.send(message, { isNotification, timeoutMs, retried: true, interactive });
     }
 
     if (response.status === 202) {

--- a/src/mcp-http-client.js
+++ b/src/mcp-http-client.js
@@ -53,8 +53,11 @@ export class McpHttpClient {
     };
   }
 
-  async connect() {
+  async connect({ interactive = true } = {}) {
     if (this.connected) return { tools: this.tools, serverInfo: this.serverInfo };
+    // Applies for the duration of this connect's requests; controls whether an
+    // OAuth token miss may open a browser (true) or must fail fast (false).
+    this._interactiveAuth = interactive;
     if (this.logDir) ensureDir(this.logDir);
     try {
       this.serverInfo = await this.request(
@@ -113,7 +116,7 @@ export class McpHttpClient {
     };
     if (this.bearerToken) headers.authorization = `Bearer ${this.bearerToken}`;
     if (this.oauth) {
-      const token = await this.oauth.ensureToken();
+      const token = await this.oauth.ensureToken({ interactive: this._interactiveAuth ?? true });
       headers.authorization = `Bearer ${token}`;
     }
     if (this.sessionId) headers["mcp-session-id"] = this.sessionId;

--- a/src/mcp-oauth.js
+++ b/src/mcp-oauth.js
@@ -27,7 +27,14 @@ export class McpOAuthClient {
     if (!options.resourceUrl) throw new Error("McpOAuthClient requires resourceUrl");
     this.name = options.name ?? "mcp";
     this.resourceUrl = stripTrailingSlash(options.resourceUrl);
-    this.scope = options.scope ?? DEFAULT_SCOPE;
+    // The scope we'd *prefer*. The scope actually requested is narrowed at
+    // discovery time to what the server advertises as supported — servers that
+    // advertise none (e.g. Rize) get no scope param at all, instead of a
+    // hardcoded set they'd reject with `invalid_scope`. A scope passed
+    // explicitly (e.g. from a catalog entry) is treated as authoritative and
+    // sent as-is.
+    this.preferredScope = options.scope ?? DEFAULT_SCOPE;
+    this.scopeExplicit = options.scope != null;
     this.dataDir = options.dataDir ?? resolveDataDir();
     this.cachePath = path.join(this.dataDir, "mcp", "auth", `${this.name}.json`);
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -83,10 +90,26 @@ export class McpOAuthClient {
   /**
    * Authorization code + PKCE flow. Returns once tokens are saved to cache.
    */
+  // Narrow the requested scope to what this server actually supports. RFC 9728
+  // (protected resource) and RFC 8414 (auth server) both may advertise
+  // `scopes_supported`. We request the intersection of our preferred scopes
+  // with what's advertised; if the server advertises nothing, we omit `scope`
+  // entirely and let the server apply its own default. Returns null = "omit".
+  resolveScope(discovery) {
+    if (this.scopeExplicit) return this.preferredScope; // caller forced it
+    const supported = discovery?.resourceMeta?.scopes_supported
+      ?? discovery?.serverMeta?.scopes_supported;
+    if (!Array.isArray(supported)) return null;
+    const want = this.preferredScope.split(/\s+/).filter(Boolean);
+    const inter = want.filter((s) => supported.includes(s));
+    return inter.length ? inter.join(" ") : null;
+  }
+
   async authorize() {
     const discovery = await this.discover();
+    const scope = this.resolveScope(discovery);
     const cache = this.loadCache() ?? {};
-    const client = this.staticClient ?? cache.client ?? (await this.registerClient(discovery));
+    const client = this.staticClient ?? cache.client ?? (await this.registerClient(discovery, scope));
 
     const codeVerifier = base64url(randomBytes(48));
     const codeChallenge = base64url(createHash("sha256").update(codeVerifier).digest());
@@ -103,7 +126,9 @@ export class McpOAuthClient {
     authUrl.searchParams.set("code_challenge", codeChallenge);
     authUrl.searchParams.set("code_challenge_method", "S256");
     authUrl.searchParams.set("state", state);
-    authUrl.searchParams.set("scope", this.scope);
+    // Only send `scope` when we have one the server supports — sending an
+    // unsupported scope (or a hardcoded default) is what triggers invalid_scope.
+    if (scope) authUrl.searchParams.set("scope", scope);
     authUrl.searchParams.set("resource", this.resourceUrl);
 
     this.printAuthUrlFn({ name: this.name, url: authUrl.toString() });
@@ -180,7 +205,7 @@ export class McpOAuthClient {
       refresh_token: tokens.refresh_token ?? this.loadCache()?.refresh_token ?? null,
       token_type: tokens.token_type ?? "Bearer",
       expires_at,
-      scope: tokens.scope ?? this.scope,
+      scope: tokens.scope ?? this.preferredScope,
       discovery,
       client
     });
@@ -230,20 +255,29 @@ export class McpOAuthClient {
    * Dynamic client registration (RFC 7591). Returns the registered client
    * descriptor, including client_id (and client_secret if confidential).
    */
-  async registerClient(discovery) {
+  async registerClient(discovery, scope = null) {
     if (!discovery.serverMeta.registration_endpoint) {
       throw new Error("Authorization server has no registration_endpoint and no static client_id was provided");
     }
+    // Only register grant types the server actually supports — Rize, for
+    // example, advertises authorization_code only, so registering
+    // refresh_token can be rejected.
+    const supportedGrants = discovery.serverMeta.grant_types_supported;
+    const grant_types = Array.isArray(supportedGrants)
+      ? ["authorization_code", "refresh_token"].filter((g) => supportedGrants.includes(g))
+      : ["authorization_code", "refresh_token"];
+    if (!grant_types.includes("authorization_code")) grant_types.push("authorization_code");
     const body = {
       client_name: "OpenAGI",
       client_uri: "https://github.com/Spshulem/openAGI",
       redirect_uris: redirectUriCandidates(),
-      grant_types: ["authorization_code", "refresh_token"],
+      grant_types,
       response_types: ["code"],
       token_endpoint_auth_method: "none",
-      scope: this.scope,
       application_type: "native"
     };
+    // Only advertise a scope at registration if we have a server-supported one.
+    if (scope) body.scope = scope;
     const response = await fetch(discovery.serverMeta.registration_endpoint, {
       method: "POST",
       headers: { "content-type": "application/json", accept: "application/json" },

--- a/src/mcp-oauth.js
+++ b/src/mcp-oauth.js
@@ -105,9 +105,15 @@ export class McpOAuthClient {
   // entirely and let the server apply its own default. Returns null = "omit".
   resolveScope(discovery) {
     if (this.scopeExplicit) return this.preferredScope; // caller forced it
-    const supported = discovery?.resourceMeta?.scopes_supported
-      ?? discovery?.serverMeta?.scopes_supported;
-    if (!Array.isArray(supported)) return null;
+    // Prefer the resource's advertised scopes, but fall through to the auth
+    // server's when the resource advertises an EMPTY list (an empty array is
+    // not nullish, so a plain `??` would wrongly stop at it).
+    const resourceScopes = discovery?.resourceMeta?.scopes_supported;
+    const serverScopes = discovery?.serverMeta?.scopes_supported;
+    const supported = (Array.isArray(resourceScopes) && resourceScopes.length) ? resourceScopes
+      : (Array.isArray(serverScopes) && serverScopes.length) ? serverScopes
+      : null;
+    if (!supported) return null;
     const want = this.preferredScope.split(/\s+/).filter(Boolean);
     const inter = want.filter((s) => supported.includes(s));
     return inter.length ? inter.join(" ") : null;

--- a/src/mcp-oauth.js
+++ b/src/mcp-oauth.js
@@ -64,7 +64,7 @@ export class McpOAuthClient {
    * Return a valid access token. Uses cached if not expired, refreshes if it
    * has a refresh_token, otherwise runs the full authorization code flow.
    */
-  async ensureToken() {
+  async ensureToken({ interactive = true } = {}) {
     const cache = this.loadCache() ?? {};
     if (cache.access_token && !this.isExpired(cache)) {
       return cache.access_token;
@@ -77,6 +77,14 @@ export class McpOAuthClient {
         // fall through to full flow
         cache.refresh_token = null;
       }
+    }
+    // Non-interactive callers (e.g. silent reconnect on daemon boot) must never
+    // trigger the browser flow — surface a typed error so the caller can leave
+    // the server "idle" with a Connect button instead of popping a window.
+    if (!interactive) {
+      const err = new Error(`OAuth authorization required for ${this.name}`);
+      err.code = "OAUTH_INTERACTIVE_REQUIRED";
+      throw err;
     }
     await this.authorize();
     return this.loadCache().access_token;

--- a/src/mcp-oauth.js
+++ b/src/mcp-oauth.js
@@ -17,6 +17,7 @@ import { spawn } from "node:child_process";
 import { randomBytes, createHash } from "node:crypto";
 import { ensureDir, readJsonFile, writeJsonAtomic } from "./file-utils.js";
 import { nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 const DEFAULT_SCOPE = "openid profile email offline_access";
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 min for the user to click through
@@ -27,7 +28,7 @@ export class McpOAuthClient {
     this.name = options.name ?? "mcp";
     this.resourceUrl = stripTrailingSlash(options.resourceUrl);
     this.scope = options.scope ?? DEFAULT_SCOPE;
-    this.dataDir = options.dataDir ?? path.join(process.cwd(), ".openagi");
+    this.dataDir = options.dataDir ?? resolveDataDir();
     this.cachePath = path.join(this.dataDir, "mcp", "auth", `${this.name}.json`);
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.printAuthUrlFn = options.printAuthUrlFn ?? defaultPrintAuthUrl;

--- a/src/mcp-registry.js
+++ b/src/mcp-registry.js
@@ -5,6 +5,7 @@ import { McpHttpClient } from "./mcp-http-client.js";
 import { McpOAuthClient } from "./mcp-oauth.js";
 import { ensureDir, readJsonFile, writeJsonAtomic } from "./file-utils.js";
 import { resolveDataDir } from "./data-dir.js";
+import { assertSafePublicUrl } from "./url-guard.js";
 
 // Whitelist of executables permitted as the `command` for stdio MCP servers.
 // Anything not in this set is rejected at registerServer() — closes the
@@ -422,32 +423,10 @@ function loadDotenvKeys(dataDir) {
 
 // Reject MCP URLs that point at loopback / link-local / RFC1918 / cloud
 // metadata endpoints. Combined with the env-var allowlist this closes the
-// SSRF + secret-exfil chain through `/mcp/register`.
+// SSRF + secret-exfil chain through `/mcp/register`. Delegates to the shared
+// url-guard (same guard the fetch_url tool uses).
 function assertSafeMcpUrl(value) {
-  let u;
-  try { u = new URL(value); } catch { throw new Error(`Invalid MCP url: ${value}`); }
-  if (u.protocol !== "http:" && u.protocol !== "https:") {
-    throw new Error(`MCP url protocol must be http or https, got "${u.protocol}".`);
-  }
-  const host = u.hostname.toLowerCase();
-  if (
-    host === "localhost" || host === "0.0.0.0" || host === "::" ||
-    host.endsWith(".localhost") ||
-    /^127\./.test(host) ||
-    /^10\./.test(host) ||
-    /^192\.168\./.test(host) ||
-    /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
-    /^169\.254\./.test(host) ||
-    host === "169.254.169.254" || // AWS / GCP IMDS
-    /^fd[0-9a-f]{2}:/.test(host) || // ULA
-    /^fe80:/.test(host) || // link-local
-    host === "::1"
-  ) {
-    throw new Error(
-      `MCP url host "${host}" is not allowed (loopback, private, or link-local). ` +
-      `Use a public hostname.`
-    );
-  }
+  assertSafePublicUrl(value, "MCP url");
 }
 
 // For OAuth discovery, use the MCP endpoint's origin as the resource URL

--- a/src/mcp-registry.js
+++ b/src/mcp-registry.js
@@ -312,19 +312,22 @@ export class McpRegistry {
   }
 
   async connectAll({ silent = false } = {}) {
+    const targets = [...this.servers].filter(([, server]) => {
+      if (!server.enabled) return false;
+      if (server.transport === "stdio" && !server.command) return false;
+      if (server.transport === "http" && !server.url) return false;
+      return server.transport === "stdio" || server.transport === "http";
+    });
+    const attempt = (name) => this.connect(name, { silent }).then(
+      (status) => ({ name, ok: true, status }),
+      (error) => ({ name, ok: false, error: error.message, code: error.code ?? null })
+    );
+    // Silent boot reconnect runs concurrently (no browser, so no popup storm)
+    // to pay max-latency, not sum. Interactive connect-all stays sequential so
+    // we never open several OAuth browser tabs at once.
+    if (silent) return Promise.all(targets.map(([name]) => attempt(name)));
     const results = [];
-    for (const [name, server] of this.servers) {
-      if (!server.enabled) continue;
-      if (server.transport === "stdio" && !server.command) continue;
-      if (server.transport === "http" && !server.url) continue;
-      if (server.transport !== "stdio" && server.transport !== "http") continue;
-      try {
-        const status = await this.connect(name, { silent });
-        results.push({ name, ok: true, status });
-      } catch (error) {
-        results.push({ name, ok: false, error: error.message, code: error.code ?? null });
-      }
-    }
+    for (const [name] of targets) results.push(await attempt(name));
     return results;
   }
 

--- a/src/mcp-registry.js
+++ b/src/mcp-registry.js
@@ -294,7 +294,15 @@ export class McpRegistry {
   hasOAuthToken(name) {
     try {
       const cache = readJsonFile(path.join(this.dataDir, "mcp", "auth", `${name}.json`), null);
-      return Boolean(cache?.access_token || cache?.refresh_token);
+      if (!cache) return false;
+      // Mirror what ensureToken({interactive:false}) can actually do: a
+      // refresh_token can always mint a fresh access token silently, but a
+      // bare access_token only counts while unexpired (same 30s safety margin
+      // as McpOAuthClient.isExpired) — otherwise integrations report
+      // "configured", ack webhooks, and then silently fail to authenticate.
+      if (cache.refresh_token) return true;
+      if (!cache.access_token || !cache.expires_at) return false;
+      return Date.now() < cache.expires_at - 30_000;
     } catch {
       return false;
     }

--- a/src/mcp-registry.js
+++ b/src/mcp-registry.js
@@ -235,14 +235,69 @@ export class McpRegistry {
   }
 
   async connect(name, { silent = false } = {}) {
-    if (this.connecting.has(name)) return this.connecting.get(name);
+    const inflight = this.connecting.get(name);
+    if (inflight) {
+      // An interactive (non-silent) in-flight connect serves any caller. A
+      // silent in-flight connect serves silent callers. But an interactive
+      // caller must NOT be handed a silent attempt (which fails fast without
+      // opening a browser) — wait for it, then connect interactively if the
+      // silent attempt didn't already get us connected.
+      if (!inflight.silent || silent) return inflight.promise;
+      return inflight.promise.then(
+        (status) => status,
+        () => this.connect(name, { silent: false })
+      );
+    }
     const promise = this.doConnect(name, { silent });
-    this.connecting.set(name, promise);
+    const entry = { promise, silent };
+    this.connecting.set(name, entry);
     // The caller awaits `promise` and handles its rejection; this cleanup chain
     // is separate, so swallow its copy of the rejection to avoid an
     // unhandledRejection when a connect fails (e.g. silent boot reconnect).
-    promise.finally(() => this.connecting.delete(name)).catch(() => {});
+    promise.finally(() => {
+      if (this.connecting.get(name) === entry) this.connecting.delete(name);
+    }).catch(() => {});
     return promise;
+  }
+
+  /**
+   * Silently obtain a Bearer token for a connected OAuth MCP server, reusing
+   * the registry's own OAuth client (or the cached token on disk) — never opens
+   * a browser. Returns null when there's no usable token. This is the shared
+   * primitive integrations use to call a vendor's REST/GraphQL API with the
+   * same login the user already granted to that vendor's MCP server.
+   */
+  async silentTokenFor(name) {
+    let oauth = this.clients.get(name)?.oauth ?? null;
+    if (!oauth) {
+      const server = this.servers.get(name);
+      if (server?.auth !== "oauth" || !server.url) return null;
+      oauth = new McpOAuthClient({
+        name: server.name,
+        resourceUrl: server.resourceUrl ?? deriveResourceUrl(server.url),
+        scope: server.scope,
+        dataDir: this.dataDir
+      });
+    }
+    try {
+      return await oauth.ensureToken({ interactive: false });
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Sync probe: is there a usable OAuth token cached on disk for this server
+   * (so an integration can report itself "configured" without a network call)?
+   * Reads the same <dataDir>/mcp/auth/<name>.json the OAuth client writes.
+   */
+  hasOAuthToken(name) {
+    try {
+      const cache = readJsonFile(path.join(this.dataDir, "mcp", "auth", `${name}.json`), null);
+      return Boolean(cache?.access_token || cache?.refresh_token);
+    } catch {
+      return false;
+    }
   }
 
   async doConnect(name, { silent = false } = {}) {

--- a/src/mcp-registry.js
+++ b/src/mcp-registry.js
@@ -4,6 +4,7 @@ import { McpStdioClient } from "./mcp-client.js";
 import { McpHttpClient } from "./mcp-http-client.js";
 import { McpOAuthClient } from "./mcp-oauth.js";
 import { ensureDir, readJsonFile, writeJsonAtomic } from "./file-utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 // Whitelist of executables permitted as the `command` for stdio MCP servers.
 // Anything not in this set is rejected at registerServer() — closes the
@@ -408,7 +409,7 @@ function expandEnv(obj, allowedKeys) {
 // We deliberately don't read process.env directly — only what the user has
 // explicitly placed in this file is eligible for ${VAR} substitution.
 function loadDotenvKeys(dataDir) {
-  const file = path.join(dataDir ?? ".openagi", ".env");
+  const file = path.join(dataDir ?? resolveDataDir(), ".env");
   let text;
   try { text = fs.readFileSync(file, "utf8"); } catch { return []; }
   const keys = [];

--- a/src/mcp-registry.js
+++ b/src/mcp-registry.js
@@ -234,15 +234,18 @@ export class McpRegistry {
     return this.connecting.has(name);
   }
 
-  async connect(name) {
+  async connect(name, { silent = false } = {}) {
     if (this.connecting.has(name)) return this.connecting.get(name);
-    const promise = this.doConnect(name);
+    const promise = this.doConnect(name, { silent });
     this.connecting.set(name, promise);
-    promise.finally(() => this.connecting.delete(name));
+    // The caller awaits `promise` and handles its rejection; this cleanup chain
+    // is separate, so swallow its copy of the rejection to avoid an
+    // unhandledRejection when a connect fails (e.g. silent boot reconnect).
+    promise.finally(() => this.connecting.delete(name)).catch(() => {});
     return promise;
   }
 
-  async doConnect(name) {
+  async doConnect(name, { silent = false } = {}) {
     const server = this.servers.get(name);
     if (!server) throw new Error(`Unknown MCP server: ${name}`);
     if (!server.enabled) throw new Error(`MCP server ${name} is disabled.`);
@@ -302,12 +305,13 @@ export class McpRegistry {
       }
       this.clients.set(name, client);
     }
-    await client.connect();
+    // silent → never open a browser for OAuth; fail fast if a token isn't cached.
+    await client.connect({ interactive: !silent });
     this.exposeAsTools(server.name);
     return client.status();
   }
 
-  async connectAll() {
+  async connectAll({ silent = false } = {}) {
     const results = [];
     for (const [name, server] of this.servers) {
       if (!server.enabled) continue;
@@ -315,10 +319,10 @@ export class McpRegistry {
       if (server.transport === "http" && !server.url) continue;
       if (server.transport !== "stdio" && server.transport !== "http") continue;
       try {
-        const status = await this.connect(name);
+        const status = await this.connect(name, { silent });
         results.push({ name, ok: true, status });
       } catch (error) {
-        results.push({ name, ok: false, error: error.message });
+        results.push({ name, ok: false, error: error.message, code: error.code ?? null });
       }
     }
     return results;

--- a/src/mcp-registry.js
+++ b/src/mcp-registry.js
@@ -20,7 +20,7 @@ export class McpRegistry {
     this.servers = new Map();
     this.clients = new Map();
     this.logDir = options.logDir;
-    this.dataDir = options.dataDir ?? (options.logDir ? path.dirname(path.dirname(options.logDir)) : ".openagi");
+    this.dataDir = options.dataDir ?? (options.logDir ? path.dirname(path.dirname(options.logDir)) : resolveDataDir());
     this.toolRegistry = options.toolRegistry ?? null;
     // Set by hosted-interface so OAuth-required surfaces in the dashboard SSE.
     this.onOauthRequired = options.onOauthRequired ?? null;

--- a/src/model-provider.js
+++ b/src/model-provider.js
@@ -143,12 +143,13 @@ export class OpenAIResponsesProvider {
       });
       const json = await response.json().catch(() => ({}));
       if (!response.ok) throw new Error(json?.error?.message ?? `OpenAI request failed with ${response.status}`);
+      const callTools = (json.output ?? []).filter((item) => item.type === "function_call").map((item) => item.name);
       this.budgetGuard?.record(json.usage, this.model, {
         channel: context.channel,
         agentId: context.agentId,
         sessionId: context.sessionId,
         from: context.from,
-        tools: toolCalls.map((c) => c.name)
+        tools: callTools
       });
       return json;
     } finally {
@@ -256,12 +257,13 @@ export class AnthropicProvider {
       });
       const json = await response.json().catch(() => ({}));
       if (!response.ok) throw new Error(json?.error?.message ?? `Anthropic request failed with ${response.status}`);
+      const callTools = (json.content ?? []).filter((b) => b.type === "tool_use").map((b) => b.name);
       this.budgetGuard?.record(json.usage, this.model, {
         channel: context.channel,
         agentId: context.agentId,
         sessionId: context.sessionId,
         from: context.from,
-        tools: toolCalls.map((c) => c.name)
+        tools: callTools
       });
       return json;
     } finally {

--- a/src/model-provider.js
+++ b/src/model-provider.js
@@ -89,7 +89,7 @@ export class OpenAIResponsesProvider {
         input: conversationInput
       };
       if (toolList.length > 0) body.tools = toolList;
-      response = await this.postResponses(body);
+      response = await this.postResponses(body, context, toolCalls);
 
       const calls = extractFunctionCalls(response);
       if (calls.length === 0) break;
@@ -128,7 +128,7 @@ export class OpenAIResponsesProvider {
     };
   }
 
-  async postResponses(body) {
+  async postResponses(body, context = {}, toolCalls = []) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
@@ -143,7 +143,13 @@ export class OpenAIResponsesProvider {
       });
       const json = await response.json().catch(() => ({}));
       if (!response.ok) throw new Error(json?.error?.message ?? `OpenAI request failed with ${response.status}`);
-      this.budgetGuard?.record(json.usage, this.model);
+      this.budgetGuard?.record(json.usage, this.model, {
+        channel: context.channel,
+        agentId: context.agentId,
+        sessionId: context.sessionId,
+        from: context.from,
+        tools: toolCalls.map((c) => c.name)
+      });
       return json;
     } finally {
       clearTimeout(timeout);
@@ -198,7 +204,7 @@ export class AnthropicProvider {
         system,
         messages: convo,
         ...(tools.length > 0 ? { tools } : {})
-      });
+      }, context, toolCalls);
 
       convo.push({ role: "assistant", content: response.content });
 
@@ -234,7 +240,7 @@ export class AnthropicProvider {
     };
   }
 
-  async postMessages(body) {
+  async postMessages(body, context = {}, toolCalls = []) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
@@ -250,7 +256,13 @@ export class AnthropicProvider {
       });
       const json = await response.json().catch(() => ({}));
       if (!response.ok) throw new Error(json?.error?.message ?? `Anthropic request failed with ${response.status}`);
-      this.budgetGuard?.record(json.usage, this.model);
+      this.budgetGuard?.record(json.usage, this.model, {
+        channel: context.channel,
+        agentId: context.agentId,
+        sessionId: context.sessionId,
+        from: context.from,
+        tools: toolCalls.map((c) => c.name)
+      });
       return json;
     } finally {
       clearTimeout(timeout);

--- a/src/model-provider.js
+++ b/src/model-provider.js
@@ -89,7 +89,7 @@ export class OpenAIResponsesProvider {
         input: conversationInput
       };
       if (toolList.length > 0) body.tools = toolList;
-      response = await this.postResponses(body, context, toolCalls);
+      response = await this.postResponses(body, context);
 
       const calls = extractFunctionCalls(response);
       if (calls.length === 0) break;
@@ -128,7 +128,7 @@ export class OpenAIResponsesProvider {
     };
   }
 
-  async postResponses(body, context = {}, toolCalls = []) {
+  async postResponses(body, context = {}) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
@@ -205,7 +205,7 @@ export class AnthropicProvider {
         system,
         messages: convo,
         ...(tools.length > 0 ? { tools } : {})
-      }, context, toolCalls);
+      }, context);
 
       convo.push({ role: "assistant", content: response.content });
 
@@ -241,7 +241,7 @@ export class AnthropicProvider {
     };
   }
 
-  async postMessages(body, context = {}, toolCalls = []) {
+  async postMessages(body, context = {}) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
     try {

--- a/src/observation-store.js
+++ b/src/observation-store.js
@@ -16,6 +16,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { ensureDir } from "./file-utils.js";
 import { createId, nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 let sqlite3Module = null;
 async function loadSqlite() {
@@ -31,7 +32,7 @@ async function loadSqlite() {
 
 export class ObservationStore {
   constructor(options = {}) {
-    this.dir = options.dir ?? path.join(process.cwd(), ".openagi", "observations");
+    this.dir = options.dir ?? path.join(resolveDataDir(), "observations");
     this.dbPath = path.join(this.dir, "index.db");
     ensureDir(this.dir);
     this.db = null;

--- a/src/observation-store.js
+++ b/src/observation-store.js
@@ -185,10 +185,13 @@ export class ObservationStore {
     if (this.fallback) {
       try {
         const rows = fs.readFileSync(this.fallbackPath, "utf8").split("\n").filter(Boolean).map(JSON.parse);
-        return rows.some((o) => o.ref === ref);
+        return rows.some((o) => o.kind === "transcript" && o.ref === ref);
       } catch { return false; }
     }
-    const row = this.db.prepare(`SELECT 1 FROM texts WHERE ref = ? LIMIT 1`).get(ref);
+    // `ref` is UNINDEXED in the FTS5 table so this is a small scan; fine for the
+    // handful of transcript rows a sync checks. Scoped to kind='transcript' so the
+    // dedup check never collides with activity/frame refs.
+    const row = this.db.prepare(`SELECT 1 FROM texts WHERE kind = 'transcript' AND ref = ? LIMIT 1`).get(ref);
     return Boolean(row);
   }
 

--- a/src/observation-store.js
+++ b/src/observation-store.js
@@ -18,6 +18,18 @@ import { ensureDir } from "./file-utils.js";
 import { createId, nowIso } from "./utils.js";
 import { resolveDataDir } from "./data-dir.js";
 
+// Cap the `text` returned by search() for long-form transcript rows so a
+// single hit can't dump an entire call transcript into a tool result. The
+// FTS `snippet` already carries the match context; full text stays in the DB.
+const TRANSCRIPT_SEARCH_TEXT_CAP = 1000;
+
+function capTranscriptText(row) {
+  if (row && row.kind === "transcript" && typeof row.text === "string" && row.text.length > TRANSCRIPT_SEARCH_TEXT_CAP) {
+    return { ...row, text: row.text.slice(0, TRANSCRIPT_SEARCH_TEXT_CAP) + "…" };
+  }
+  return row;
+}
+
 let sqlite3Module = null;
 async function loadSqlite() {
   if (sqlite3Module) return sqlite3Module;
@@ -147,7 +159,7 @@ export class ObservationStore {
       if (app) out = out.filter((o) => o.app === app);
       if (since) out = out.filter((o) => (o.at ?? "") >= since);
       if (until) out = out.filter((o) => (o.at ?? "") <= until);
-      return out.sort((a, b) => (b.at ?? "").localeCompare(a.at ?? "")).slice(0, limit);
+      return out.sort((a, b) => (b.at ?? "").localeCompare(a.at ?? "")).slice(0, limit).map(capTranscriptText);
     }
 
     if (query) {
@@ -167,7 +179,7 @@ export class ObservationStore {
       if (since) params.push(since);
       if (until) params.push(until);
       params.push(limit);
-      return rows.all(...params);
+      return rows.all(...params).map(capTranscriptText);
     }
     // No query → return recent activity by default.
     const params = [];

--- a/src/observation-store.js
+++ b/src/observation-store.js
@@ -117,6 +117,11 @@ export class ObservationStore {
           const uid = o.frameId ? String(o.frameId) : createId("frm");
           insertFrame.run(uid, o.at ?? nowIso(), o.app ?? null, o.window ?? null, o.thumbnail ?? null, typeof o.confidence === "number" ? o.confidence : null);
           if (o.ocrText) insertText.run("frame", uid, o.at ?? nowIso(), o.app ?? "", o.window ?? "", o.ocrText);
+        } else if (o.kind === "transcript") {
+          // Long-form text (e.g. a BuildBetter call transcript) recorded so it's
+          // searchable via the same FTS path as OCR/activity (and thus recall_activity).
+          const ref = o.ref ? String(o.ref) : createId("txt");
+          if (o.text) insertText.run("transcript", ref, o.at ?? nowIso(), o.app ?? "", o.window ?? "", o.text);
         }
         count += 1;
       }
@@ -137,7 +142,7 @@ export class ObservationStore {
       let out = rows;
       if (query) {
         const q = query.toLowerCase();
-        out = out.filter((o) => (o.ocrText || "").toLowerCase().includes(q) || (o.window || "").toLowerCase().includes(q));
+        out = out.filter((o) => (o.ocrText || "").toLowerCase().includes(q) || (o.window || "").toLowerCase().includes(q) || (o.text || "").toLowerCase().includes(q));
       }
       if (app) out = out.filter((o) => o.app === app);
       if (since) out = out.filter((o) => (o.at ?? "") >= since);
@@ -172,6 +177,19 @@ export class ObservationStore {
     if (until) { where += " AND at <= ?"; params.push(until); }
     params.push(limit);
     return this.db.prepare(`SELECT 'activity' AS kind, app, window, at, event FROM activity WHERE ${where} ORDER BY at DESC LIMIT ?`).all(...params);
+  }
+
+  async existsRef(ref) {
+    await this.ready;
+    if (!ref) return false;
+    if (this.fallback) {
+      try {
+        const rows = fs.readFileSync(this.fallbackPath, "utf8").split("\n").filter(Boolean).map(JSON.parse);
+        return rows.some((o) => o.ref === ref);
+      } catch { return false; }
+    }
+    const row = this.db.prepare(`SELECT 1 FROM texts WHERE ref = ? LIMIT 1`).get(ref);
+    return Boolean(row);
   }
 
   // Build a compact "what was the user just doing" digest the agent host

--- a/src/outcome-store.js
+++ b/src/outcome-store.js
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { appendJsonLine, ensureDir, readJsonFile, writeJsonAtomic } from "./file-utils.js";
 import { createId, nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 // Append-only JSONL log + atomic snapshot of recent outcomes.
 // Outcome kinds: agent-reply, tool-call, cron-fire, autopilot-fire, sent-message, specialist-action.
@@ -10,7 +11,7 @@ const SNAPSHOT_LIMIT = 2000; // keep last N resolved + all pending
 
 export class OutcomeStore {
   constructor(options = {}) {
-    this.dir = options.dir ?? path.join(process.cwd(), ".openagi", "outcomes");
+    this.dir = options.dir ?? path.join(resolveDataDir(), "outcomes");
     this.eventsPath = path.join(this.dir, "events.jsonl");
     this.snapshotPath = path.join(this.dir, "snapshot.json");
     ensureDir(this.dir);

--- a/src/pattern-miner.js
+++ b/src/pattern-miner.js
@@ -15,6 +15,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { ensureDir, readJsonFile, writeJsonAtomic } from "./file-utils.js";
 import { createId, nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 const DEFAULT_LOOKBACK_DAYS = 14;
 const MIN_OCCURRENCES = 3;
@@ -26,7 +27,7 @@ const SUGGESTED_DIR = "skills-suggested";
 export class PatternMiner {
   constructor(options = {}) {
     this.runtime = options.runtime;
-    this.dataDir = options.dataDir ?? process.env.OPENAGI_DATA_DIR ?? ".openagi";
+    this.dataDir = options.dataDir ?? resolveDataDir();
     this.lookbackDays = options.lookbackDays ?? DEFAULT_LOOKBACK_DAYS;
     this.minOccurrences = options.minOccurrences ?? MIN_OCCURRENCES;
     this.minSequenceLen = options.minSequenceLen ?? MIN_SEQUENCE_LEN;

--- a/src/pending-actions.js
+++ b/src/pending-actions.js
@@ -2,6 +2,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { ensureDir, writeJsonAtomic, readJsonFile, appendJsonLine } from "./file-utils.js";
 import { createId, nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 // File-backed queue of agent-initiated actions awaiting human approval.
 // When the agent invokes a tool flagged `needsConfirmation: true`, the
@@ -15,7 +16,7 @@ import { createId, nowIso } from "./utils.js";
 
 export class PendingActionStore {
   constructor({ dir } = {}) {
-    this.dir = dir ?? path.join(process.cwd(), ".openagi", "pending-actions");
+    this.dir = dir ?? path.join(resolveDataDir(), "pending-actions");
     ensureDir(this.dir);
     this.actions = new Map();
     this.events = null;

--- a/src/proactive-observer.js
+++ b/src/proactive-observer.js
@@ -269,15 +269,74 @@ export class ProactiveObserver {
       proposedAt: nowIso(),
       ...record
     };
+    const task = this.materializeTaskSuggestion(candidate);
+    if (task) {
+      candidate.status = "accepted";
+      candidate.resolvedAt = nowIso();
+      candidate.taskId = task.id;
+      candidate.taskAutoCreated = true;
+      candidate.note = "Auto-created task from proactive observer.";
+    }
     writeJsonAtomic(path.join(this.suggestDir, `${id}.json`), candidate);
-    this.runtime?.events?.emit?.("proactive-suggestion", {
-      id,
-      category: candidate.category,
-      title: candidate.title,
-      rationale: candidate.rationale,
-      mcpId: candidate.mcpId
-    });
+    if (task) {
+      this.runtime?.events?.emit?.("task-reminder", {
+        kind: "created",
+        at: nowIso(),
+        taskId: task.id,
+        queue: task.queue,
+        bucket: task.bucket,
+        title: `Task added: ${task.title}`,
+        body: task.description ? task.description.slice(0, 200) : ""
+      });
+    } else {
+      this.runtime?.events?.emit?.("proactive-suggestion", {
+        id,
+        category: candidate.category,
+        title: candidate.title,
+        rationale: candidate.rationale,
+        mcpId: candidate.mcpId
+      });
+    }
     return { suggested: 1, candidate };
+  }
+
+  materializeTaskSuggestion(candidate) {
+    if (candidate?.category !== "task") return null;
+    if (!candidate.title || !this.runtime?.tasks?.add) return null;
+    const queue = candidate.taskQueue === "agent" ? "agent" : "user";
+    try {
+      const existing = this.runtime.tasks.list?.({ limit: 500 }) ?? [];
+      const duplicate = existing.find((t) => t.sourceMeta?.suggestionId === candidate.id);
+      if (duplicate) return duplicate;
+
+      const descriptionParts = [];
+      if (candidate.rationale) descriptionParts.push(candidate.rationale);
+      if (queue === "agent") {
+        descriptionParts.push(
+          "Produce a draft only. Do NOT send, publish, schedule externally, or take any irreversible action without user approval.",
+          "Leave the result for the user to review."
+        );
+      }
+
+      return this.runtime.tasks.add(
+        {
+          title: candidate.title,
+          description: descriptionParts.join("\n\n").trim(),
+          bucket: candidate.taskBucket ?? "today",
+          priority: queue === "agent" ? 60 : 50,
+          tags: queue === "agent" ? ["observer-proposed", "draft-only"] : ["observer-proposed"],
+          sourceMeta: {
+            suggestionId: candidate.id,
+            autoMaterialized: true,
+            observedApps: candidate.context?.apps ?? null,
+            source: candidate.source ?? "proactive-observer"
+          }
+        },
+        { source: candidate.source ?? "proactive-observer", queue }
+      );
+    } catch {
+      return null;
+    }
   }
 
   list({ status = "pending" } = {}) {

--- a/src/proactive-observer.js
+++ b/src/proactive-observer.js
@@ -17,6 +17,7 @@ import { ensureDir, writeJsonAtomic, readJsonFile } from "./file-utils.js";
 import { createId, nowIso } from "./utils.js";
 import { matchCatalog } from "./mcp-catalog.js";
 import { buildReconciliationCalibration } from "./reconciliation-calibration.js";
+import { resolveDataDir } from "./data-dir.js";
 
 const SUGGEST_DIR = "proactive/suggestions";
 const DEDUPE_WINDOW_MS = 6 * 60 * 60 * 1000; // 6h — don't repeat the same proposal within a 6h window
@@ -57,7 +58,7 @@ const SYSTEM_PROMPT = [
 export class ProactiveObserver {
   constructor(options = {}) {
     this.runtime = options.runtime;
-    this.dataDir = options.dataDir ?? process.env.OPENAGI_DATA_DIR ?? ".openagi";
+    this.dataDir = options.dataDir ?? resolveDataDir();
     this.suggestDir = path.join(this.dataDir, SUGGEST_DIR);
     this.lookbackMinutes = options.lookbackMinutes ?? 15;
     this.lastRunAt = 0;

--- a/src/scrutiny-fitter.js
+++ b/src/scrutiny-fitter.js
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { ensureDir, readJsonFile, writeJsonAtomic } from "./file-utils.js";
 import { nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 // Outcome → scrutiny weight fitter (B2). For each panel judge, compute the
 // correlation between each scrutiny dimension and the outcome qualityScore,
@@ -23,7 +24,7 @@ const DIMENSIONS = ["environment", "company", "evidence", "memory", "uncertainty
 export class ScrutinyFitter {
   constructor(options = {}) {
     this.runtime = options.runtime;
-    this.dir = options.dir ?? path.join(process.cwd(), ".openagi", "scrutiny");
+    this.dir = options.dir ?? path.join(resolveDataDir(), "scrutiny");
     this.statePath = path.join(this.dir, "fitter-state.json");
     this.pendingPath = path.join(this.dir, "pending-changes.json");
     this.minSamples = options.minSamples ?? DEFAULT_MIN_SAMPLES;

--- a/src/session-miner.js
+++ b/src/session-miner.js
@@ -18,6 +18,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { ensureDir, readJsonFile, writeJsonAtomic } from "./file-utils.js";
 import { createId, nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 const DEFAULT_LOOKBACK_DAYS = 21;
 const MIN_OCCURRENCES = 2;
@@ -48,7 +49,7 @@ const PROPOSAL_SYSTEM_PROMPT = [
 export class SessionMiner {
   constructor(options = {}) {
     this.runtime = options.runtime;
-    this.dataDir = options.dataDir ?? process.env.OPENAGI_DATA_DIR ?? ".openagi";
+    this.dataDir = options.dataDir ?? resolveDataDir();
     this.lookbackDays = options.lookbackDays ?? DEFAULT_LOOKBACK_DAYS;
     this.minOccurrences = options.minOccurrences ?? MIN_OCCURRENCES;
     this.suggestedDir = path.join(this.dataDir, SUGGESTED_DIR);

--- a/src/setup-wizard.js
+++ b/src/setup-wizard.js
@@ -272,9 +272,10 @@ export function renderWizard({ proposedToken } = {}) {
         <summary>BuildBetter — call action items become tasks</summary>
         <div style="padding-top:10px;" class="grid">
           <p class="sub">Pulls action_item / commitment / follow_up extractions from your recent calls. Polls every 15 min, and (optionally) syncs instantly via webhook.</p>
-          <div><label>BUILDBETTER_API_KEY</label><input type="password" name="BUILDBETTER_API_KEY" autocomplete="off"></div>
-          <div><label>BUILDBETTER_USER_EMAIL <span class="sub">(or use BUILDBETTER_USER_NAME below)</span></label><input type="email" name="BUILDBETTER_USER_EMAIL" placeholder="you@example.com"></div>
-          <div><label>BUILDBETTER_USER_NAME <span class="sub">(alternative to email)</span></label><input type="text" name="BUILDBETTER_USER_NAME" placeholder="Your Name"></div>
+          <p class="sub">Already connected BuildBetter on the <code>MCP</code> tab? You can leave everything below blank — OpenAGI reuses that login.</p>
+          <div><label>BUILDBETTER_API_KEY <span class="sub">(optional if connected via MCP)</span></label><input type="password" name="BUILDBETTER_API_KEY" autocomplete="off"></div>
+          <div><label>BUILDBETTER_USER_EMAIL <span class="sub">(optional — auto-detected from your login)</span></label><input type="email" name="BUILDBETTER_USER_EMAIL" placeholder="you@example.com"></div>
+          <div><label>BUILDBETTER_USER_NAME <span class="sub">(optional — only needed if auto-detect can't pinpoint you)</span></label><input type="text" name="BUILDBETTER_USER_NAME" placeholder="Your Name"></div>
           <div><label>BUILDBETTER_WEBHOOK_SECRET <span class="sub">(optional — enables instant push)</span></label><input type="password" name="BUILDBETTER_WEBHOOK_SECRET" autocomplete="off" placeholder="a long random string"><p class="sub">Set this, then point a BuildBetter webhook at <code>&lt;your public URL&gt;/webhooks/buildbetter?secret=…</code> (shown on the Channels tab once a public URL is set) to sync the moment a call is processed instead of waiting for the poll.</p></div>
         </div>
       </details>

--- a/src/setup-wizard.js
+++ b/src/setup-wizard.js
@@ -25,6 +25,10 @@ const WIZARD_FIELDS = [
   "OPENAGI_COMPUTER_USE",
   "OPENAGI_PUBLIC_URL",
   "OPENAGI_DAILY_USD_LIMIT",
+  "EXA_API_KEY", "TAVILY_API_KEY", "FIRECRAWL_API_KEY", "BRAVE_API_KEY",
+  "PERPLEXITY_API_KEY", "SERPAPI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_CSE_ID",
+  "WEB_SEARCH_PROVIDER",
+  "BUILDBETTER_INGEST_MODE",
   // Per-MCP bearer keys, declared by catalog entries via apiKeyEnvVar.
   // Kept in this allowlist so the wizard's /setup/save can write them.
   ...MCP_CATALOG.filter((e) => e.apiKeyEnvVar).map((e) => e.apiKeyEnvVar)

--- a/src/setup-wizard.js
+++ b/src/setup-wizard.js
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { ensureDir, writeTextAtomic } from "./file-utils.js";
 import { generateToken } from "./auth.js";
 import { MCP_CATALOG, CATEGORIES } from "./mcp-catalog.js";
+import { resolveDataDir } from "./data-dir.js";
 
 // Cross-platform first-run setup wizard. When the daemon detects no API keys
 // configured (no ANTHROPIC_API_KEY, no OPENAI_API_KEY) AND no auth token, every
@@ -41,7 +42,7 @@ export function isFirstRun() {
 }
 
 export function envFilePath(dataDir) {
-  return path.join(dataDir ?? process.env.OPENAGI_DATA_DIR ?? ".openagi", ".env");
+  return path.join(dataDir ?? resolveDataDir(), ".env");
 }
 
 export function readExistingEnv(dataDir) {

--- a/src/skill-replay.js
+++ b/src/skill-replay.js
@@ -8,6 +8,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { ensureDir, readJsonFile, writeJsonAtomic } from "./file-utils.js";
 import { createId, nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 const ALLOWED_ACTIONS = new Set([
   "open_app",
@@ -25,7 +26,7 @@ const ALLOWED_ACTIONS = new Set([
 export class SkillReplay {
   constructor(options = {}) {
     this.runtime = options.runtime;
-    this.dataDir = options.dataDir ?? process.env.OPENAGI_DATA_DIR ?? ".openagi";
+    this.dataDir = options.dataDir ?? resolveDataDir();
     this.replayDir = path.join(this.dataDir, "replay");
     ensureDir(this.replayDir);
     this.events = options.events ?? null; // EventEmitter from hosted-interface

--- a/src/suggestion-feed.js
+++ b/src/suggestion-feed.js
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { readJsonFile, writeJsonAtomic } from "./file-utils.js";
 import { nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 // Story 4: unified read/write surface for proposals coming from three
 // independent sources:
@@ -157,8 +158,5 @@ function findSourceFile(runtime, id) {
 // Used when runtime doesn't expose dataDir directly — falls back to the
 // proactive observer's known dataDir (set at construction).
 function defaultDataDir(runtime) {
-  return runtime?.proactiveObserver?.dataDir
-    ?? runtime?.patternMiner?.dataDir
-    ?? process.env.OPENAGI_DATA_DIR
-    ?? ".openagi";
+  return runtime?.proactiveObserver?.dataDir ?? runtime?.patternMiner?.dataDir ?? resolveDataDir();
 }

--- a/src/suggestion-feedback.js
+++ b/src/suggestion-feedback.js
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { ensureDir, writeJsonAtomic, readJsonFile } from "./file-utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 // Story 3: closes the "self-improving" loop. Reads the proactive-observer's
 // resolved suggestions (accepted / rejected / dismissed) and produces:
@@ -20,7 +21,7 @@ const MIN_SAMPLES_FOR_SIGNAL = 3;
 export class SuggestionFeedback {
   constructor({ runtime, dataDir, windowDays = DEFAULT_WINDOW_DAYS } = {}) {
     this.runtime = runtime;
-    this.dataDir = dataDir ?? path.join(process.cwd(), ".openagi");
+    this.dataDir = dataDir ?? resolveDataDir();
     this.windowDays = windowDays;
     this.prefsPath = path.join(this.dataDir, "preferences.json");
     ensureDir(path.dirname(this.prefsPath));

--- a/src/task-store.js
+++ b/src/task-store.js
@@ -15,6 +15,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { ensureDir, writeJsonAtomic, readJsonFile } from "./file-utils.js";
 import { createId, nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 // Story 8: order matters — sort + filter UI traverses this top-to-bottom.
 // today / this_week stay at the top, done at the bottom; month/quarter/
@@ -35,7 +36,7 @@ export const GOAL_STATUSES = ["active", "completed", "cancelled", "deferred"];
 export class TaskStore {
   constructor(options = {}) {
     this.runtime = options.runtime ?? null;
-    this.dataDir = options.dataDir ?? process.env.OPENAGI_DATA_DIR ?? ".openagi";
+    this.dataDir = options.dataDir ?? resolveDataDir();
     this.taskDir = path.join(this.dataDir, TASK_DIR);
     ensureDir(this.taskDir);
     this.tasks = new Map(); // id → task

--- a/src/tool-registry.js
+++ b/src/tool-registry.js
@@ -278,14 +278,15 @@ export function registerCoreTools(registry, runtime) {
     parameters: {
       type: "object",
       properties: {
-        days: { type: "integer", minimum: 1, maximum: 90, description: "Look-back window in days (default 1 = today)." }
+        days: { type: "integer", minimum: 1, maximum: 30, description: "Look-back window in days (default 1 = today; the local ledger retains 30 days)." }
       },
       additionalProperties: false
     },
     handler: async (args) => {
       const ledger = runtime.budget?.ledger;
       if (!ledger) return { error: "no credit ledger available" };
-      const days = args.days ?? 1;
+      // Clamp to the retained window so the reported `days` matches the data.
+      const days = Math.min(args.days ?? 1, ledger.retentionDays ?? 30);
       const analytics = ledger.analytics({ days });
       const top = ledger.query({ days })
         .slice()

--- a/src/tool-registry.js
+++ b/src/tool-registry.js
@@ -273,6 +273,30 @@ export function registerCoreTools(registry, runtime) {
   });
 
   registry.register({
+    name: "recall_spend",
+    description: "Summarize LLM credit (USD) usage: how much has been spent, on what activity/model, and the costliest recent calls. Use to answer questions about cost/credits/budget — e.g. 'why did I spend $4 today?'.",
+    parameters: {
+      type: "object",
+      properties: {
+        days: { type: "integer", minimum: 1, maximum: 90, description: "Look-back window in days (default 1 = today)." }
+      },
+      additionalProperties: false
+    },
+    handler: async (args) => {
+      const ledger = runtime.budget?.ledger;
+      if (!ledger) return { error: "no credit ledger available" };
+      const days = args.days ?? 1;
+      const analytics = ledger.analytics({ days });
+      const top = ledger.query({ days })
+        .slice()
+        .sort((a, b) => (b.usd ?? 0) - (a.usd ?? 0))
+        .slice(0, 10)
+        .map((r) => ({ at: r.at, model: r.model, activity: r.channel, agentId: r.agentId, usd: Number((r.usd ?? 0).toFixed(4)), tools: r.tools ?? [] }));
+      return { days, totalUsd: analytics.totalUsd, calls: analytics.totalCalls, byActivity: analytics.byActivity, byModel: analytics.byModel, top };
+    }
+  });
+
+  registry.register({
     name: "list_sessions",
     description: "List recent conversations across channels.",
     parameters: {

--- a/src/tool-registry.js
+++ b/src/tool-registry.js
@@ -1,4 +1,5 @@
 import { createId, nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 export class ToolRegistry {
   constructor() {
@@ -800,8 +801,7 @@ export function registerCoreTools(registry, runtime) {
         const existing = process.env[entry.apiKeyEnvVar] ?? "";
         if (incoming) {
           const { saveEnv } = await import("./setup-wizard.js");
-          const path = await import("node:path");
-          const dataDir = process.env.OPENAGI_DATA_DIR ?? path.join(process.cwd(), ".openagi");
+          const dataDir = resolveDataDir();
           saveEnv({ dataDir, values: { [entry.apiKeyEnvVar]: incoming } });
         } else if (!existing) {
           throw new Error(`Catalog entry '${entry.id}' uses ${entry.apiKeyEnvVar} which isn't set. Ask the user for their key, then call this tool again with apiKey set.`);

--- a/src/tunnel-watcher.js
+++ b/src/tunnel-watcher.js
@@ -14,6 +14,7 @@ import path from "node:path";
 import { EventEmitter } from "node:events";
 import { ensureDir, writeTextAtomic } from "./file-utils.js";
 import { nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 const QUICK_TUNNEL_RE = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/i;
 const POLL_MS = 2000;
@@ -21,7 +22,7 @@ const POLL_MS = 2000;
 export class TunnelWatcher extends EventEmitter {
   constructor(options = {}) {
     super();
-    this.dataDir = options.dataDir ?? process.env.OPENAGI_DATA_DIR ?? ".openagi";
+    this.dataDir = options.dataDir ?? resolveDataDir();
     this.logPath = options.logPath ?? path.join(this.dataDir, "tunnel.log");
     this.envPath = options.envPath ?? path.join(this.dataDir, ".env");
     this.timer = null;

--- a/src/url-guard.js
+++ b/src/url-guard.js
@@ -6,8 +6,13 @@
 // being steered by injected web/transcript content into fetching
 // http://169.254.169.254/... and returning the response).
 //
-// This is a host-string check (it does not resolve DNS) — matching the
-// project's existing baseline. It is intentionally conservative.
+// assertSafePublicUrl is a host-string check; safeFetch additionally resolves
+// the hostname and rejects URLs whose DNS answers land in blocked space, so a
+// public-looking name (attacker DNS, localtest.me/nip.io) can't smuggle a
+// fetch into loopback/private/metadata addresses.
+
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
 
 function isBlockedHost(host) {
   return (
@@ -65,12 +70,40 @@ export function assertSafePublicUrl(value, label = "url") {
   return u;
 }
 
-// fetch() that re-validates the host on EVERY redirect hop, so a public URL
-// cannot 30x-redirect into an internal address. Returns the final Response.
+// Resolve a hostname and throw if ANY A/AAAA answer is a blocked address.
+// Literal IPs are skipped (assertSafePublicUrl already vetted the string).
+// Note: the subsequent fetch() does its own lookup, so a fast-rebinding DNS
+// server retains a small TOCTOU window — but plain private-DNS / rebind names
+// (the common fetch_url injection vector) are rejected here.
+export async function assertHostResolvesPublic(hostname, label = "url", { lookupFn = lookup } = {}) {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (isIP(host)) return;
+  let answers;
+  try {
+    answers = await lookupFn(host, { all: true, verbatim: true });
+  } catch (error) {
+    throw new Error(`${label} host "${host}" did not resolve: ${error.code ?? error.message}`);
+  }
+  for (const { address } of answers) {
+    const addr = String(address).toLowerCase();
+    const mappedV4 = ipv4FromMappedV6(addr);
+    if (isBlockedHost(addr) || (mappedV4 && isBlockedHost(mappedV4))) {
+      throw new Error(
+        `${label} host "${host}" resolves to "${address}", which is not allowed ` +
+        `(loopback, private, or link-local).`
+      );
+    }
+  }
+}
+
+// fetch() that re-validates the host — including its DNS resolution — on EVERY
+// redirect hop, so a public URL cannot 30x-redirect into an internal address.
+// Returns the final Response.
 export async function safeFetch(url, init = {}, { label = "url", maxRedirects = 5 } = {}) {
   let current = String(url);
   for (let hop = 0; hop <= maxRedirects; hop++) {
-    assertSafePublicUrl(current, label);
+    const parsed = assertSafePublicUrl(current, label);
+    await assertHostResolvesPublic(parsed.hostname, label);
     const res = await fetch(current, { ...init, redirect: "manual" });
     if (res.status >= 300 && res.status < 400) {
       const loc = res.headers.get("location");

--- a/src/url-guard.js
+++ b/src/url-guard.js
@@ -1,0 +1,62 @@
+// SSRF guard shared by MCP registration and the fetch_url tool.
+//
+// Rejects URLs that point at loopback / link-local / RFC1918 / cloud-metadata
+// endpoints, and constrains the protocol to http/https. Combined with the
+// env-var allowlist this closes the SSRF + secret-exfil chain (e.g. an agent
+// being steered by injected web/transcript content into fetching
+// http://169.254.169.254/... and returning the response).
+//
+// This is a host-string check (it does not resolve DNS) — matching the
+// project's existing baseline. It is intentionally conservative.
+
+export function assertSafePublicUrl(value, label = "url") {
+  let u;
+  try {
+    u = new URL(value);
+  } catch {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+  if (u.protocol !== "http:" && u.protocol !== "https:") {
+    throw new Error(`${label} protocol must be http or https, got "${u.protocol}".`);
+  }
+  // URL.hostname keeps brackets for IPv6 (e.g. "[::1]") — strip them so the
+  // loopback/link-local checks below match.
+  const host = u.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (
+    host === "localhost" || host === "0.0.0.0" || host === "::" ||
+    host.endsWith(".localhost") ||
+    /^127\./.test(host) ||
+    /^10\./.test(host) ||
+    /^192\.168\./.test(host) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
+    /^169\.254\./.test(host) ||
+    host === "169.254.169.254" || // AWS / GCP IMDS
+    /^fd[0-9a-f]{2}:/.test(host) || // ULA
+    /^fe80:/.test(host) || // link-local
+    host === "::1"
+  ) {
+    throw new Error(
+      `${label} host "${host}" is not allowed (loopback, private, or link-local). ` +
+      `Use a public hostname.`
+    );
+  }
+  return u;
+}
+
+// fetch() that re-validates the host on EVERY redirect hop, so a public URL
+// cannot 30x-redirect into an internal address. Returns the final Response.
+export async function safeFetch(url, init = {}, { label = "url", maxRedirects = 5 } = {}) {
+  let current = String(url);
+  for (let hop = 0; hop <= maxRedirects; hop++) {
+    assertSafePublicUrl(current, label);
+    const res = await fetch(current, { ...init, redirect: "manual" });
+    if (res.status >= 300 && res.status < 400) {
+      const loc = res.headers.get("location");
+      if (!loc) return res;
+      current = new URL(loc, current).toString();
+      continue;
+    }
+    return res;
+  }
+  throw new Error(`${label}: too many redirects`);
+}

--- a/src/url-guard.js
+++ b/src/url-guard.js
@@ -19,8 +19,8 @@ function isBlockedHost(host) {
     /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
     /^169\.254\./.test(host) ||
     host === "169.254.169.254" || // AWS / GCP IMDS
-    /^fd[0-9a-f]{2}:/.test(host) || // ULA
-    /^fe80:/.test(host) || // link-local
+    /^f[cd][0-9a-f]{2}:/.test(host) || // ULA fc00::/7 (fc00–fdff)
+    /^fe[89ab][0-9a-f]:/.test(host) || // link-local fe80::/10 (fe80–febf)
     host === "::1"
   );
 }

--- a/src/url-guard.js
+++ b/src/url-guard.js
@@ -9,6 +9,39 @@
 // This is a host-string check (it does not resolve DNS) — matching the
 // project's existing baseline. It is intentionally conservative.
 
+function isBlockedHost(host) {
+  return (
+    host === "localhost" || host === "0.0.0.0" || host === "::" ||
+    host.endsWith(".localhost") ||
+    /^127\./.test(host) ||
+    /^10\./.test(host) ||
+    /^192\.168\./.test(host) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
+    /^169\.254\./.test(host) ||
+    host === "169.254.169.254" || // AWS / GCP IMDS
+    /^fd[0-9a-f]{2}:/.test(host) || // ULA
+    /^fe80:/.test(host) || // link-local
+    host === "::1"
+  );
+}
+
+// Extract the embedded IPv4 from an IPv4-mapped IPv6 host, in either the dotted
+// form (`::ffff:127.0.0.1`) or the hex form Node normalizes to
+// (`::ffff:7f00:1`). Returns null when the host isn't a mapped address. Without
+// this, `http://[::ffff:127.0.0.1]/` would slip past the loopback/RFC1918 checks.
+function ipv4FromMappedV6(host) {
+  const m = /^::ffff:(.+)$/i.exec(host);
+  if (!m) return null;
+  const rest = m[1];
+  if (rest.includes(".")) return rest; // ::ffff:127.0.0.1
+  const g = rest.split(":");           // ::ffff:7f00:1 → ["7f00","1"]
+  if (g.length !== 2) return null;
+  const a = parseInt(g[0], 16);
+  const b = parseInt(g[1], 16);
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return null;
+  return `${(a >> 8) & 255}.${a & 255}.${(b >> 8) & 255}.${b & 255}`;
+}
+
 export function assertSafePublicUrl(value, label = "url") {
   let u;
   try {
@@ -22,19 +55,8 @@ export function assertSafePublicUrl(value, label = "url") {
   // URL.hostname keeps brackets for IPv6 (e.g. "[::1]") — strip them so the
   // loopback/link-local checks below match.
   const host = u.hostname.toLowerCase().replace(/^\[|\]$/g, "");
-  if (
-    host === "localhost" || host === "0.0.0.0" || host === "::" ||
-    host.endsWith(".localhost") ||
-    /^127\./.test(host) ||
-    /^10\./.test(host) ||
-    /^192\.168\./.test(host) ||
-    /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
-    /^169\.254\./.test(host) ||
-    host === "169.254.169.254" || // AWS / GCP IMDS
-    /^fd[0-9a-f]{2}:/.test(host) || // ULA
-    /^fe80:/.test(host) || // link-local
-    host === "::1"
-  ) {
+  const mappedV4 = ipv4FromMappedV6(host);
+  if (isBlockedHost(host) || (mappedV4 && isBlockedHost(mappedV4))) {
     throw new Error(
       `${label} host "${host}" is not allowed (loopback, private, or link-local). ` +
       `Use a public hostname.`

--- a/src/vector-store.js
+++ b/src/vector-store.js
@@ -2,6 +2,7 @@ import path from "node:path";
 import { ensureDir, readJsonFile, writeJsonAtomic } from "./file-utils.js";
 import { cosine } from "./embeddings.js";
 import { nowIso } from "./utils.js";
+import { resolveDataDir } from "./data-dir.js";
 
 // Namespaced cosine vector store. File-backed for persistence across restarts.
 // Namespaces: "principle" (distilled long-term memory), "specialist" (bounded
@@ -10,7 +11,7 @@ import { nowIso } from "./utils.js";
 export class VectorStore {
   constructor(options = {}) {
     this.embedder = options.embedder;
-    this.dir = options.dir ?? path.join(process.cwd(), ".openagi", "vectors");
+    this.dir = options.dir ?? path.join(resolveDataDir(), "vectors");
     this.path = options.path ?? path.join(this.dir, "store.json");
     ensureDir(this.dir);
     const snap = readJsonFile(this.path, { version: 1, entries: [] });

--- a/test/abi-runtime.test.js
+++ b/test/abi-runtime.test.js
@@ -3215,7 +3215,7 @@ test("webhooks: /webhooks/buildbetter requires secret, then triggers a sync (202
   const { createHostedInterface } = await import("../src/hosted-interface.js");
   let synced = 0;
   const runtime = {
-    buildBetterTaskSource: { triggerSync: async () => { synced += 1; return { created: 1 }; } },
+    buildBetterTaskSource: { isConfigured: () => true, triggerSync: async () => { synced += 1; return { created: 1 }; } },
     events: { on: () => {}, emit: () => {} }
   };
   const app = createHostedInterface(runtime, { port: 0, buildBetterWebhookSecret: "hook-secret" });
@@ -3241,5 +3241,22 @@ test("webhooks: /webhooks/buildbetter requires secret, then triggers a sync (202
   await new Promise((r) => setTimeout(r, 30));
   assert.ok(synced >= 1, "sync triggered by webhook");
 
+  await app.close();
+});
+
+test("webhooks: /webhooks/buildbetter 503s (not a false 202) when the source is unconfigured", async () => {
+  const { createHostedInterface } = await import("../src/hosted-interface.js");
+  let synced = 0;
+  const runtime = {
+    // Source is registered (so a mid-session MCP login works) but has no creds yet.
+    buildBetterTaskSource: { isConfigured: () => false, triggerSync: async () => { synced += 1; } },
+    events: { on: () => {}, emit: () => {} }
+  };
+  const app = createHostedInterface(runtime, { port: 0, buildBetterWebhookSecret: "hook-secret" });
+  const address = await app.listen();
+  const resp = await fetch(`${address.url}/webhooks/buildbetter?secret=hook-secret`, { method: "POST", headers: { "content-type": "application/json" }, body: "{}" });
+  assert.equal(resp.status, 503, "unconfigured → 503 so BuildBetter retries, not a swallowed 202");
+  await new Promise((r) => setTimeout(r, 20));
+  assert.equal(synced, 0, "no sync attempted while unconfigured");
   await app.close();
 });

--- a/test/agent-host-screen-context.test.js
+++ b/test/agent-host-screen-context.test.js
@@ -1,0 +1,27 @@
+// test/agent-host-screen-context.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { formatScreenContextBlock } from "../src/agent-host.js";
+
+test("formats a labeled active-window block from screenContext", () => {
+  const block = formatScreenContextBlock({ app: "Safari", window: "Spec — Notion", text: "the deadline is Friday" });
+  assert.match(block, /Active window the user is looking at right now \(Safari · Spec — Notion\)/);
+  assert.match(block, /the deadline is Friday/);
+});
+
+test("returns empty string for missing/empty screenContext", () => {
+  assert.equal(formatScreenContextBlock(null), "");
+  assert.equal(formatScreenContextBlock({ app: "X" }), "");
+  assert.equal(formatScreenContextBlock({ text: "   " }), "");
+});
+
+test("truncates very long screen text to 4000 chars", () => {
+  const block = formatScreenContextBlock({ app: "X", text: "a".repeat(5000) });
+  const body = block.split("\n").find((l) => l.startsWith("aaaa"));
+  assert.ok(body.length <= 4000, `body should be <= 4000, got ${body.length}`);
+});
+
+test("falls back to 'active window' when app is absent", () => {
+  const block = formatScreenContextBlock({ text: "hello" });
+  assert.match(block, /\(active window\)/);
+});

--- a/test/budget-guard-ledger.test.js
+++ b/test/budget-guard-ledger.test.js
@@ -1,0 +1,38 @@
+// test/budget-guard-ledger.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { BudgetGuard } from "../src/budget-guard.js";
+import { CreditLedger } from "../src/credit-ledger.js";
+
+function tmp() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bg-"));
+  const ledger = new CreditLedger({ storePath: path.join(dir, "ledger.jsonl") });
+  const guard = new BudgetGuard({ storePath: path.join(dir, "usage.json"), ledger });
+  return { guard, ledger };
+}
+
+test("record(meta) writes a ledger entry carrying the context", () => {
+  const { guard, ledger } = tmp();
+  guard.record({ input_tokens: 1000, output_tokens: 500 }, "claude-opus-4-7", {
+    channel: "autopilot", agentId: "main", sessionId: "s9", from: "cron", tools: ["web_search", "add_task"]
+  });
+  const rows = ledger.query({ days: 1 });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].channel, "autopilot");
+  assert.deepEqual(rows[0].tools, ["web_search", "add_task"]);
+  assert.equal(rows[0].model, "claude-opus-4-7");
+  assert.ok(rows[0].usd > 0);
+  assert.equal(rows[0].tokens.input, 1000);
+});
+
+test("record without meta still aggregates and does not throw (back-compat)", () => {
+  const { guard, ledger } = tmp();
+  const res = guard.record({ input_tokens: 100, output_tokens: 50 }, "gpt-5");
+  assert.ok(res.added > 0);
+  const rows = ledger.query({ days: 1 });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].channel, null);
+});

--- a/test/buildbetter-auth.test.js
+++ b/test/buildbetter-auth.test.js
@@ -74,42 +74,35 @@ test("authHeaders uses the API key when set", async () => {
 });
 
 test("authHeaders falls back to a reused OAuth bearer token", async () => {
+  // _oauthToken delegates to the canonical ensureToken({interactive:false}).
   const fakeOauth = {
-    loadCache: () => ({ access_token: "tok", expires_at: Date.now() + 600_000 }),
-    isExpired: () => false,
-    refresh: async () => { throw new Error("should not refresh a fresh token"); }
+    ensureToken: async ({ interactive }) => {
+      assert.equal(interactive, false, "poller must never open a browser");
+      return "tok";
+    }
   };
   const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
   assert.deepEqual(await src.authHeaders(), { authorization: "Bearer tok" });
 });
 
-test("authHeaders returns null with no api key and no OAuth cache", async () => {
-  const fakeOauth = { loadCache: () => null, isExpired: () => true, refresh: async () => {} };
+test("authHeaders returns null when ensureToken can't get a token without a browser", async () => {
+  const fakeOauth = {
+    ensureToken: async () => { const e = new Error("no token"); e.code = "OAUTH_INTERACTIVE_REQUIRED"; throw e; }
+  };
   const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
   assert.equal(await src.authHeaders(), null);
 });
 
-test("_oauthToken silently refreshes an expired token (no browser flow)", async () => {
-  let refreshed = false;
-  const fakeOauth = {
-    loadCache() {
-      return refreshed
-        ? { access_token: "new", expires_at: Date.now() + 600_000 }
-        : { access_token: "old", expires_at: 0, refresh_token: "r", discovery: {}, client: {} };
-    },
-    isExpired(c) { return (c.expires_at ?? 0) <= Date.now(); },
-    refresh: async () => { refreshed = true; }
-  };
+test("_oauthToken delegates to ensureToken({interactive:false}) and returns its token", async () => {
+  let calledWith;
+  const fakeOauth = { ensureToken: async (opts) => { calledWith = opts; return "fresh-token"; } };
   const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
-  assert.equal(await src._oauthToken(), "new");
+  assert.equal(await src._oauthToken(), "fresh-token");
+  assert.deepEqual(calledWith, { interactive: false }, "must request a silent token, never interactive");
 });
 
-test("_oauthToken never triggers interactive auth when nothing is cached", async () => {
-  const fakeOauth = {
-    loadCache: () => null,
-    isExpired: () => true,
-    refresh: async () => { throw new Error("must not refresh"); }
-  };
+test("_oauthToken returns null when ensureToken throws (no usable cache / refresh failed)", async () => {
+  const fakeOauth = { ensureToken: async () => { throw new Error("refresh failed"); } };
   const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
   assert.equal(await src._oauthToken(), null);
 });

--- a/test/buildbetter-auth.test.js
+++ b/test/buildbetter-auth.test.js
@@ -1,0 +1,127 @@
+// test/buildbetter-auth.test.js
+// Covers the two auth improvements:
+//   1. Identity is auto-derived from the `me` query (no manual email/name).
+//   2. The poller can reuse the BuildBetter MCP OAuth connection (Bearer token,
+//      silently refreshed) instead of an API key.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { BuildBetterTaskSource } from "../src/integrations/buildbetter-tasks.js";
+
+// Isolate from any real BuildBetter env in the host so the OAuth path is
+// reachable when we don't pass an API key.
+delete process.env.BUILDBETTER_API_KEY;
+delete process.env.BUILDBETTER_USER_EMAIL;
+delete process.env.BUILDBETTER_USER_NAME;
+
+// — Option 1: identity auto-derivation via `me` —
+
+test("ensureIdentity auto-derives email from the me query", async () => {
+  const src = new BuildBetterTaskSource({ apiKey: "k" }); // no email/name given
+  src.query = async (q) => {
+    assert.match(q, /\bme\b/);
+    return { me: { person: { first_name: "Spencer", last_name: "Shulem", email: "spencer@buildbetter.app" } } };
+  };
+  await src.ensureIdentity();
+  assert.equal(src.userEmail, "spencer@buildbetter.app");
+});
+
+test("ensureIdentity falls back to full name when me has no email", async () => {
+  const src = new BuildBetterTaskSource({ apiKey: "k" });
+  src.query = async () => ({ me: { person: { first_name: "Ada", last_name: "Lovelace", email: null } } });
+  await src.ensureIdentity();
+  assert.equal(src.userEmail, null);
+  assert.equal(src.userName, "Ada Lovelace");
+});
+
+test("ensureIdentity is a no-op when identity is already known", async () => {
+  const src = new BuildBetterTaskSource({ apiKey: "k", userEmail: "me@x.com" });
+  let called = 0;
+  src.query = async () => { called += 1; return {}; };
+  await src.ensureIdentity();
+  assert.equal(called, 0, "must not hit the API when we already know who you are");
+});
+
+test("ensureIdentity does not re-query after a null me (org-scoped key)", async () => {
+  const src = new BuildBetterTaskSource({ apiKey: "k" });
+  let called = 0;
+  src.query = async () => { called += 1; return { me: null }; };
+  await src.ensureIdentity();
+  await src.ensureIdentity();
+  assert.equal(called, 1, "asked once, then falls back to env identity without re-asking");
+  assert.equal(src.userEmail, null);
+});
+
+test("ensureIdentity retries after a thrown (transient) error", async () => {
+  const src = new BuildBetterTaskSource({ apiKey: "k" });
+  let called = 0;
+  src.query = async () => {
+    called += 1;
+    if (called === 1) throw new Error("network");
+    return { me: { person: { first_name: "Grace", last_name: "Hopper", email: "grace@x.com" } } };
+  };
+  await src.ensureIdentity();
+  assert.equal(src.userEmail, null, "first attempt failed → still unresolved");
+  await src.ensureIdentity();
+  assert.equal(src.userEmail, "grace@x.com", "second attempt succeeds");
+  assert.equal(called, 2);
+});
+
+// — Option 2: reuse the MCP OAuth connection —
+
+test("authHeaders uses the API key when set", async () => {
+  const src = new BuildBetterTaskSource({ apiKey: "secret" });
+  assert.deepEqual(await src.authHeaders(), { "X-BuildBetter-Api-Key": "secret" });
+});
+
+test("authHeaders falls back to a reused OAuth bearer token", async () => {
+  const fakeOauth = {
+    loadCache: () => ({ access_token: "tok", expires_at: Date.now() + 600_000 }),
+    isExpired: () => false,
+    refresh: async () => { throw new Error("should not refresh a fresh token"); }
+  };
+  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+  assert.deepEqual(await src.authHeaders(), { authorization: "Bearer tok" });
+});
+
+test("authHeaders returns null with no api key and no OAuth cache", async () => {
+  const fakeOauth = { loadCache: () => null, isExpired: () => true, refresh: async () => {} };
+  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+  assert.equal(await src.authHeaders(), null);
+});
+
+test("_oauthToken silently refreshes an expired token (no browser flow)", async () => {
+  let refreshed = false;
+  const fakeOauth = {
+    loadCache() {
+      return refreshed
+        ? { access_token: "new", expires_at: Date.now() + 600_000 }
+        : { access_token: "old", expires_at: 0, refresh_token: "r", discovery: {}, client: {} };
+    },
+    isExpired(c) { return (c.expires_at ?? 0) <= Date.now(); },
+    refresh: async () => { refreshed = true; }
+  };
+  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+  assert.equal(await src._oauthToken(), "new");
+});
+
+test("_oauthToken never triggers interactive auth when nothing is cached", async () => {
+  const fakeOauth = {
+    loadCache: () => null,
+    isExpired: () => true,
+    refresh: async () => { throw new Error("must not refresh"); }
+  };
+  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+  assert.equal(await src._oauthToken(), null);
+});
+
+test("isConfigured is true with only a reused OAuth connection", () => {
+  const fakeOauth = { loadCache: () => ({ refresh_token: "r" }), isExpired: () => true };
+  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+  assert.equal(src.isConfigured(), true);
+});
+
+test("isConfigured is false with neither api key nor OAuth cache", () => {
+  const fakeOauth = { loadCache: () => null, isExpired: () => true };
+  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+  assert.equal(src.isConfigured(), false);
+});

--- a/test/buildbetter-auth.test.js
+++ b/test/buildbetter-auth.test.js
@@ -73,48 +73,30 @@ test("authHeaders uses the API key when set", async () => {
   assert.deepEqual(await src.authHeaders(), { "X-BuildBetter-Api-Key": "secret" });
 });
 
-test("authHeaders falls back to a reused OAuth bearer token", async () => {
-  // _oauthToken delegates to the canonical ensureToken({interactive:false}).
-  const fakeOauth = {
-    ensureToken: async ({ interactive }) => {
-      assert.equal(interactive, false, "poller must never open a browser");
-      return "tok";
-    }
-  };
-  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+test("authHeaders falls back to the BuildBetter MCP OAuth token via the registry", async () => {
+  let askedFor;
+  const mcp = { silentTokenFor: async (name) => { askedFor = name; return "tok"; } };
+  const src = new BuildBetterTaskSource({ apiKey: null, runtime: { mcp } });
   assert.deepEqual(await src.authHeaders(), { authorization: "Bearer tok" });
+  assert.equal(askedFor, "buildbetter", "reuses the buildbetter MCP server's token");
 });
 
-test("authHeaders returns null when ensureToken can't get a token without a browser", async () => {
-  const fakeOauth = {
-    ensureToken: async () => { const e = new Error("no token"); e.code = "OAUTH_INTERACTIVE_REQUIRED"; throw e; }
-  };
-  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
-  assert.equal(await src.authHeaders(), null);
+test("authHeaders returns null when the registry has no silent token", async () => {
+  const src1 = new BuildBetterTaskSource({ apiKey: null, runtime: { mcp: { silentTokenFor: async () => null } } });
+  assert.equal(await src1.authHeaders(), null);
+  // ...and when there's no registry at all.
+  const src2 = new BuildBetterTaskSource({ apiKey: null, runtime: {} });
+  assert.equal(await src2.authHeaders(), null);
 });
 
-test("_oauthToken delegates to ensureToken({interactive:false}) and returns its token", async () => {
-  let calledWith;
-  const fakeOauth = { ensureToken: async (opts) => { calledWith = opts; return "fresh-token"; } };
-  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
-  assert.equal(await src._oauthToken(), "fresh-token");
-  assert.deepEqual(calledWith, { interactive: false }, "must request a silent token, never interactive");
-});
-
-test("_oauthToken returns null when ensureToken throws (no usable cache / refresh failed)", async () => {
-  const fakeOauth = { ensureToken: async () => { throw new Error("refresh failed"); } };
-  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
-  assert.equal(await src._oauthToken(), null);
-});
-
-test("isConfigured is true with only a reused OAuth connection", () => {
-  const fakeOauth = { loadCache: () => ({ refresh_token: "r" }), isExpired: () => true };
-  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+test("isConfigured is true with only a reused OAuth connection (registry reports a cached token)", () => {
+  const src = new BuildBetterTaskSource({ apiKey: null, runtime: { mcp: { hasOAuthToken: () => true } } });
   assert.equal(src.isConfigured(), true);
 });
 
-test("isConfigured is false with neither api key nor OAuth cache", () => {
-  const fakeOauth = { loadCache: () => null, isExpired: () => true };
-  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+test("isConfigured is false with neither api key nor a cached OAuth token", () => {
+  const src = new BuildBetterTaskSource({ apiKey: null, runtime: { mcp: { hasOAuthToken: () => false } } });
   assert.equal(src.isConfigured(), false);
+  // No registry at all → also false.
+  assert.equal(new BuildBetterTaskSource({ apiKey: null, runtime: {} }).isConfigured(), false);
 });

--- a/test/buildbetter-transcripts.test.js
+++ b/test/buildbetter-transcripts.test.js
@@ -41,6 +41,20 @@ test("ingestMode defaults to signals", () => {
   if (prev !== undefined) process.env.BUILDBETTER_INGEST_MODE = prev;
 });
 
+test("syncTranscripts skips with a reason when identity can't be determined (no silent empty)", async () => {
+  const observations = fakeObservations();
+  // Auth present (api key) but no email/name, and `me` returns no user.
+  const src = new BuildBetterTaskSource({ apiKey: "k", runtime: { observations } });
+  src.query = async () => ({ me: { person: null } });
+  let fetched = 0;
+  src.getTranscript = async () => { fetched += 1; return "x"; };
+  const res = await src.syncTranscripts({ now: new Date("2026-06-02T00:00:00Z") });
+  assert.equal(res.skipped, true);
+  assert.match(res.reason, /identity/i);
+  assert.equal(observations._rows.length, 0, "records nothing");
+  assert.equal(fetched, 0, "never even fetches transcripts");
+});
+
 test("getTranscript assembles speaker-labeled lines, falling back to Speaker N", async () => {
   const src = new BuildBetterTaskSource({ apiKey: "k", userEmail: "me@x.com" });
   src.query = async () => ({

--- a/test/buildbetter-transcripts.test.js
+++ b/test/buildbetter-transcripts.test.js
@@ -1,0 +1,42 @@
+// test/buildbetter-transcripts.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { BuildBetterTaskSource } from "../src/integrations/buildbetter-tasks.js";
+
+function fakeObservations() {
+  const rows = [];
+  return {
+    record: async (o) => { rows.push(o); return { count: 1 }; },
+    search: async () => rows,
+    existsRef: async (ref) => rows.some((o) => o.ref === ref),
+    _rows: rows
+  };
+}
+
+test("syncTranscripts records one transcript per call and dedupes", async () => {
+  const observations = fakeObservations();
+  const src = new BuildBetterTaskSource({
+    apiKey: "k", userEmail: "me@x.com",
+    runtime: { observations }
+  });
+  // Stub the two network calls.
+  src.getRecentCalls = async () => [{ id: 7, name: "Acme Discovery", started_at: "2026-06-01T10:00:00Z" }];
+  src.getTranscript = async (callId) => `Transcript for ${callId}: ship it by Friday.`;
+
+  const first = await src.syncTranscripts({ now: new Date("2026-06-02T00:00:00Z") });
+  assert.equal(first.created, 1);
+  assert.equal(observations._rows[0].kind, "transcript");
+  assert.equal(observations._rows[0].ref, "buildbetter:call:7");
+
+  // Second run: same call already recorded -> no new row.
+  const second = await src.syncTranscripts({ now: new Date("2026-06-02T00:05:00Z") });
+  assert.equal(second.created, 0);
+});
+
+test("ingestMode defaults to signals", () => {
+  const prev = process.env.BUILDBETTER_INGEST_MODE;
+  delete process.env.BUILDBETTER_INGEST_MODE;
+  const src = new BuildBetterTaskSource({ apiKey: "k", userEmail: "me@x.com" });
+  assert.equal(src.ingestMode, "signals");
+  if (prev !== undefined) process.env.BUILDBETTER_INGEST_MODE = prev;
+});

--- a/test/buildbetter-transcripts.test.js
+++ b/test/buildbetter-transcripts.test.js
@@ -40,3 +40,53 @@ test("ingestMode defaults to signals", () => {
   assert.equal(src.ingestMode, "signals");
   if (prev !== undefined) process.env.BUILDBETTER_INGEST_MODE = prev;
 });
+
+test("getTranscript assembles speaker-labeled lines, falling back to Speaker N", async () => {
+  const src = new BuildBetterTaskSource({ apiKey: "k", userEmail: "me@x.com" });
+  src.query = async () => ({
+    interview: [{
+      id: 7,
+      monologues: [
+        { speaker: 0, text: "Hello there", attendee: { person: { first_name: "Ada", last_name: "Lovelace" } } },
+        { speaker: 1, text: "Hi", attendee: null }
+      ]
+    }]
+  });
+  const t = await src.getTranscript(7);
+  assert.equal(t, "Ada Lovelace: Hello there\nSpeaker 1: Hi");
+});
+
+test("getTranscript returns empty string when there are no monologues", async () => {
+  const src = new BuildBetterTaskSource({ apiKey: "k", userEmail: "me@x.com" });
+  src.query = async () => ({ interview: [{ id: 7, monologues: [] }] });
+  assert.equal(await src.getTranscript(7), "");
+});
+
+test("sync dispatches by ingestMode", async () => {
+  const calls = [];
+  const make = (mode) => {
+    const src = new BuildBetterTaskSource({ apiKey: "k", userEmail: "me@x.com", ingestMode: mode });
+    src.syncSignals = async () => { calls.push(`${mode}:signals`); return { created: 0 }; };
+    src.syncTranscripts = async () => { calls.push(`${mode}:transcripts`); return { created: 0 }; };
+    return src;
+  };
+  await make("signals").sync({ now: new Date("2026-06-02T00:00:00Z") });
+  await make("transcripts").sync({ now: new Date("2026-06-02T00:00:00Z") });
+  await make("both").sync({ now: new Date("2026-06-02T00:00:00Z") });
+  assert.deepEqual(calls, [
+    "signals:signals",
+    "transcripts:transcripts",
+    "both:signals", "both:transcripts"
+  ]);
+});
+
+test("syncTranscripts does not refetch an already-ingested transcript", async () => {
+  const observations = fakeObservations();
+  const src = new BuildBetterTaskSource({ apiKey: "k", userEmail: "me@x.com", runtime: { observations } });
+  src.getRecentCalls = async () => [{ id: 7, name: "Acme", started_at: "2026-06-01T10:00:00Z" }];
+  let fetchCount = 0;
+  src.getTranscript = async () => { fetchCount += 1; return "some transcript text"; };
+  await src.syncTranscripts({ now: new Date("2026-06-02T00:00:00Z") });
+  await src.syncTranscripts({ now: new Date("2026-06-02T00:05:00Z") });
+  assert.equal(fetchCount, 1, "transcript fetched once; second run skips via existsRef");
+});

--- a/test/credit-ledger.test.js
+++ b/test/credit-ledger.test.js
@@ -86,6 +86,13 @@ test("days=7 includes today plus the previous 6 calendar days", () => {
   assert.equal(rows[0].at, "2026-05-31T10:00:00.000Z");
 });
 
+test("creates the ledger file with private 0600 permissions", { skip: process.platform === "win32" }, () => {
+  const L = tmpLedger();
+  L.record(entry());
+  const mode = fs.statSync(L.storePath).mode & 0o777;
+  assert.equal(mode, 0o600, `expected 0600, got 0o${mode.toString(8)}`);
+});
+
 test("re-arms the compaction threshold so it doesn't rewrite on every append", () => {
   const L = tmpLedger({ compactBytes: 1 }); // would compact on every append without re-arming
   const now = new Date("2026-06-06T10:00:00.000Z");

--- a/test/credit-ledger.test.js
+++ b/test/credit-ledger.test.js
@@ -96,6 +96,16 @@ test("enforces 30-day retention on disk even below the compaction threshold", ()
   assert.match(onDisk[0], /2026-06-06T09:00/);
 });
 
+test("clamps query/analytics to the retention window (stale on-disk rows never surface)", () => {
+  const L = tmpLedger();
+  // Write an aged-out row directly, bypassing record()'s prune, to simulate
+  // data still on disk past the window.
+  fs.writeFileSync(L.storePath, JSON.stringify({ at: "2026-04-01T10:00:00.000Z", model: "x", usd: 1, channel: "chat", tools: [] }) + "\n");
+  const now = new Date("2026-06-06T10:00:00.000Z");
+  assert.equal(L.query({ days: 90, now }).length, 0, "days=90 must not return a >30-day-old row");
+  assert.equal(L.analytics({ days: 90, now }).totalCalls, 0);
+});
+
 test("creates the ledger file with private 0600 permissions", { skip: process.platform === "win32" }, () => {
   const L = tmpLedger();
   L.record(entry());

--- a/test/credit-ledger.test.js
+++ b/test/credit-ledger.test.js
@@ -86,6 +86,16 @@ test("days=7 includes today plus the previous 6 calendar days", () => {
   assert.equal(rows[0].at, "2026-05-31T10:00:00.000Z");
 });
 
+test("enforces 30-day retention on disk even below the compaction threshold", () => {
+  const L = tmpLedger({ compactBytes: 10 * 1024 * 1024 }); // never size-compacts
+  const now = new Date("2026-06-06T10:00:00.000Z");
+  L.record(entry({ at: "2026-04-01T10:00:00.000Z" }), { now }); // ~66 days old → pruned
+  L.record(entry({ at: "2026-06-06T09:00:00.000Z" }), { now }); // within window
+  const onDisk = fs.readFileSync(L.storePath, "utf8").split("\n").filter(Boolean);
+  assert.equal(onDisk.length, 1, "old row physically removed despite a small file");
+  assert.match(onDisk[0], /2026-06-06T09:00/);
+});
+
 test("creates the ledger file with private 0600 permissions", { skip: process.platform === "win32" }, () => {
   const L = tmpLedger();
   L.record(entry());

--- a/test/credit-ledger.test.js
+++ b/test/credit-ledger.test.js
@@ -62,3 +62,37 @@ test("tolerates a missing/corrupt file", () => {
   fs.writeFileSync(L.storePath, "not json\n{bad\n");
   assert.deepEqual(L.query(), []);
 });
+
+test("days=1 means today (UTC calendar day), not a rolling 24h window", () => {
+  const L = tmpLedger();
+  // now = today 08:00 UTC. An entry at yesterday 23:00 is within the last 24h
+  // but is NOT today — it must be excluded from a days=1 ("today") query.
+  L.record(entry({ at: "2026-06-05T23:00:00.000Z" })); // yesterday evening
+  L.record(entry({ at: "2026-06-06T02:00:00.000Z" })); // today, early
+  const now = new Date("2026-06-06T08:00:00.000Z");
+  const rows = L.query({ days: 1, now });
+  assert.equal(rows.length, 1, "only today's entry");
+  assert.equal(rows[0].at, "2026-06-06T02:00:00.000Z");
+  assert.equal(L.analytics({ days: 1, now }).totalCalls, 1);
+});
+
+test("days=7 includes today plus the previous 6 calendar days", () => {
+  const L = tmpLedger();
+  L.record(entry({ at: "2026-05-31T10:00:00.000Z" })); // 6 days before the 6th — included
+  L.record(entry({ at: "2026-05-30T10:00:00.000Z" })); // 7 days before — excluded
+  const now = new Date("2026-06-06T08:00:00.000Z");
+  const rows = L.query({ days: 7, now });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].at, "2026-05-31T10:00:00.000Z");
+});
+
+test("re-arms the compaction threshold so it doesn't rewrite on every append", () => {
+  const L = tmpLedger({ compactBytes: 1 }); // would compact on every append without re-arming
+  const now = new Date("2026-06-06T10:00:00.000Z");
+  L.record(entry({ at: "2026-06-06T09:00:00.000Z" }), { now });
+  L.record(entry({ at: "2026-06-06T09:30:00.000Z" }), { now });
+  // After compacting a retained (non-empty) window, the next threshold must
+  // climb above compactBytes so subsequent appends within the headroom skip the
+  // full read+rewrite.
+  assert.ok(L._nextCompactBytes > 1, `expected re-armed threshold > 1, got ${L._nextCompactBytes}`);
+});

--- a/test/credit-ledger.test.js
+++ b/test/credit-ledger.test.js
@@ -1,0 +1,64 @@
+// test/credit-ledger.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { CreditLedger } from "../src/credit-ledger.js";
+
+function tmpLedger(opts = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ledger-"));
+  return new CreditLedger({ storePath: path.join(dir, "ledger.jsonl"), ...opts });
+}
+const entry = (over = {}) => ({
+  model: "claude-opus-4-7", usd: 0.05, channel: "chat", agentId: "main",
+  sessionId: "s1", from: "user", tools: ["web_search"],
+  tokens: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0 }, ...over
+});
+
+test("records and queries entries newest-first", () => {
+  const L = tmpLedger();
+  L.record(entry({ usd: 0.01, at: "2026-06-05T10:00:00.000Z" }));
+  L.record(entry({ usd: 0.02, at: "2026-06-06T10:00:00.000Z" }));
+  const rows = L.query({ days: 30, now: new Date("2026-06-06T12:00:00.000Z") });
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0].usd, 0.02);
+  assert.equal(rows[0].channel, "chat");
+});
+
+test("query window excludes entries older than days", () => {
+  const L = tmpLedger();
+  L.record(entry({ at: "2026-05-01T10:00:00.000Z" }));
+  L.record(entry({ at: "2026-06-06T10:00:00.000Z" }));
+  const rows = L.query({ days: 30, now: new Date("2026-06-06T12:00:00.000Z") });
+  assert.equal(rows.length, 1);
+});
+
+test("analytics groups by day, model, activity", () => {
+  const L = tmpLedger();
+  L.record(entry({ usd: 0.10, channel: "autopilot", model: "claude-opus-4-7", at: "2026-06-06T09:00:00.000Z" }));
+  L.record(entry({ usd: 0.04, channel: "chat", model: "gpt-5", at: "2026-06-06T10:00:00.000Z" }));
+  L.record(entry({ usd: 0.01, channel: "chat", model: "gpt-5", at: "2026-06-05T10:00:00.000Z" }));
+  const a = L.analytics({ days: 30, now: new Date("2026-06-06T12:00:00.000Z") });
+  assert.equal(a.totalCalls, 3);
+  assert.equal(a.totalUsd, 0.15);
+  assert.equal(a.byActivity.find((x) => x.activity === "autopilot").usd, 0.10);
+  assert.equal(a.byActivity[0].activity, "autopilot");
+  assert.equal(a.byModel.find((x) => x.model === "gpt-5").calls, 2);
+  assert.deepEqual(a.byDay.map((d) => d.date), ["2026-06-05", "2026-06-06"]);
+});
+
+test("compacts when the file exceeds the byte threshold, keeping the window", () => {
+  const L = tmpLedger({ compactBytes: 1 });
+  L.record(entry({ at: "2026-05-01T10:00:00.000Z" }), { now: new Date("2026-06-06T10:00:00.000Z") });
+  L.record(entry({ at: "2026-06-06T10:00:00.000Z" }), { now: new Date("2026-06-06T10:00:00.000Z") });
+  const onDisk = fs.readFileSync(L.storePath, "utf8").split("\n").filter(Boolean);
+  assert.equal(onDisk.length, 1);
+});
+
+test("tolerates a missing/corrupt file", () => {
+  const L = tmpLedger();
+  assert.deepEqual(L.query(), []);
+  fs.writeFileSync(L.storePath, "not json\n{bad\n");
+  assert.deepEqual(L.query(), []);
+});

--- a/test/data-dir.test.js
+++ b/test/data-dir.test.js
@@ -31,3 +31,12 @@ test("resolves a relative OPENAGI_DATA_DIR to absolute", () => {
   if (prev !== undefined) process.env.OPENAGI_DATA_DIR = prev; else delete process.env.OPENAGI_DATA_DIR;
   _resetDataDirCache();
 });
+
+test("treats an empty or whitespace OPENAGI_DATA_DIR as unset", () => {
+  const prev = process.env.OPENAGI_DATA_DIR;
+  process.env.OPENAGI_DATA_DIR = "   ";
+  _resetDataDirCache();
+  assert.equal(resolveDataDir(), path.join(os.homedir(), ".openagi"));
+  if (prev !== undefined) process.env.OPENAGI_DATA_DIR = prev; else delete process.env.OPENAGI_DATA_DIR;
+  _resetDataDirCache();
+});

--- a/test/data-dir.test.js
+++ b/test/data-dir.test.js
@@ -1,0 +1,33 @@
+// test/data-dir.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { resolveDataDir, _resetDataDirCache } from "../src/data-dir.js";
+
+test("defaults to ~/.openagi when OPENAGI_DATA_DIR is unset", () => {
+  const prev = process.env.OPENAGI_DATA_DIR;
+  delete process.env.OPENAGI_DATA_DIR;
+  _resetDataDirCache();
+  assert.equal(resolveDataDir(), path.join(os.homedir(), ".openagi"));
+  if (prev !== undefined) process.env.OPENAGI_DATA_DIR = prev;
+  _resetDataDirCache();
+});
+
+test("honors OPENAGI_DATA_DIR as an absolute path", () => {
+  const prev = process.env.OPENAGI_DATA_DIR;
+  process.env.OPENAGI_DATA_DIR = "/tmp/openagi-test";
+  _resetDataDirCache();
+  assert.equal(resolveDataDir(), "/tmp/openagi-test");
+  if (prev !== undefined) process.env.OPENAGI_DATA_DIR = prev; else delete process.env.OPENAGI_DATA_DIR;
+  _resetDataDirCache();
+});
+
+test("resolves a relative OPENAGI_DATA_DIR to absolute", () => {
+  const prev = process.env.OPENAGI_DATA_DIR;
+  process.env.OPENAGI_DATA_DIR = "rel-data";
+  _resetDataDirCache();
+  assert.equal(resolveDataDir(), path.resolve("rel-data"));
+  if (prev !== undefined) process.env.OPENAGI_DATA_DIR = prev; else delete process.env.OPENAGI_DATA_DIR;
+  _resetDataDirCache();
+});

--- a/test/env-persistence.test.js
+++ b/test/env-persistence.test.js
@@ -21,6 +21,7 @@ test("saveEnv writes under OPENAGI_DATA_DIR and survives a reload", () => {
 
   if (prev !== undefined) process.env.OPENAGI_DATA_DIR = prev; else delete process.env.OPENAGI_DATA_DIR;
   _resetDataDirCache();
+  delete process.env.ANTHROPIC_API_KEY;
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 

--- a/test/env-persistence.test.js
+++ b/test/env-persistence.test.js
@@ -23,3 +23,12 @@ test("saveEnv writes under OPENAGI_DATA_DIR and survives a reload", () => {
   _resetDataDirCache();
   fs.rmSync(tmp, { recursive: true, force: true });
 });
+
+test("envFilePath() returns absolute ~/.openagi/.env when OPENAGI_DATA_DIR is unset", () => {
+  const prev = process.env.OPENAGI_DATA_DIR;
+  delete process.env.OPENAGI_DATA_DIR;
+  _resetDataDirCache();
+  assert.equal(envFilePath(), path.join(os.homedir(), ".openagi", ".env"));
+  if (prev !== undefined) process.env.OPENAGI_DATA_DIR = prev;
+  _resetDataDirCache();
+});

--- a/test/env-persistence.test.js
+++ b/test/env-persistence.test.js
@@ -1,0 +1,25 @@
+// test/env-persistence.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { _resetDataDirCache } from "../src/data-dir.js";
+import { envFilePath, saveEnv } from "../src/setup-wizard.js";
+
+test("saveEnv writes under OPENAGI_DATA_DIR and survives a reload", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-env-"));
+  const prev = process.env.OPENAGI_DATA_DIR;
+  process.env.OPENAGI_DATA_DIR = tmp;
+  _resetDataDirCache();
+
+  assert.equal(envFilePath(), path.join(tmp, ".env"));
+  saveEnv({ values: { ANTHROPIC_API_KEY: "sk-test-123" } });
+
+  const onDisk = fs.readFileSync(path.join(tmp, ".env"), "utf8");
+  assert.match(onDisk, /ANTHROPIC_API_KEY=sk-test-123/);
+
+  if (prev !== undefined) process.env.OPENAGI_DATA_DIR = prev; else delete process.env.OPENAGI_DATA_DIR;
+  _resetDataDirCache();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});

--- a/test/mcp-boot-reconnect.test.js
+++ b/test/mcp-boot-reconnect.test.js
@@ -42,13 +42,22 @@ test("connectAll({silent:true}) leaves an un-authorized OAuth server idle withou
   assert.equal(server.connected, false);
 });
 
-test("hasOAuthToken reflects the cached token on disk", () => {
+test("hasOAuthToken reflects a SILENTLY USABLE cached token on disk", () => {
   const reg = new McpRegistry({ dataDir: tmp, configPath: null });
   assert.equal(reg.hasOAuthToken("nope-no-cache"), false);
-  writeTokenCache("hbtcache", { access_token: "a" });
-  assert.equal(reg.hasOAuthToken("hbtcache"), true);
+  // A refresh token can always mint a new access token silently.
   writeTokenCache("hbtrefresh", { refresh_token: "r" });
   assert.equal(reg.hasOAuthToken("hbtrefresh"), true);
+  // A live access token (unexpired) counts.
+  writeTokenCache("hbtlive", { access_token: "a", expires_at: Date.now() + 600_000 });
+  assert.equal(reg.hasOAuthToken("hbtlive"), true);
+  // An expired (or unknown-expiry) access token with no refresh token does NOT:
+  // silentTokenFor() can't use it, so reporting "configured" would ack webhooks
+  // and then silently drop them.
+  writeTokenCache("hbtexpired", { access_token: "a", expires_at: Date.now() - 1000 });
+  assert.equal(reg.hasOAuthToken("hbtexpired"), false);
+  writeTokenCache("hbtcache", { access_token: "a" });
+  assert.equal(reg.hasOAuthToken("hbtcache"), false);
 });
 
 test("silentTokenFor returns a cached, unexpired token without a browser", async () => {

--- a/test/mcp-boot-reconnect.test.js
+++ b/test/mcp-boot-reconnect.test.js
@@ -5,11 +5,18 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
+import fs from "node:fs";
 import path from "node:path";
 import { McpOAuthClient } from "../src/mcp-oauth.js";
 import { McpRegistry } from "../src/mcp-registry.js";
 
 const tmp = path.join(os.tmpdir(), `openagi-boot-test-${process.pid}`);
+
+function writeTokenCache(name, cache) {
+  const dir = path.join(tmp, "mcp", "auth");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${name}.json`), JSON.stringify(cache));
+}
 
 test("ensureToken({interactive:false}) fails fast instead of opening a browser", async () => {
   const client = new McpOAuthClient({ resourceUrl: "https://example.test", dataDir: tmp });
@@ -33,4 +40,46 @@ test("connectAll({silent:true}) leaves an un-authorized OAuth server idle withou
   // And it must not report as connected.
   const server = reg.listServers().find((s) => s.name === "rize");
   assert.equal(server.connected, false);
+});
+
+test("hasOAuthToken reflects the cached token on disk", () => {
+  const reg = new McpRegistry({ dataDir: tmp, configPath: null });
+  assert.equal(reg.hasOAuthToken("nope-no-cache"), false);
+  writeTokenCache("hbtcache", { access_token: "a" });
+  assert.equal(reg.hasOAuthToken("hbtcache"), true);
+  writeTokenCache("hbtrefresh", { refresh_token: "r" });
+  assert.equal(reg.hasOAuthToken("hbtrefresh"), true);
+});
+
+test("silentTokenFor returns a cached, unexpired token without a browser", async () => {
+  const reg = new McpRegistry({ dataDir: tmp, configPath: null });
+  reg.registerServer({ name: "bb", url: "https://mcp.buildbetter.app/sse", auth: "oauth", trustLevel: "trusted" });
+  writeTokenCache("bb", { access_token: "live-token", expires_at: Date.now() + 600_000 });
+  assert.equal(await reg.silentTokenFor("bb"), "live-token");
+});
+
+test("silentTokenFor returns null for an un-authorized / unknown server (never prompts)", async () => {
+  const reg = new McpRegistry({ dataDir: tmp, configPath: null });
+  reg.registerServer({ name: "bb2", url: "https://mcp.buildbetter.app/sse", auth: "oauth", trustLevel: "trusted" });
+  assert.equal(await reg.silentTokenFor("bb2"), null);   // registered, no token cached
+  assert.equal(await reg.silentTokenFor("ghost"), null); // not registered at all
+});
+
+test("an interactive connect is not swallowed by an in-flight silent connect", async () => {
+  const reg = new McpRegistry({ dataDir: tmp, configPath: null });
+  reg.registerServer({ name: "x", url: "https://mcp.x.test/sse", auth: "oauth", trustLevel: "trusted" });
+  const calls = [];
+  reg.doConnect = async (_name, { silent }) => {
+    calls.push(silent);
+    if (silent) { const e = new Error("need browser"); e.code = "OAUTH_INTERACTIVE_REQUIRED"; throw e; }
+    return { connected: true };
+  };
+  // Silent boot attempt in-flight, then a user clicks Connect (interactive).
+  const silentP = reg.connect("x", { silent: true });
+  const interactiveP = reg.connect("x", { silent: false });
+  const [silentR, interactiveR] = await Promise.allSettled([silentP, interactiveP]);
+  assert.equal(silentR.status, "rejected", "silent attempt fails fast");
+  assert.equal(interactiveR.status, "fulfilled", "interactive attempt still runs");
+  assert.deepEqual(interactiveR.value, { connected: true });
+  assert.deepEqual(calls, [true, false], "both attempts ran; interactive was not handed the silent failure");
 });

--- a/test/mcp-boot-reconnect.test.js
+++ b/test/mcp-boot-reconnect.test.js
@@ -1,0 +1,36 @@
+// test/mcp-boot-reconnect.test.js
+// The daemon reconnects MCP servers on boot, but must do so SILENTLY — an
+// OAuth server without a cached token has to fail fast (no browser), leaving
+// it "idle" with a Connect button, never blocking startup.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { McpOAuthClient } from "../src/mcp-oauth.js";
+import { McpRegistry } from "../src/mcp-registry.js";
+
+const tmp = path.join(os.tmpdir(), `openagi-boot-test-${process.pid}`);
+
+test("ensureToken({interactive:false}) fails fast instead of opening a browser", async () => {
+  const client = new McpOAuthClient({ resourceUrl: "https://example.test", dataDir: tmp });
+  await assert.rejects(
+    () => client.ensureToken({ interactive: false }),
+    (e) => e.code === "OAUTH_INTERACTIVE_REQUIRED",
+    "must throw the typed interactive-required error, not call authorize()"
+  );
+});
+
+test("connectAll({silent:true}) leaves an un-authorized OAuth server idle without prompting", async () => {
+  const reg = new McpRegistry({ dataDir: tmp, configPath: null });
+  reg.registerServer({ name: "rize", url: "https://mcp.rize.io/sse", auth: "oauth", trustLevel: "trusted" });
+
+  // If silent mode were broken, this would hang on a 5-min browser callback.
+  const results = await reg.connectAll({ silent: true });
+  const rize = results.find((r) => r.name === "rize");
+  assert.equal(rize.ok, false);
+  assert.equal(rize.code, "OAUTH_INTERACTIVE_REQUIRED");
+
+  // And it must not report as connected.
+  const server = reg.listServers().find((s) => s.name === "rize");
+  assert.equal(server.connected, false);
+});

--- a/test/mcp-http-interactive.test.js
+++ b/test/mcp-http-interactive.test.js
@@ -1,0 +1,40 @@
+// test/mcp-http-interactive.test.js
+// Regression for the latched-interactive bug: the OAuth "may I open a browser?"
+// flag must be per-request, not stored on the client at connect time. A silent
+// boot connect must not leave later tool calls unable to re-authorize.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { McpHttpClient } from "../src/mcp-http-client.js";
+
+test("interactive flag is threaded per-call, not latched on the client", async () => {
+  const seen = [];
+  const fakeOauth = {
+    ensureToken: async ({ interactive }) => { seen.push(interactive); return "tok"; }
+  };
+  const client = new McpHttpClient({ name: "x", url: "https://example.test/mcp", oauth: fakeOauth });
+
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, opts) => {
+    const req = JSON.parse(opts.body);
+    return new Response(
+      JSON.stringify({ jsonrpc: "2.0", id: req.id, result: { tools: [] } }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+  try {
+    await client.connect({ interactive: false }); // silent boot connect
+    const duringConnect = [...seen];
+    seen.length = 0;
+    await client.callTool("foo", {}); // a later tool call, no explicit flag
+    assert.ok(
+      duringConnect.length >= 1 && duringConnect.every((i) => i === false),
+      "every request in a silent connect must be non-interactive"
+    );
+    assert.deepEqual(
+      seen, [true],
+      "a tool call after a silent connect must default back to interactive (can re-auth)"
+    );
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});

--- a/test/mcp-oauth-scope.test.js
+++ b/test/mcp-oauth-scope.test.js
@@ -1,0 +1,62 @@
+// test/mcp-oauth-scope.test.js
+// Regression test for the `invalid_scope` OAuth failure: the client must
+// narrow the requested scope to what each server advertises, and omit `scope`
+// entirely for servers (like Rize) that advertise none — instead of always
+// sending a hardcoded openid/profile/email/offline_access set.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { McpOAuthClient } from "../src/mcp-oauth.js";
+
+const dataDir = path.join(os.tmpdir(), `openagi-oauth-test-${process.pid}`);
+const make = (opts = {}) => new McpOAuthClient({ resourceUrl: "https://example.test", dataDir, ...opts });
+
+test("Rize-style server (no scopes advertised) → omit scope entirely", () => {
+  const client = make();
+  // Real shapes pulled from mcp.rize.io: protected-resource has no
+  // scopes_supported; auth-server metadata has no scopes_supported either.
+  const discovery = {
+    resourceMeta: { resource: "https://mcp.rize.io/mcp", authorization_servers: ["https://mcp.rize.io"] },
+    serverMeta: { issuer: "https://mcp.rize.io", grant_types_supported: ["authorization_code"] }
+  };
+  assert.equal(client.resolveScope(discovery), null);
+});
+
+test("BuildBetter-style resource scopes → intersection with preferred (drops extras like service_account)", () => {
+  const client = make();
+  const discovery = {
+    resourceMeta: { scopes_supported: ["openid", "profile", "email", "offline_access", "service_account"] },
+    serverMeta: {}
+  };
+  assert.equal(client.resolveScope(discovery), "openid profile email offline_access");
+});
+
+test("auth-server scopes_supported is used when the resource doesn't advertise", () => {
+  const client = make();
+  const discovery = {
+    resourceMeta: {},
+    serverMeta: { scopes_supported: ["openid", "email", "read:stuff"] }
+  };
+  assert.equal(client.resolveScope(discovery), "openid email");
+});
+
+test("no overlap between preferred and supported → omit scope", () => {
+  const client = make();
+  const discovery = { resourceMeta: { scopes_supported: ["read:repo", "write:repo"] }, serverMeta: {} };
+  assert.equal(client.resolveScope(discovery), null);
+});
+
+test("an explicitly-configured scope is treated as authoritative and sent as-is", () => {
+  const client = make({ scope: "custom:scope another" });
+  // Even though the server advertises something else, an explicit catalog
+  // scope wins (the integration author knows what that server needs).
+  const discovery = { resourceMeta: { scopes_supported: ["openid"] }, serverMeta: {} };
+  assert.equal(client.resolveScope(discovery), "custom:scope another");
+});
+
+test("empty resource scopes_supported array → omit scope", () => {
+  const client = make();
+  const discovery = { resourceMeta: { scopes_supported: [] }, serverMeta: {} };
+  assert.equal(client.resolveScope(discovery), null);
+});

--- a/test/mcp-oauth-scope.test.js
+++ b/test/mcp-oauth-scope.test.js
@@ -60,3 +60,14 @@ test("empty resource scopes_supported array → omit scope", () => {
   const discovery = { resourceMeta: { scopes_supported: [] }, serverMeta: {} };
   assert.equal(client.resolveScope(discovery), null);
 });
+
+test("empty resource scopes_supported falls through to the auth server's scopes (not the empty array)", () => {
+  const client = make();
+  // resourceMeta advertises an EMPTY list but the auth server advertises real
+  // scopes — a naive `??` would keep [] and wrongly omit the scope.
+  const discovery = {
+    resourceMeta: { scopes_supported: [] },
+    serverMeta: { scopes_supported: ["openid", "email"] }
+  };
+  assert.equal(client.resolveScope(discovery), "openid email");
+});

--- a/test/observation-transcript.test.js
+++ b/test/observation-transcript.test.js
@@ -26,3 +26,19 @@ test("records and searches a transcript observation", async () => {
   assert.equal(await store.existsRef("buildbetter:call:999"), false);
   fs.rmSync(dir, { recursive: true, force: true });
 });
+
+test("search caps long transcript text but keeps the match snippet", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obs-cap-"));
+  const store = new ObservationStore({ dir });
+  const longText = "intro. " + "alpha ".repeat(400) + "the secret passphrase is xyzzy. " + "omega ".repeat(400);
+  await store.record({
+    kind: "transcript", at: "2026-06-01T10:00:00.000Z", app: "BuildBetter",
+    window: "Long call", text: longText, ref: "buildbetter:call:77"
+  });
+  const results = await store.search({ query: "passphrase", limit: 5 });
+  assert.equal(results.length, 1);
+  // text is capped (not the full multi-KB transcript) and marked truncated
+  assert.ok(results[0].text.length <= 1001, `expected capped text, got ${results[0].text.length}`);
+  assert.ok(results[0].text.endsWith("…"), "capped text should end with an ellipsis");
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/test/observation-transcript.test.js
+++ b/test/observation-transcript.test.js
@@ -1,0 +1,28 @@
+// test/observation-transcript.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ObservationStore } from "../src/observation-store.js";
+
+test("records and searches a transcript observation", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "obs-tx-"));
+  const store = new ObservationStore({ dir });
+  await store.record({
+    kind: "transcript",
+    at: "2026-06-01T10:00:00.000Z",
+    app: "BuildBetter",
+    window: "Acme <> Us — Discovery",
+    text: "We agreed to send the security questionnaire by Friday.",
+    ref: "buildbetter:call:42"
+  });
+  const results = await store.search({ query: "security questionnaire", limit: 5 });
+  assert.equal(results.length, 1);
+  assert.match(results[0].text ?? results[0].snippet ?? "", /security questionnaire/);
+
+  // Durable dedup lookup used by the BuildBetter transcript sync.
+  assert.equal(await store.existsRef("buildbetter:call:42"), true);
+  assert.equal(await store.existsRef("buildbetter:call:999"), false);
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/test/recall-spend.test.js
+++ b/test/recall-spend.test.js
@@ -1,0 +1,22 @@
+// test/recall-spend.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ToolRegistry, registerCoreTools } from "../src/tool-registry.js";
+import { CreditLedger } from "../src/credit-ledger.js";
+
+test("recall_spend summarizes the ledger", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rs-"));
+  const ledger = new CreditLedger({ storePath: path.join(dir, "ledger.jsonl") });
+  ledger.record({ usd: 0.10, channel: "autopilot", model: "claude-opus-4-7", tools: ["web_search"] });
+  ledger.record({ usd: 0.02, channel: "chat", model: "gpt-5", tools: [] });
+  const registry = new ToolRegistry();
+  registerCoreTools(registry, { budget: { ledger } });
+  const { result } = await registry.invoke("recall_spend", { days: 30 });
+  assert.ok(result.totalUsd >= 0.12 - 1e-9);
+  assert.equal(result.byActivity[0].activity, "autopilot");
+  assert.ok(Array.isArray(result.top));
+  assert.equal(result.top[0].activity, "autopilot"); // costliest first
+});

--- a/test/url-guard.test.js
+++ b/test/url-guard.test.js
@@ -1,7 +1,7 @@
 // test/url-guard.test.js
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { assertSafePublicUrl } from "../src/url-guard.js";
+import { assertSafePublicUrl, assertHostResolvesPublic } from "../src/url-guard.js";
 
 const blocks = (url) => assert.throws(() => assertSafePublicUrl(url, "fetch_url url"), /not allowed|must be http|Invalid/i, `should block ${url}`);
 const allows = (url) => assert.doesNotThrow(() => assertSafePublicUrl(url), `should allow ${url}`);
@@ -45,4 +45,39 @@ test("allows public hosts", () => {
   allows("https://example.com/page");
   allows("http://93.184.216.34/");            // a public IPv4
   allows("https://api.exa.ai/search");
+});
+
+// DNS-resolution layer: a public-looking name must be rejected when its
+// A/AAAA records land in blocked space (attacker DNS, localtest.me, nip.io).
+const fakeLookup = (answers) => async () => answers.map((address) => ({ address, family: address.includes(":") ? 6 : 4 }));
+
+test("rejects hostnames that resolve to private/loopback/metadata addresses", async () => {
+  const cases = [["127.0.0.1"], ["10.1.2.3"], ["169.254.169.254"], ["::1"], ["fd00::1"], ["::ffff:127.0.0.1"], ["93.184.216.34", "192.168.1.1"]];
+  for (const answers of cases) {
+    await assert.rejects(
+      assertHostResolvesPublic("evil.example.com", "fetch_url url", { lookupFn: fakeLookup(answers) }),
+      /not allowed/i,
+      `should reject resolution to ${answers.join(", ")}`
+    );
+  }
+});
+
+test("accepts hostnames that resolve only to public addresses", async () => {
+  await assert.doesNotReject(
+    assertHostResolvesPublic("example.com", "fetch_url url", { lookupFn: fakeLookup(["93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946"]) })
+  );
+});
+
+test("rejects hostnames that fail to resolve", async () => {
+  const failingLookup = async () => { const e = new Error("getaddrinfo ENOTFOUND"); e.code = "ENOTFOUND"; throw e; };
+  await assert.rejects(
+    assertHostResolvesPublic("nx.example.invalid", "fetch_url url", { lookupFn: failingLookup }),
+    /did not resolve/i
+  );
+});
+
+test("skips resolution for literal IPs (already string-checked)", async () => {
+  const explodingLookup = async () => { throw new Error("lookup should not be called for IP literals"); };
+  await assert.doesNotReject(assertHostResolvesPublic("93.184.216.34", "url", { lookupFn: explodingLookup }));
+  await assert.doesNotReject(assertHostResolvesPublic("[2606:2800:220:1:248:1893:25c8:1946]", "url", { lookupFn: explodingLookup }));
 });

--- a/test/url-guard.test.js
+++ b/test/url-guard.test.js
@@ -26,6 +26,16 @@ test("blocks IPv4-mapped IPv6 addresses (the bypass)", () => {
   blocks("http://[::ffff:a9fe:a9fe]/");       // hex form of 169.254.169.254
 });
 
+test("blocks the full IPv6 ULA (fc00::/7) and link-local (fe80::/10) ranges", () => {
+  blocks("http://[fc00::1]/");   // ULA — was missed (only fd* matched before)
+  blocks("http://[fcff::1]/");
+  blocks("http://[fd00::1]/");
+  blocks("http://[fdab::1]/");
+  blocks("http://[fe80::1]/");   // link-local
+  blocks("http://[fe81::1]/");   // was missed (only exactly fe80 matched before)
+  blocks("http://[febf::1]/");
+});
+
 test("rejects non-http(s) protocols", () => {
   blocks("file:///etc/passwd");
   blocks("gopher://127.0.0.1/");

--- a/test/url-guard.test.js
+++ b/test/url-guard.test.js
@@ -1,0 +1,38 @@
+// test/url-guard.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { assertSafePublicUrl } from "../src/url-guard.js";
+
+const blocks = (url) => assert.throws(() => assertSafePublicUrl(url, "fetch_url url"), /not allowed|must be http|Invalid/i, `should block ${url}`);
+const allows = (url) => assert.doesNotThrow(() => assertSafePublicUrl(url), `should allow ${url}`);
+
+test("blocks loopback / private / link-local / metadata (plain forms)", () => {
+  blocks("http://localhost/");
+  blocks("http://127.0.0.1:8080/");
+  blocks("http://10.0.0.5/");
+  blocks("http://192.168.1.1/");
+  blocks("http://172.16.0.1/");
+  blocks("http://169.254.169.254/latest/meta-data/");
+  blocks("http://[::1]/");
+});
+
+test("blocks IPv4-mapped IPv6 addresses (the bypass)", () => {
+  // Node normalizes [::ffff:127.0.0.1] → ::ffff:7f00:1 ; both must be blocked.
+  blocks("http://[::ffff:127.0.0.1]/");
+  blocks("http://[::ffff:7f00:1]/");          // hex form of 127.0.0.1
+  blocks("http://[::ffff:10.0.0.1]/");
+  blocks("http://[::ffff:a00:1]/");           // hex form of 10.0.0.1
+  blocks("http://[::ffff:169.254.169.254]/");
+  blocks("http://[::ffff:a9fe:a9fe]/");       // hex form of 169.254.169.254
+});
+
+test("rejects non-http(s) protocols", () => {
+  blocks("file:///etc/passwd");
+  blocks("gopher://127.0.0.1/");
+});
+
+test("allows public hosts", () => {
+  allows("https://example.com/page");
+  allows("http://93.184.216.34/");            // a public IPv4
+  allows("https://api.exa.ai/search");
+});

--- a/test/web-search-providers.test.js
+++ b/test/web-search-providers.test.js
@@ -1,0 +1,36 @@
+// test/web-search-providers.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { PROVIDERS } from "../src/integrations/web-search-providers.js";
+
+function withMockFetch(handler, fn) {
+  const real = globalThis.fetch;
+  globalThis.fetch = handler;
+  return Promise.resolve(fn()).finally(() => { globalThis.fetch = real; });
+}
+const jsonResponse = (obj) => ({ ok: true, status: 200, json: async () => obj });
+
+test("exa adapter maps results", async () => {
+  const exa = PROVIDERS.find((p) => p.name === "exa");
+  await withMockFetch(async (url, init) => {
+    assert.equal(url, "https://api.exa.ai/search");
+    assert.equal(JSON.parse(init.body).query, "claude api");
+    return jsonResponse({ results: [{ title: "Docs", url: "https://x", text: "body", publishedDate: "2026-01-01" }] });
+  }, async () => {
+    const out = await exa.search("claude api", { numResults: 3, apiKey: "k" });
+    assert.equal(out[0].title, "Docs");
+    assert.equal(out[0].url, "https://x");
+    assert.equal(out[0].content, "body");
+  });
+});
+
+test("tavily adapter maps results", async () => {
+  const tav = PROVIDERS.find((p) => p.name === "tavily");
+  await withMockFetch(async (url) => {
+    assert.equal(url, "https://api.tavily.com/search");
+    return jsonResponse({ results: [{ title: "T", url: "https://t", content: "snip" }] });
+  }, async () => {
+    const out = await tav.search("q", { apiKey: "k" });
+    assert.equal(out[0].snippet, "snip");
+  });
+});

--- a/test/web-search-providers.test.js
+++ b/test/web-search-providers.test.js
@@ -34,3 +34,87 @@ test("tavily adapter maps results", async () => {
     assert.equal(out[0].snippet, "snip");
   });
 });
+
+test("firecrawl maps the v2 data[] array shape and fetch() returns markdown", async () => {
+  const fc = PROVIDERS.find((p) => p.name === "firecrawl");
+  await withMockFetch(async (url) => {
+    assert.equal(url, "https://api.firecrawl.dev/v2/search");
+    return jsonResponse({ data: [{ title: "F", url: "https://f", description: "desc", markdown: "# body" }] });
+  }, async () => {
+    const out = await fc.search("q", { apiKey: "k" });
+    assert.equal(out[0].title, "F");
+    assert.equal(out[0].snippet, "desc");
+    assert.equal(out[0].content, "# body");
+  });
+  await withMockFetch(async (url) => {
+    assert.equal(url, "https://api.firecrawl.dev/v2/scrape");
+    return jsonResponse({ data: { markdown: "# page" } });
+  }, async () => {
+    const md = await fc.fetch("https://f", { apiKey: "k" });
+    assert.equal(md, "# page");
+  });
+});
+
+test("brave maps web.results[] and uses page_age for publishedDate", async () => {
+  const br = PROVIDERS.find((p) => p.name === "brave");
+  await withMockFetch(async (url) => {
+    assert.match(url, /^https:\/\/api\.search\.brave\.com\/res\/v1\/web\/search\?q=/);
+    return jsonResponse({ web: { results: [{ title: "B", url: "https://b", description: "d", page_age: "2026-01-02T00:00:00Z", age: "3 days ago" }] } });
+  }, async () => {
+    const out = await br.search("q", { apiKey: "k" });
+    assert.equal(out[0].title, "B");
+    assert.equal(out[0].snippet, "d");
+    assert.equal(out[0].publishedDate, "2026-01-02T00:00:00Z");
+  });
+});
+
+test("perplexity returns the answer plus citation rows", async () => {
+  const px = PROVIDERS.find((p) => p.name === "perplexity");
+  await withMockFetch(async (url) => {
+    assert.equal(url, "https://api.perplexity.ai/chat/completions");
+    return jsonResponse({ choices: [{ message: { content: "the answer" } }], citations: ["https://c1", "https://c2"] });
+  }, async () => {
+    const out = await px.search("q", { apiKey: "k", numResults: 5 });
+    assert.equal(out[0].title, "Perplexity answer");
+    assert.equal(out[0].content, "the answer");
+    assert.equal(out[1].url, "https://c1");
+  });
+});
+
+test("serpapi maps organic_results[] (link -> url)", async () => {
+  const sp = PROVIDERS.find((p) => p.name === "serpapi");
+  const prev = process.env.SERPAPI_API_KEY;
+  process.env.SERPAPI_API_KEY = "serp-key";
+  try {
+    await withMockFetch(async (url) => {
+      assert.match(url, /^https:\/\/serpapi\.com\/search\.json\?engine=google/);
+      return jsonResponse({ organic_results: [{ title: "S", link: "https://s", snippet: "sn" }] });
+    }, async () => {
+      const out = await sp.search("q");
+      assert.equal(out[0].url, "https://s");
+      assert.equal(out[0].snippet, "sn");
+    });
+  } finally {
+    if (prev !== undefined) process.env.SERPAPI_API_KEY = prev; else delete process.env.SERPAPI_API_KEY;
+  }
+});
+
+test("serpapi error does NOT leak the api key", async () => {
+  const sp = PROVIDERS.find((p) => p.name === "serpapi");
+  const prev = process.env.SERPAPI_API_KEY;
+  process.env.SERPAPI_API_KEY = "super-secret-key";
+  try {
+    await withMockFetch(async () => ({ ok: false, status: 401, json: async () => ({}) }), async () => {
+      await assert.rejects(
+        () => sp.search("q"),
+        (err) => {
+          assert.ok(!err.message.includes("super-secret-key"), "error message must not contain the api key");
+          assert.match(err.message, /\[REDACTED\]/);
+          return true;
+        }
+      );
+    });
+  } finally {
+    if (prev !== undefined) process.env.SERPAPI_API_KEY = prev; else delete process.env.SERPAPI_API_KEY;
+  }
+});

--- a/test/web-search-tools.test.js
+++ b/test/web-search-tools.test.js
@@ -107,7 +107,9 @@ test("fetch_url allows a public host and returns stripped text", async () => {
   registerWebSearchTools({ tools });
   await withFetchUrlEnv(async () => {
     globalThis.fetch = async () => ({ ok: true, status: 200, headers: { get: () => null }, text: async () => "<p>hello <b>world</b></p>" });
-    const { result } = await tools.invoke("fetch_url", { url: "https://example.com/page" });
+    // Literal public IP: skips safeFetch's DNS-resolution layer so this test
+    // stays deterministic in network-restricted CI (no real lookup needed).
+    const { result } = await tools.invoke("fetch_url", { url: "https://93.184.216.34/page" });
     assert.equal(result.error, undefined);
     assert.match(result.content, /hello\s+world/);
   });
@@ -118,13 +120,14 @@ test("fetch_url does not follow a redirect into an internal host", async () => {
   registerWebSearchTools({ tools });
   await withFetchUrlEnv(async () => {
     globalThis.fetch = async (u) => {
-      if (String(u).includes("example.com")) {
+      if (String(u).includes("93.184.216.34")) {
         return { ok: false, status: 302, headers: { get: (h) => (h.toLowerCase() === "location" ? "http://169.254.169.254/" : null) }, text: async () => "" };
       }
       // would only be reached if the guard failed to block the redirect target
       return { ok: true, status: 200, headers: { get: () => null }, text: async () => "INTERNAL-SECRET" };
     };
-    const { result } = await tools.invoke("fetch_url", { url: "https://example.com/redir" });
+    // Literal public IP start URL: no DNS lookup, deterministic offline.
+    const { result } = await tools.invoke("fetch_url", { url: "https://93.184.216.34/redir" });
     assert.ok(result.error, "redirect into an internal host must surface an error");
     assert.ok(!JSON.stringify(result).includes("INTERNAL-SECRET"), "internal body must never be returned");
   });

--- a/test/web-search-tools.test.js
+++ b/test/web-search-tools.test.js
@@ -63,3 +63,69 @@ test("web_search honors WEB_SEARCH_PROVIDER as the default and doesn't double-tr
     if (prev !== undefined) process.env.WEB_SEARCH_PROVIDER = prev; else delete process.env.WEB_SEARCH_PROVIDER;
   }
 });
+
+// --- fetch_url SSRF guard ---
+
+function withFetchUrlEnv(fn) {
+  // fetch_url uses the real providers; ensure Firecrawl is OFF so the plain
+  // (guarded) fetch path runs, and restore global fetch + env after.
+  const prevKey = process.env.FIRECRAWL_API_KEY;
+  const realFetch = globalThis.fetch;
+  delete process.env.FIRECRAWL_API_KEY;
+  return Promise.resolve(fn(realFetch)).finally(() => {
+    globalThis.fetch = realFetch;
+    if (prevKey !== undefined) process.env.FIRECRAWL_API_KEY = prevKey;
+  });
+}
+
+test("fetch_url blocks loopback / private / metadata hosts and non-http protocols", async () => {
+  const tools = new ToolRegistry();
+  registerWebSearchTools({ tools });
+  await withFetchUrlEnv(async () => {
+    let fetched = false;
+    globalThis.fetch = async () => { fetched = true; return { ok: true, status: 200, headers: { get: () => null }, text: async () => "INTERNAL" }; };
+    const blocked = [
+      "http://169.254.169.254/latest/meta-data/iam/security-credentials/role",
+      "http://127.0.0.1:8080/admin",
+      "http://localhost/",
+      "http://10.0.0.5/",
+      "http://192.168.1.1/",
+      "http://[::1]/",
+      "file:///etc/passwd"
+    ];
+    for (const url of blocked) {
+      const { result } = await tools.invoke("fetch_url", { url });
+      assert.ok(result.error, `expected error for ${url}`);
+      assert.match(result.error, /not allowed|must be http|Invalid/i, `unexpected error for ${url}: ${result.error}`);
+    }
+    assert.equal(fetched, false, "global fetch must never be called for a blocked host");
+  });
+});
+
+test("fetch_url allows a public host and returns stripped text", async () => {
+  const tools = new ToolRegistry();
+  registerWebSearchTools({ tools });
+  await withFetchUrlEnv(async () => {
+    globalThis.fetch = async () => ({ ok: true, status: 200, headers: { get: () => null }, text: async () => "<p>hello <b>world</b></p>" });
+    const { result } = await tools.invoke("fetch_url", { url: "https://example.com/page" });
+    assert.equal(result.error, undefined);
+    assert.match(result.content, /hello\s+world/);
+  });
+});
+
+test("fetch_url does not follow a redirect into an internal host", async () => {
+  const tools = new ToolRegistry();
+  registerWebSearchTools({ tools });
+  await withFetchUrlEnv(async () => {
+    globalThis.fetch = async (u) => {
+      if (String(u).includes("example.com")) {
+        return { ok: false, status: 302, headers: { get: (h) => (h.toLowerCase() === "location" ? "http://169.254.169.254/" : null) }, text: async () => "" };
+      }
+      // would only be reached if the guard failed to block the redirect target
+      return { ok: true, status: 200, headers: { get: () => null }, text: async () => "INTERNAL-SECRET" };
+    };
+    const { result } = await tools.invoke("fetch_url", { url: "https://example.com/redir" });
+    assert.ok(result.error, "redirect into an internal host must surface an error");
+    assert.ok(!JSON.stringify(result).includes("INTERNAL-SECRET"), "internal body must never be returned");
+  });
+});

--- a/test/web-search-tools.test.js
+++ b/test/web-search-tools.test.js
@@ -39,3 +39,27 @@ test("web_search returns a clear error when nothing is configured", async () => 
   const { result } = await tools.invoke("web_search", { query: "hi" });
   assert.match(result.error, /no web search provider/i);
 });
+
+test("web_search honors WEB_SEARCH_PROVIDER as the default and doesn't double-try it", async () => {
+  const calls = [];
+  const tools = new ToolRegistry();
+  registerWebSearchTools({ tools }, {
+    providers: [
+      fakeProvider("exa", async () => { calls.push("exa"); throw new Error("exa down"); }),
+      fakeProvider("tavily", async () => { calls.push("tavily"); throw new Error("tavily down"); }),
+      fakeProvider("brave", async () => { calls.push("brave"); return [{ title: "B", url: "u", snippet: "s" }]; })
+    ]
+  });
+  const prev = process.env.WEB_SEARCH_PROVIDER;
+  process.env.WEB_SEARCH_PROVIDER = "tavily";
+  try {
+    const { result } = await tools.invoke("web_search", { query: "hi" });
+    // tavily is tried first (env default), fails, then exa, then brave succeeds.
+    assert.equal(calls[0], "tavily", "env-default provider must be tried first");
+    assert.equal(result.provider, "brave");
+    // tavily appears exactly once despite being both env-default and in the list.
+    assert.equal(calls.filter((c) => c === "tavily").length, 1, "env default must not be tried twice");
+  } finally {
+    if (prev !== undefined) process.env.WEB_SEARCH_PROVIDER = prev; else delete process.env.WEB_SEARCH_PROVIDER;
+  }
+});

--- a/test/web-search-tools.test.js
+++ b/test/web-search-tools.test.js
@@ -1,0 +1,41 @@
+// test/web-search-tools.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ToolRegistry } from "../src/tool-registry.js";
+import { registerWebSearchTools } from "../src/integrations/web-search.js";
+
+function fakeProvider(name, behavior) {
+  return { name, isConfigured: () => true, search: behavior };
+}
+
+test("web_search uses explicit provider and normalizes", async () => {
+  const tools = new ToolRegistry();
+  registerWebSearchTools({ tools }, {
+    providers: [fakeProvider("exa", async () => [{ title: "A", url: "u", snippet: "s" }])]
+  });
+  const { result } = await tools.invoke("web_search", { query: "hi", provider: "exa" });
+  assert.equal(result.provider, "exa");
+  assert.equal(result.results[0].title, "A");
+});
+
+test("web_search falls back to the next configured provider on error", async () => {
+  const tools = new ToolRegistry();
+  registerWebSearchTools({ tools }, {
+    providers: [
+      fakeProvider("exa", async () => { throw new Error("boom"); }),
+      fakeProvider("tavily", async () => [{ title: "B", url: "u", snippet: "s" }])
+    ]
+  });
+  const { result } = await tools.invoke("web_search", { query: "hi" });
+  assert.equal(result.provider, "tavily");
+  assert.equal(result.results[0].title, "B");
+});
+
+test("web_search returns a clear error when nothing is configured", async () => {
+  const tools = new ToolRegistry();
+  registerWebSearchTools({ tools }, {
+    providers: [{ name: "exa", isConfigured: () => false, search: async () => [] }]
+  });
+  const { result } = await tools.invoke("web_search", { query: "hi" });
+  assert.match(result.error, /no web search provider/i);
+});


### PR DESCRIPTION
## Summary

Two independent features (each spec'd + planned under `docs/superpowers/`), plus a requested Mac quality-of-life addition. Built task-by-task with per-task spec + code-quality review. **Full test suite: 138 passing.**

### Part A — Stable config location (`~/.openagi`)
Fixes API keys / setup getting wiped across updates and relaunches. The root cause was a **cwd-relative `.openagi` default** scattered across ~35 call sites, so the daemon read a different folder than the one it wrote to depending on how it was launched.

- New `src/data-dir.js` `resolveDataDir()` — single source of truth, defaults to an absolute `~/.openagi`, honors `OPENAGI_DATA_DIR` (Docker `/data`, etc.). Treats empty/whitespace env as unset.
- Routed **all ~35 state-dir call sites** + the env file + boot loader through it.
- Mac app (`AppState.swift`) data dir → `~/.openagi` so the `.app` and CLI daemon finally share one location.
- Docs + launchd/systemd install scripts pin the location explicitly.

### Part B — External knowledge sources
- **Observation store** gains a `transcript` text kind + durable `existsRef()` dedup; search caps transcript text to avoid context bloat.
- **Web search**: six provider adapters (Exa, Tavily, Firecrawl, Brave, Perplexity, SerpAPI/Google CSE) behind a unified `web_search` tool (provider override + automatic fallback) and a `fetch_url` tool (Firecrawl when configured, else plain fetch). API keys are redacted from error messages (regression-tested).
- **BuildBetter**: `BUILDBETTER_INGEST_MODE` (`signals` default | `transcripts` | `both`) ingests call transcripts (`interview.monologues`, schema-verified live) into searchable memory via `recall_activity`.
- New env vars added to the setup allowlist + README + `.env.example`.

### Mac — open at login
- `SMAppService`-based login item, enabled by default on first launch, with a tray toggle to disable.

## Notes
- Includes `61271b2` (proactive-observer auto-materializes task suggestions) — your in-progress work, committed at your request before the data-dir sweep touched the same file.
- Specs: `docs/superpowers/specs/2026-06-02-*.md`; plan: `docs/superpowers/plans/2026-06-02-config-location-and-knowledge-sources.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)