### PR TITLE
feat(mac): floating widget — Quick Ask overlay (⌥Space) with screen context + nudges

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,18 @@ Privacy posture (non-negotiable):
 
 ---
 
+## Floating widget — Quick Ask
+
+Press **⌥Space** (or click the tray icon → **Quick Ask**) to summon a small always-on-top pill that expands into an ask box over any app.
+
+**Screen context.** On each ask, the widget does an on-device OCR grab of the focused window using the same ScreenCaptureKit pipeline as the pattern miner. The capture exclusion list applies — 1Password, banking sites, 2FA screens, and private windows are never read. Requires **Screen Recording** permission; without it, the ask still works but the panel shows "no screen context."
+
+**Proactive nudges.** Suggestions from the agent's scrutiny layer surface as a badge on the pill. Open the nudge list to send it to chat or dismiss it.
+
+**Toggle.** Enable or disable the whole feature from the tray via **Enable Quick Ask** (on by default).
+
+---
+
 ## MCP servers
 
 Drop a config at `.openagi/mcp.json`:

--- a/docs/superpowers/plans/2026-06-05-floating-widget.md
+++ b/docs/superpowers/plans/2026-06-05-floating-widget.md
@@ -1,0 +1,656 @@
+# Floating Widget ("Quick Ask") Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A native macOS always-on-top pill that expands to ask OpenAGI from anywhere, grounded in the focused window, with a global hotkey (⌥Space) + tray toggle and (phase 2) proactive nudges.
+
+**Architecture:** SwiftUI hosted in an AppKit `NSPanel` inside the existing menu-bar app, talking to the local daemon over HTTP. One JS change: `agent-host` injects `metadata.screenContext` into the turn. Screen context reuses the existing ScreenCapturer + Vision OCR (exclusion-aware).
+
+**Tech Stack:** Swift / AppKit / SwiftUI / ScreenCaptureKit / Vision / Carbon (hotkey); Node 22 ESM (daemon) with `node:test`.
+
+**Verification reality:** The macOS UI cannot be unit-tested here (all existing tests are JS). Each Swift task is verified by `cd mac && swift build` (compile-clean). The one JS seam (`agent-host` screen-context) gets a real `node:test`. A manual smoke checklist (Task 8) is for the user.
+
+**Spec:** `docs/superpowers/specs/2026-06-05-floating-widget-design.md`
+
+---
+
+# Phase 1 — Ask flow
+
+### Task 1: Daemon — inject `metadata.screenContext` into the agent turn
+
+**Files:**
+- Modify: `src/agent-host.js`
+- Test: `test/agent-host-screen-context.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/agent-host-screen-context.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { formatScreenContextBlock } from "../src/agent-host.js";
+
+test("formats a labeled active-window block from screenContext", () => {
+  const block = formatScreenContextBlock({ app: "Safari", window: "Spec — Notion", text: "the deadline is Friday" });
+  assert.match(block, /Active window the user is looking at right now \(Safari · Spec — Notion\)/);
+  assert.match(block, /the deadline is Friday/);
+});
+
+test("returns empty string for missing/empty screenContext", () => {
+  assert.equal(formatScreenContextBlock(null), "");
+  assert.equal(formatScreenContextBlock({ app: "X" }), ""); // no text
+  assert.equal(formatScreenContextBlock({ text: "   " }), ""); // blank text
+});
+
+test("truncates very long screen text to 4000 chars", () => {
+  const block = formatScreenContextBlock({ app: "X", text: "a".repeat(5000) });
+  // 4000 of the body + the surrounding labels; assert body itself is capped
+  const body = block.split("\n").find((l) => l.startsWith("aaaa"));
+  assert.ok(body.length <= 4000, `body should be <= 4000, got ${body.length}`);
+});
+
+test("falls back to 'active window' when app is absent", () => {
+  const block = formatScreenContextBlock({ text: "hello" });
+  assert.match(block, /\(active window\)/);
+});
+```
+
+- [ ] **Step 2: Run it — verify it FAILS**
+
+Run: `node --test test/agent-host-screen-context.test.js`
+Expected: FAIL — `formatScreenContextBlock` is not exported.
+
+- [ ] **Step 3: Implement**
+
+In `src/agent-host.js`, add this exported pure function near the bottom (next to `friendlyProviderLabel`):
+
+```js
+// Format the fresh focused-window context the floating widget attaches to a
+// message (metadata.screenContext = { app, window, text }) into a labeled
+// prompt block. Returns "" when absent/empty. Pure + exported for testing.
+export function formatScreenContextBlock(screenContext) {
+  if (!screenContext || typeof screenContext.text !== "string" || !screenContext.text.trim()) return "";
+  const where = screenContext.window
+    ? `${screenContext.app || "?"} · ${screenContext.window}`
+    : (screenContext.app || "active window");
+  const body = screenContext.text.slice(0, 4000);
+  return `\nActive window the user is looking at right now (${where}):\n${body}\nGround your answer in this if it's relevant; don't quote it back verbatim.\n`;
+}
+```
+
+Then thread it through `instructionsForAgent`:
+- Change the signature: `instructionsForAgent(agent, output, intuitions = [], ambientContext = null, screenContext = null) {`
+- After the `ambientBlock` is built (before the `return` template), add:
+  ```js
+  const screenBlock = formatScreenContextBlock(screenContext);
+  ```
+- In the returned template string, insert `${screenBlock}` immediately after `${ambientBlock}` (so it reads `...${intuitionBlock}${ambientBlock}${screenBlock}\nAnswer the user plainly...`).
+
+And pass it from `handleMessage`: change the existing call (currently `this.instructionsForAgent(agent, output, intuitions, ambientContext)`) to:
+```js
+instructions: this.instructionsForAgent(agent, output, intuitions, ambientContext, input.metadata?.screenContext ?? null),
+```
+
+(The `"overlay"` channel already receives ambient context — the gate is `channel !== "autopilot" && channel !== "cron"` — so no channel-list change is needed.)
+
+- [ ] **Step 4: Run it — verify it PASSES**
+
+Run: `node --test test/agent-host-screen-context.test.js` → 4 pass.
+
+- [ ] **Step 5: Full suite**
+
+Run: `node --test` → all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agent-host.js test/agent-host-screen-context.test.js
+git commit -m "feat: agent-host injects metadata.screenContext into the turn
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Swift — `captureFocusedText()` on ScreenCapturer
+
+**Files:**
+- Modify: `mac/Sources/OpenAGI/Capture/ScreenCapturer.swift`
+
+Factor an on-demand capture+OCR that returns text instead of recording, reusing the existing exclusion check and Vision OCR.
+
+- [ ] **Step 1: Add the `ScreenContext` type + method**
+
+At the top of `ScreenCapturer.swift` (after imports), add:
+
+```swift
+struct ScreenContext {
+  let app: String
+  let window: String?
+  let text: String
+}
+```
+
+Add this method to `ScreenCapturer` (it reuses the private `runOcr` and the same SCScreenshotManager path as `captureOnce`, but returns the OCR text via a continuation and does NOT write to storage):
+
+```swift
+// On-demand grab for the floating widget: OCR the current screen (dominated by
+// the frontmost window) and return the text. Honors the same exclusion list as
+// ambient capture, and returns nil when excluded or when capture/permission is
+// unavailable — callers then proceed without screen context.
+func captureFocusedText() async -> ScreenContext? {
+  let app = NSWorkspace.shared.frontmostApplication
+  let bundleId = app?.bundleIdentifier
+  let appName = app?.localizedName ?? bundleId ?? "(unknown)"
+  let windowTitle = Self.frontmostWindowTitle()
+
+  if CaptureSettings.shared.isExcluded(bundleId: bundleId, windowTitle: windowTitle) {
+    return nil
+  }
+
+  do {
+    let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+    guard let display = content.displays.first else { return nil }
+    let filter = SCContentFilter(display: display, excludingWindows: [])
+    let cfg = SCStreamConfiguration()
+    cfg.width = display.width
+    cfg.height = display.height
+    cfg.minimumFrameInterval = CMTime(value: 1, timescale: 1)
+    cfg.queueDepth = 1
+    cfg.scalesToFit = true
+    cfg.showsCursor = false
+
+    let cgImage = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: cfg)
+    let text: String = await withCheckedContinuation { cont in
+      ocrQueue.async {
+        Self.runOcr(image: cgImage) { ocrText, _ in cont.resume(returning: ocrText) }
+      }
+    }
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty { return ScreenContext(app: appName, window: windowTitle, text: "") }
+    return ScreenContext(app: appName, window: windowTitle, text: String(trimmed.prefix(8000)))
+  } catch {
+    NSLog("OpenAGI overlay capture: \(error.localizedDescription)")
+    return nil
+  }
+}
+```
+
+> Note: `ocrQueue` and `runOcr` are existing private members of `ScreenCapturer`, so this method must live in that class (it does). The daemon caps the text again at 4000 (Task 1); 8000 here is a generous upper bound.
+
+- [ ] **Step 2: Build**
+
+Run: `cd mac && swift build 2>&1 | tail -15`
+Expected: build succeeds (warnings OK).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
+git commit -m "feat(mac): ScreenCapturer.captureFocusedText() for on-demand context
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Swift — AppState overlay networking + nudge state hook
+
+**Files:**
+- Modify: `mac/Sources/OpenAGI/AppState.swift`
+
+- [ ] **Step 1: Add a public ask method + a nudges list**
+
+In `AppState`, add a published nudges array near the other `@Published` props:
+```swift
+@Published var nudges: [Nudge] = []
+
+struct Nudge: Identifiable, Equatable {
+  let id: String
+  let title: String
+  let body: String
+  let category: String
+}
+```
+
+Add a public overlay-ask method (uses the existing private `post`):
+```swift
+struct MessageReply: Decodable { let reply: String? }
+
+// Send a question to the agent from the floating widget, attaching fresh
+// focused-window context. Returns the agent's reply text.
+func askOverlay(text: String, screenContext: ScreenContext?) async throws -> String {
+  var meta: [String: Any] = [:]
+  if let s = screenContext, !s.text.isEmpty {
+    meta["screenContext"] = ["app": s.app, "window": s.window as Any, "text": s.text]
+  }
+  let payload: [String: Any] = ["text": text, "channel": "overlay", "metadata": meta]
+  let body = try JSONSerialization.data(withJSONObject: payload)
+  let data = try await post("/message", body: body)
+  let decoded = try JSONDecoder().decode(MessageReply.self, from: data)
+  return decoded.reply ?? "(no reply)"
+}
+```
+
+`askOverlay` is a method on `AppState`, so it can call the existing `private func post` directly — no visibility change needed.
+
+In `handleSSEEvent`, in the existing `if event == "proactive-suggestion"` block, AFTER the `notify(...)` call, append to the nudge list so the widget can show it:
+```swift
+      let nudge = Nudge(
+        id: suggestionId.isEmpty ? UUID().uuidString : suggestionId,
+        title: parsed.name ?? "OpenAGI noticed something",
+        body: body,
+        category: category
+      )
+      nudges.removeAll { $0.id == nudge.id }
+      nudges.insert(nudge, at: 0)
+      if nudges.count > 20 { nudges = Array(nudges.prefix(20)) }
+```
+(`suggestionId`, `parsed`, `category`, `body` are all already in scope in that block.)
+
+- [ ] **Step 2: Build**
+
+Run: `cd mac && swift build 2>&1 | tail -15` → succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mac/Sources/OpenAGI/AppState.swift
+git commit -m "feat(mac): AppState.askOverlay + nudge list from proactive events
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Swift — the panel, view model, and view
+
+**Files:**
+- Create: `mac/Sources/OpenAGI/Overlay/OverlayState.swift`
+- Create: `mac/Sources/OpenAGI/Overlay/OverlayView.swift`
+- Create: `mac/Sources/OpenAGI/Overlay/OverlayController.swift`
+
+- [ ] **Step 1: `OverlayState.swift`**
+
+```swift
+import Foundation
+import SwiftUI
+
+@MainActor
+final class OverlayState: ObservableObject {
+  static let shared = OverlayState()
+
+  @Published var expanded = false
+  @Published var question = ""
+  @Published var answer: String = ""
+  @Published var isLoading = false
+  @Published var error: String? = nil
+  @Published var contextNote: String? = nil   // e.g. "reading Safari" / "no screen context"
+
+  func ask() async {
+    let q = question.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !q.isEmpty else { return }
+    isLoading = true; error = nil; answer = ""
+    let ctx = await ScreenCapturer.shared.captureFocusedText()
+    if let ctx, !ctx.text.isEmpty {
+      contextNote = "reading \(ctx.app)"
+    } else {
+      contextNote = "no screen context"
+    }
+    do {
+      answer = try await AppState.shared.askOverlay(text: q, screenContext: ctx)
+    } catch {
+      self.error = error.localizedDescription
+    }
+    isLoading = false
+  }
+}
+```
+
+- [ ] **Step 2: `OverlayView.swift`**
+
+```swift
+import SwiftUI
+
+struct OverlayView: View {
+  @ObservedObject var state = OverlayState.shared
+  @ObservedObject var app = AppState.shared
+  var onCollapse: () -> Void = {}
+
+  var body: some View {
+    if state.expanded {
+      expandedPanel
+    } else {
+      pill
+    }
+  }
+
+  private var pill: some View {
+    Button(action: { state.expanded = true }) {
+      ZStack {
+        Circle().fill(Color.accentColor).frame(width: 16, height: 16)
+        if !app.nudges.isEmpty {
+          Text("\(app.nudges.count)")
+            .font(.system(size: 9, weight: .bold)).foregroundColor(.white)
+        }
+      }
+      .padding(8)
+    }
+    .buttonStyle(.plain)
+    .background(.ultraThinMaterial, in: Circle())
+  }
+
+  private var expandedPanel: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack {
+        Text("Ask OpenAGI").font(.caption).foregroundStyle(.secondary)
+        Spacer()
+        Button(action: { state.expanded = false; onCollapse() }) {
+          Image(systemName: "xmark.circle.fill").foregroundStyle(.tertiary)
+        }.buttonStyle(.plain)
+      }
+      if app.status == .down {
+        Text("OpenAGI is offline").font(.caption).foregroundStyle(.red)
+      }
+      TextField("Ask about what you're looking at…", text: $state.question, onCommit: { Task { await state.ask() } })
+        .textFieldStyle(.roundedBorder)
+        .disabled(app.status == .down)
+      if let note = state.contextNote {
+        Text(note).font(.system(size: 10)).foregroundStyle(.tertiary)
+      }
+      if state.isLoading {
+        ProgressView().controlSize(.small)
+      } else if let err = state.error {
+        Text(err).font(.caption).foregroundStyle(.red)
+      } else if !state.answer.isEmpty {
+        ScrollView { Text(state.answer).font(.callout).textSelection(.enabled).frame(maxWidth: .infinity, alignment: .leading) }
+          .frame(maxHeight: 220)
+        Button("Continue in chat") { app.openDashboard(path: "/?tab=chat") }
+          .font(.caption).buttonStyle(.plain).foregroundStyle(.blue)
+      }
+    }
+    .padding(12)
+    .frame(width: 320)
+    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+  }
+}
+```
+
+- [ ] **Step 3: `OverlayController.swift`**
+
+```swift
+import AppKit
+import SwiftUI
+
+@MainActor
+final class OverlayController {
+  static let shared = OverlayController()
+  private var panel: NSPanel?
+
+  private static let enabledKey = "openagi.overlay.enabled"
+  private static let frameKey = "openagi.overlay.originX" // y stored alongside
+
+  static var isEnabled: Bool {
+    UserDefaults.standard.object(forKey: enabledKey) == nil ? true : UserDefaults.standard.bool(forKey: enabledKey)
+  }
+  static func setEnabled(_ on: Bool) {
+    UserDefaults.standard.set(on, forKey: enabledKey)
+    if on { shared.show() } else { shared.hide() }
+  }
+
+  func startIfEnabled() { if Self.isEnabled { show() } }
+
+  func show() {
+    if panel == nil { panel = makePanel() }
+    positionPanel()
+    panel?.orderFrontRegardless()
+  }
+
+  func hide() { panel?.orderOut(nil) }
+
+  func toggle() {
+    if panel?.isVisible == true {
+      // toggle expands/collapses rather than hiding entirely
+      OverlayState.shared.expanded.toggle()
+      sizeToContent()
+    } else {
+      OverlayState.shared.expanded = true
+      show(); sizeToContent()
+    }
+  }
+
+  private func makePanel() -> NSPanel {
+    let p = NSPanel(
+      contentRect: NSRect(x: 0, y: 0, width: 320, height: 60),
+      styleMask: [.nonactivatingPanel, .borderless, .fullSizeContentView],
+      backing: .buffered, defer: false)
+    p.isFloatingPanel = true
+    p.level = .statusBar
+    p.hidesOnDeactivate = false
+    p.isMovableByWindowBackground = true
+    p.backgroundColor = .clear
+    p.hasShadow = true
+    p.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+    let host = NSHostingView(rootView: OverlayView(onCollapse: { [weak self] in self?.sizeToContent() }))
+    host.translatesAutoresizingMaskIntoConstraints = true
+    p.contentView = host
+    return p
+  }
+
+  private func sizeToContent() {
+    guard let p = panel, let host = p.contentView else { return }
+    let fitting = host.fittingSize
+    var frame = p.frame
+    let newH = max(44, fitting.height)
+    frame.origin.y += (frame.height - newH) // keep top-left anchored
+    frame.size.height = newH
+    frame.size.width = OverlayState.shared.expanded ? 320 : 44
+    p.setFrame(frame, display: true, animate: false)
+  }
+
+  private func positionPanel() {
+    guard let p = panel, let screen = NSScreen.main else { return }
+    let d = UserDefaults.standard
+    if d.object(forKey: Self.frameKey) != nil {
+      let x = d.double(forKey: Self.frameKey)
+      let y = d.double(forKey: "openagi.overlay.originY")
+      p.setFrameOrigin(NSPoint(x: x, y: y))
+    } else {
+      // default: bottom-right inset
+      let vf = screen.visibleFrame
+      p.setFrameOrigin(NSPoint(x: vf.maxX - 360, y: vf.minY + 80))
+    }
+    sizeToContent()
+  }
+
+  func persistPosition() {
+    guard let p = panel else { return }
+    UserDefaults.standard.set(Double(p.frame.origin.x), forKey: Self.frameKey)
+    UserDefaults.standard.set(Double(p.frame.origin.y), forKey: "openagi.overlay.originY")
+  }
+}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `cd mac && swift build 2>&1 | tail -20` → succeeds. Fix any compile errors (SwiftUI `onCommit` is deprecated but compiles; if the toolchain rejects it, switch the TextField to `.onSubmit { Task { await state.ask() } }`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mac/Sources/OpenAGI/Overlay/
+git commit -m "feat(mac): floating overlay panel, view, and ask view-model
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Swift — global hotkey + app/tray wiring
+
+**Files:**
+- Create: `mac/Sources/OpenAGI/Overlay/HotkeyManager.swift`
+- Modify: `mac/Sources/OpenAGI/AppDelegate.swift`
+- Modify: `mac/Sources/OpenAGI/TrayController.swift`
+
+- [ ] **Step 1: `HotkeyManager.swift` (Carbon, ⌥Space)**
+
+```swift
+import AppKit
+import Carbon.HIToolbox
+
+// System-wide hotkey via Carbon RegisterEventHotKey (needs no Accessibility
+// permission). Default: ⌥Space. Fires onHotkey on the main actor.
+@MainActor
+final class HotkeyManager {
+  static let shared = HotkeyManager()
+  private var ref: EventHotKeyRef?
+  private var handler: EventHandlerRef?
+  var onHotkey: () -> Void = {}
+
+  func register() {
+    var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: OSType(kEventHotKeyPressed))
+    InstallEventHandler(GetApplicationEventTarget(), { _, _, userData -> OSStatus in
+      let me = Unmanaged<HotkeyManager>.fromOpaque(userData!).takeUnretainedValue()
+      Task { @MainActor in me.onHotkey() }
+      return noErr
+    }, 1, &eventType, Unmanaged.passUnretained(self).toOpaque(), &handler)
+
+    let hotKeyID = EventHotKeyID(signature: OSType(0x4F41_4749 /* 'OAGI' */), id: 1)
+    let status = RegisterEventHotKey(UInt32(kVK_Space), UInt32(optionKey), hotKeyID, GetApplicationEventTarget(), 0, &ref)
+    if status != noErr { NSLog("OpenAGI: hotkey registration failed (\(status)) — tray-only") }
+  }
+
+  func unregister() {
+    if let ref { UnregisterEventHotKey(ref) }
+    if let handler { RemoveEventHandler(handler) }
+    ref = nil; handler = nil
+  }
+}
+```
+
+- [ ] **Step 2: Wire into `AppDelegate.applicationDidFinishLaunching`**
+
+Inside the `Task { @MainActor in ... }` block, after `ReplayController.shared.start()`, add:
+```swift
+      OverlayController.shared.startIfEnabled()
+      HotkeyManager.shared.onHotkey = { OverlayController.shared.toggle() }
+      HotkeyManager.shared.register()
+```
+And in `applicationWillTerminate`'s `Task { @MainActor in ... }`, before `DaemonController.shared.stop()`, add:
+```swift
+      OverlayController.shared.persistPosition()
+      HotkeyManager.shared.unregister()
+```
+
+- [ ] **Step 3: Tray toggle + Quick Ask item in `TrayController.swift`**
+
+In `footerSection`, just above the existing `Toggle("Open at Login", ...)`, add:
+```swift
+      Button("Quick Ask  ⌥Space") { OverlayController.shared.toggle() }
+      Toggle("Enable Quick Ask", isOn: Binding(
+        get: { OverlayController.isEnabled },
+        set: { OverlayController.setEnabled($0) }
+      ))
+```
+
+- [ ] **Step 4: Build**
+
+Run: `cd mac && swift build 2>&1 | tail -20` → succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mac/Sources/OpenAGI/Overlay/HotkeyManager.swift mac/Sources/OpenAGI/AppDelegate.swift mac/Sources/OpenAGI/TrayController.swift
+git commit -m "feat(mac): ⌥Space global hotkey + tray Quick Ask toggle, wired in
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+# Phase 2 — Proactive nudges in the pill
+
+### Task 6: Swift — render nudges in the expanded panel
+
+**Files:**
+- Modify: `mac/Sources/OpenAGI/Overlay/OverlayView.swift`
+
+The badge on the collapsed pill already reflects `app.nudges.count` (Task 4). Now show the list when expanded and let the user act.
+
+- [ ] **Step 1: Add a nudges section to `expandedPanel`**
+
+In `OverlayView.expandedPanel`, after the answer block (inside the `VStack`), add:
+```swift
+      if !app.nudges.isEmpty {
+        Divider()
+        Text("Nudges").font(.system(size: 10, weight: .semibold)).foregroundStyle(.secondary)
+        ForEach(app.nudges.prefix(4)) { n in
+          HStack(alignment: .top, spacing: 6) {
+            VStack(alignment: .leading, spacing: 1) {
+              Text(n.title).font(.system(size: 11, weight: .medium))
+              if !n.body.isEmpty { Text(n.body).font(.system(size: 10)).foregroundStyle(.secondary).lineLimit(2) }
+            }
+            Spacer()
+            Button(action: { app.openDashboard(path: "/?tab=chat&suggestion=\(n.id)") }) {
+              Image(systemName: "arrow.up.right.square")
+            }.buttonStyle(.plain).help("Review in chat")
+            Button(action: { app.nudges.removeAll { $0.id == n.id } }) {
+              Image(systemName: "xmark")
+            }.buttonStyle(.plain).help("Dismiss")
+          }
+        }
+      }
+```
+
+(Reviewing a nudge routes into the dashboard chat with the suggestion id — reusing the existing approve/dismiss surface — and "Dismiss" just clears it from the pill. This keeps Phase 2 backend-free, per the spec.)
+
+- [ ] **Step 2: Build**
+
+Run: `cd mac && swift build 2>&1 | tail -20` → succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mac/Sources/OpenAGI/Overlay/OverlayView.swift
+git commit -m "feat(mac): show proactive nudges in the overlay panel
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Docs
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1:** Add a short "Floating widget (Quick Ask)" subsection: ⌥Space (or the tray) opens a floating pill to ask OpenAGI about whatever you're looking at; answers are grounded in the focused window via on-device OCR (honors the capture exclusion list; needs Screen Recording permission, degrades gracefully without it); proactive nudges appear in the pill. Toggle it from the tray ("Enable Quick Ask").
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: floating widget (Quick Ask)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Manual smoke checklist (for the user — not automated)
+
+Document in the PR body. The user runs the packaged app and verifies:
+- [ ] ⌥Space toggles the pill/panel from any app (incl. a fullscreen app).
+- [ ] The panel floats above other windows and doesn't steal focus (you can keep typing in the app behind it).
+- [ ] Asking a question about the visible window returns an answer that reflects on-screen content (Screen Recording granted).
+- [ ] With an excluded app frontmost (e.g. 1Password), the answer notes "no screen context" and nothing is OCR'd.
+- [ ] A proactive suggestion shows a badge on the pill and appears in the panel's Nudges list.
+- [ ] "Enable Quick Ask" off in the tray hides the widget; on shows it; position persists across restarts.
+
+---
+
+## Final verification
+- [ ] `node --test` — full suite green (Task 1's test included).
+- [ ] `cd mac && swift build` — compile-clean.
+- [ ] `grep -rn "formatScreenContextBlock" src test` — used + tested.

--- a/docs/superpowers/specs/2026-06-05-floating-widget-design.md
+++ b/docs/superpowers/specs/2026-06-05-floating-widget-design.md
@@ -1,0 +1,144 @@
+# Floating Widget ("Quick Ask") — Design
+
+**Date:** 2026-06-05
+**Status:** Approved (brainstorming) — pending implementation plan
+**Branch:** `feat/floating-widget` (stacks on `feat/external-knowledge-sources`)
+
+## Goal
+A native macOS always-on-top floating widget (a collapsed pill that expands into a
+panel) that lets the user ask OpenAGI a question from anywhere, grounded in the
+content of the window they're looking at, and surfaces proactive nudges. This closes
+the last of the three littlebird.ai gaps (web search and BuildBetter transcripts are
+already shipped on the sibling branch).
+
+## Decisions (from brainstorming)
+- **Form factor:** floating pill (collapsed `●`) that expands into a panel.
+- **Summon:** global hotkey (default **⌥Space**) **and** a tray menu item.
+- **v1 behavior:** ask → answer inline, **plus** proactive nudges in the panel.
+- **Context:** live-grab the focused window per ask, reusing the existing
+  ScreenCapturer + Vision OCR pipeline (honoring the privacy exclusion list).
+
+## Architecture
+The widget is added to the existing SwiftUI menu-bar app (`mac/Sources/OpenAGI`). It
+hosts SwiftUI inside a native AppKit `NSPanel` and talks to the daemon the app already
+manages (`http://127.0.0.1:43210`) over HTTP — no new service, no new process. One
+small daemon-side (JS) change lets a message carry fresh screen context and is the
+single automated-test seam.
+
+```
+⌥Space / pill tap
+  → FocusedWindowGrabber: OCR frontmost window (privacy-filtered) → {app, window, text}
+  → POST /message { text, channel:"overlay", metadata:{ screenContext } }
+  → daemon agent-host injects screenContext into the turn context → agent answers
+  → OverlayView renders the reply (markdown) with a "continue in chat" link
+```
+
+## Components
+
+### macOS (new files under `mac/Sources/OpenAGI/Overlay/`)
+1. **`OverlayPanelController.swift`** (AppKit) — owns an `NSPanel`:
+   - style: `[.nonactivatingPanel, .borderless]`; `isFloatingPanel = true`;
+     `level = .statusBar`; `hidesOnDeactivate = false`;
+     `collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]`
+     so it floats over every Space/app incl. fullscreen without stealing focus.
+   - hosts an `NSHostingView(rootView: OverlayView)`.
+   - manages collapsed↔expanded sizing, draggable position persisted to
+     `UserDefaults` (`openagi.overlay.frame`), and `show()/hide()/toggle()`.
+   - the panel's own window is excluded from capture (so the pill never OCRs itself —
+     add its `windowNumber` to the `SCContentFilter` excluded set, or rely on the
+     frontmost-window targeting which never targets a non-activating panel).
+2. **`OverlayView.swift`** (SwiftUI) — observes `OverlayState`:
+   - **collapsed:** a small `●` pill; in Phase 2 a badge with the nudge count.
+   - **expanded:** a text field ("Ask OpenAGI…"), submit affordance (Return), an
+     answer area rendering markdown, a "Continue in chat" button (opens the dashboard
+     via the existing `AppState.openDashboard`), a subtle "reading <app>"/"no screen
+     context" indicator, and (Phase 2) a nudges list.
+3. **`OverlayState.swift`** (`@MainActor ObservableObject`) — the view model:
+   - `ask(_ question:)`: calls `FocusedWindowGrabber`, POSTs `/message`, sets
+     `answer`/`isLoading`/`error`. Daemon-health aware via `AppState.shared`.
+   - holds `nudges: [Suggestion]` fed from `AppState` (Phase 2).
+4. **`HotkeyManager.swift`** — registers a system-wide hotkey via Carbon
+   `RegisterEventHotKey` (default ⌥Space; constant in v1, configurable later). On fire,
+   calls `OverlayPanelController.toggle()`. Carbon hotkeys need no Accessibility
+   permission. Unregisters on teardown.
+5. **`FocusedWindowGrabber.swift`** — a focused, on-demand capture factored from
+   `ScreenCapturer.captureOnce()`:
+   - `func grab() async -> ScreenContext?` returns `{ app, window, text }` where `text`
+     is the Vision-OCR'd frontmost window content, truncated (e.g. 4000 chars).
+   - honors `CaptureSettings.shared.isExcluded(bundleId:windowTitle:)` — returns `nil`
+     (no context) for excluded apps/windows (1Password, banking, etc.).
+   - returns `nil` quietly if Screen Recording permission is absent.
+
+### macOS (edits to existing files)
+6. **`AppDelegate.swift`** — instantiate `OverlayPanelController` + `HotkeyManager` at
+   startup (gated on the overlay-enabled setting), tear down on quit.
+7. **`TrayController.swift`** — add a "Quick Ask  ⌥Space" item that toggles the panel,
+   and an "Enable Quick Ask" toggle (persisted in `UserDefaults`
+   `openagi.overlay.enabled`, default **on**; mirrors the login-item toggle pattern).
+8. **`AppState.swift`** — expose the proactive-suggestion list it already receives via
+   `SSEDelegate` (`/events`) so `OverlayState` can show nudges (Phase 2); add a small
+   `postMessage(text:metadata:)` helper if one isn't already present.
+
+### Daemon (JS — the one backend change + its test)
+9. **`src/agent-host.js`** — when an inbound message has
+   `metadata.screenContext = { app, window, text }`, include it in the turn's context
+   block (the same place `observations.getRecentContext` output is added), clearly
+   labeled (e.g. `Active window (<app> — <window>):\n<text>`). Treat the `"overlay"`
+   channel as a context-bearing channel (like `"local"`). Truncate the injected text
+   defensively. **No secret/PII handling beyond honoring the client-side exclusion
+   list** (the grabber already filtered).
+
+## Data flow & transport
+- **Ask:** synchronous `POST /message` returns the agent's reply in the HTTP response
+  (`channels.handleLocalMessage`), so Phase 1 renders the full answer on completion
+  with a thinking state. Token-by-token streaming via the existing `/events` SSE is a
+  deferred enhancement, not required for v1.
+- **Nudges (Phase 2):** reuse the existing SSE path — `SSEDelegate` already routes
+  `proactive-suggestion` events into `AppState`; `OverlayState` mirrors that list and
+  uses the existing suggestion accept/dismiss endpoints.
+
+## Error handling
+- Daemon offline → panel shows "OpenAGI is offline" (from `AppState.status`); ask
+  disabled.
+- OCR unavailable / window excluded → ask proceeds **without** screen context, with a
+  subtle "no screen context" note (never block the ask).
+- Hotkey registration fails (conflict) → log + fall back to tray-only; surface a one-time
+  note in the tray.
+- `/message` non-200 → inline error in the panel, ask remains retryable.
+
+## Privacy & permissions
+- **Screen Recording** permission (reused from ambient capture) gates OCR; absent → no
+  context, ask still works.
+- The `CaptureSettings` exclusion list is honored on every grab, so excluded
+  apps/windows are never read.
+- The panel shows which app it read ("reading Safari…") so context capture is never
+  invisible.
+- Carbon global hotkey needs no permission.
+
+## Testing & honest constraints
+- The macOS UI (NSPanel, hotkey, OCR grab, SwiftUI) is **not** unit-testable in this
+  repo (all existing tests are JS) — it is verified by `swift build` (compile-clean) and
+  manual runtime checks by the user (the panel floats, ⌥Space toggles, an ask returns a
+  grounded answer, excluded apps yield no context).
+- **Automated test (JS):** `test/agent-host-screen-context.test.js` — a message with
+  `metadata.screenContext` produces a turn whose context block contains the labeled
+  active-window text, and the `"overlay"` channel is handled like `"local"`. This is the
+  one behavior with a real seam, so it gets a real test.
+
+## Out of scope (YAGNI)
+- Token-by-token answer streaming (deferred; sync reply is enough for v1).
+- Configurable hotkey UI (default ⌥Space hardcoded for v1; wire a setting later).
+- Inline action-approval buttons in the panel (the agent's draft/pending-action
+  surfaces stay in the dashboard for v1; "continue in chat" bridges there).
+- Windows/Linux equivalents (macOS-only feature).
+
+## Build sequencing (for the plan)
+**Phase 1 — ask flow**
+1. Daemon: `agent-host` `screenContext` injection + `overlay` channel + JS test.
+2. `FocusedWindowGrabber` (factor from ScreenCapturer) — returns OCR'd focused-window text, exclusion-aware.
+3. `OverlayPanelController` + `OverlayView` + `OverlayState` — the pill/panel and ask flow (POST /message with screenContext).
+4. `HotkeyManager` (⌥Space) + `AppDelegate` wiring + `TrayController` toggle.
+5. `swift build` green; manual smoke checklist documented.
+
+**Phase 2 — proactive nudges**
+6. `AppState` exposes the suggestion list; `OverlayState` mirrors it; `OverlayView` shows badge + list with accept/dismiss via existing endpoints.

--- a/mac/Sources/OpenAGI/AppDelegate.swift
+++ b/mac/Sources/OpenAGI/AppDelegate.swift
@@ -22,6 +22,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
       UpdateController.shared.start()
       CaptureController.shared.start()
       ReplayController.shared.start()
+      OverlayController.shared.startIfEnabled()
+      HotkeyManager.shared.onHotkey = { OverlayController.shared.toggle() }
+      HotkeyManager.shared.register()
 
       // Wake observer: the moment macOS resumes from sleep we (1) probe
       // /health to see if the daemon survived the sleep cycle, restart
@@ -52,6 +55,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
       ReplayController.shared.stop()
       CaptureController.shared.stop()
       _ = await CaptureBridge.flushNow()
+      OverlayController.shared.persistPosition()
+      HotkeyManager.shared.unregister()
       DaemonController.shared.stop()
     }
   }

--- a/mac/Sources/OpenAGI/AppState.swift
+++ b/mac/Sources/OpenAGI/AppState.swift
@@ -26,6 +26,14 @@ final class AppState: ObservableObject {
   @Published var recentSessions: [SessionSummary] = []
   @Published var topTasks: [TaskSummary] = []
   @Published var paused: Bool = false
+  @Published var nudges: [Nudge] = []
+
+  struct Nudge: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let body: String
+    let category: String
+  }
 
   private var pollTimer: Timer?
   private var sseTask: URLSessionDataTask?
@@ -262,6 +270,15 @@ final class AppState: ObservableObject {
       let suggestionId = parseField(data, "id") ?? ""
       let pathPart = suggestionId.isEmpty ? "/?tab=chat" : "/?tab=chat&suggestion=\(urlEncode(suggestionId))"
       notify(title: title, body: body, path: pathPart)
+      let nudge = Nudge(
+        id: suggestionId.isEmpty ? UUID().uuidString : suggestionId,
+        title: parsed.name ?? "OpenAGI noticed something",
+        body: body,
+        category: category
+      )
+      nudges.removeAll { $0.id == nudge.id }
+      nudges.insert(nudge, at: 0)
+      if nudges.count > 20 { nudges = Array(nudges.prefix(20)) }
     }
     if event == "daily-recap" {
       // Story 7: evening "what did you get done today" notification.
@@ -332,6 +349,24 @@ final class AppState: ObservableObject {
     content.userInfo = ["path": path]
     let req = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
     UNUserNotificationCenter.current().add(req)
+  }
+
+  struct MessageReply: Decodable { let reply: String? }
+
+  // Send a question to the agent from the floating widget, attaching fresh
+  // focused-window context. Returns the agent's reply text.
+  func askOverlay(text: String, screenContext: ScreenContext?) async throws -> String {
+    var meta: [String: Any] = [:]
+    if let s = screenContext, !s.text.isEmpty {
+      var sc: [String: Any] = ["app": s.app, "text": s.text]
+      if let w = s.window { sc["window"] = w }
+      meta["screenContext"] = sc
+    }
+    let payload: [String: Any] = ["text": text, "channel": "overlay", "metadata": meta]
+    let body = try JSONSerialization.data(withJSONObject: payload)
+    let data = try await post("/message", body: body)
+    let decoded = try JSONDecoder().decode(MessageReply.self, from: data)
+    return decoded.reply ?? "(no reply)"
   }
 
   func togglePause() async {

--- a/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
+++ b/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
@@ -119,7 +119,19 @@ final class ScreenCapturer {
 
     do {
       let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
-      guard let display = content.displays.first else { return nil }
+      // Pick the display the frontmost window is actually on — on multi-monitor
+      // setups the focused window may not be on the primary display, and grabbing
+      // displays.first would OCR the wrong monitor. Match the front app's
+      // on-screen window (preferring the AX focused-window title, else its
+      // largest window) and use the display containing that window's center.
+      let frontPid = app?.processIdentifier
+      let appWindows = content.windows.filter { $0.owningApplication?.processID == frontPid && $0.isOnScreen }
+      let frontWindow = appWindows.first { ($0.title ?? "") == (windowTitle ?? "") && !(windowTitle ?? "").isEmpty }
+        ?? appWindows.max { ($0.frame.width * $0.frame.height) < ($1.frame.width * $1.frame.height) }
+      let display = frontWindow.flatMap { w in
+        content.displays.first { $0.frame.contains(CGPoint(x: w.frame.midX, y: w.frame.midY)) }
+      } ?? content.displays.first
+      guard let display else { return nil }
       var excluded: [SCWindow] = []
       if let wn = excludingWindowNumber {
         excluded = content.windows.filter { $0.windowID == CGWindowID(wn) }

--- a/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
+++ b/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
@@ -132,20 +132,33 @@ final class ScreenCapturer {
         content.displays.first { $0.frame.contains(CGPoint(x: w.frame.midX, y: w.frame.midY)) }
       } ?? content.displays.first
       guard let display else { return nil }
-      var excluded: [SCWindow] = []
-      if let wn = excludingWindowNumber {
-        excluded += content.windows.filter { $0.windowID == CGWindowID(wn) }
-      }
-      // Also cut out any window belonging to an excluded app/title, so OCR never
-      // reads e.g. 1Password sitting beside the focused app on the same display
-      // (the frontmost-only privacy check above doesn't cover other visible windows).
-      excluded += content.windows.filter { w in
-        CaptureSettings.shared.isExcluded(bundleId: w.owningApplication?.bundleIdentifier, windowTitle: w.title)
-      }
-      let filter = SCContentFilter(display: display, excludingWindows: excluded)
+      let filter: SCContentFilter
       let cfg = SCStreamConfiguration()
-      cfg.width = display.width
-      cfg.height = display.height
+      if let frontWindow {
+        // We matched the focused window: capture JUST that window. A
+        // display-level grab would OCR every other (non-excluded) window
+        // sharing the monitor — side-by-side Mail/Slack/docs text — and
+        // attribute it to the focused app, misgrounding the answer.
+        filter = SCContentFilter(desktopIndependentWindow: frontWindow)
+        let scale = CGFloat(filter.pointPixelScale)
+        cfg.width = max(1, Int(frontWindow.frame.width * scale))
+        cfg.height = max(1, Int(frontWindow.frame.height * scale))
+      } else {
+        // No window match — fall back to the whole display, minus the overlay
+        // and any window belonging to an excluded app/title, so OCR never
+        // reads e.g. 1Password sitting beside the focused app on the display
+        // (the frontmost-only privacy check above doesn't cover other windows).
+        var excluded: [SCWindow] = []
+        if let wn = excludingWindowNumber {
+          excluded += content.windows.filter { $0.windowID == CGWindowID(wn) }
+        }
+        excluded += content.windows.filter { w in
+          CaptureSettings.shared.isExcluded(bundleId: w.owningApplication?.bundleIdentifier, windowTitle: w.title)
+        }
+        filter = SCContentFilter(display: display, excludingWindows: excluded)
+        cfg.width = display.width
+        cfg.height = display.height
+      }
       cfg.minimumFrameInterval = CMTime(value: 1, timescale: 1)
       cfg.queueDepth = 1
       cfg.scalesToFit = true

--- a/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
+++ b/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
@@ -106,7 +106,8 @@ final class ScreenCapturer {
   // the frontmost window) and return the text. Honors the same exclusion list as
   // ambient capture, and returns nil when excluded or when capture/permission is
   // unavailable — callers then proceed without screen context.
-  func captureFocusedText() async -> ScreenContext? {
+  func captureFocusedText(excludingWindowNumber: Int? = nil) async -> ScreenContext? {
+    if !CaptureSettings.shared.isActiveNow() { return nil }
     let app = NSWorkspace.shared.frontmostApplication
     let bundleId = app?.bundleIdentifier
     let appName = app?.localizedName ?? bundleId ?? "(unknown)"
@@ -119,7 +120,11 @@ final class ScreenCapturer {
     do {
       let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
       guard let display = content.displays.first else { return nil }
-      let filter = SCContentFilter(display: display, excludingWindows: [])
+      var excluded: [SCWindow] = []
+      if let wn = excludingWindowNumber {
+        excluded = content.windows.filter { $0.windowID == CGWindowID(wn) }
+      }
+      let filter = SCContentFilter(display: display, excludingWindows: excluded)
       let cfg = SCStreamConfiguration()
       cfg.width = display.width
       cfg.height = display.height

--- a/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
+++ b/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
@@ -134,7 +134,13 @@ final class ScreenCapturer {
       guard let display else { return nil }
       var excluded: [SCWindow] = []
       if let wn = excludingWindowNumber {
-        excluded = content.windows.filter { $0.windowID == CGWindowID(wn) }
+        excluded += content.windows.filter { $0.windowID == CGWindowID(wn) }
+      }
+      // Also cut out any window belonging to an excluded app/title, so OCR never
+      // reads e.g. 1Password sitting beside the focused app on the same display
+      // (the frontmost-only privacy check above doesn't cover other visible windows).
+      excluded += content.windows.filter { w in
+        CaptureSettings.shared.isExcluded(bundleId: w.owningApplication?.bundleIdentifier, windowTitle: w.title)
       }
       let filter = SCContentFilter(display: display, excludingWindows: excluded)
       let cfg = SCStreamConfiguration()

--- a/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
+++ b/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
@@ -13,6 +13,12 @@ import Vision
 // exclusion check (so private windows / banking sites are skipped before
 // OCR runs).
 
+struct ScreenContext {
+  let app: String
+  let window: String?
+  let text: String
+}
+
 @MainActor
 final class ScreenCapturer {
   static let shared = ScreenCapturer()
@@ -93,6 +99,47 @@ final class ScreenCapturer {
       }
     } catch {
       NSLog("OpenAGI capture: \(error.localizedDescription)")
+    }
+  }
+
+  // On-demand grab for the floating widget: OCR the current screen (dominated by
+  // the frontmost window) and return the text. Honors the same exclusion list as
+  // ambient capture, and returns nil when excluded or when capture/permission is
+  // unavailable — callers then proceed without screen context.
+  func captureFocusedText() async -> ScreenContext? {
+    let app = NSWorkspace.shared.frontmostApplication
+    let bundleId = app?.bundleIdentifier
+    let appName = app?.localizedName ?? bundleId ?? "(unknown)"
+    let windowTitle = Self.frontmostWindowTitle()
+
+    if CaptureSettings.shared.isExcluded(bundleId: bundleId, windowTitle: windowTitle) {
+      return nil
+    }
+
+    do {
+      let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+      guard let display = content.displays.first else { return nil }
+      let filter = SCContentFilter(display: display, excludingWindows: [])
+      let cfg = SCStreamConfiguration()
+      cfg.width = display.width
+      cfg.height = display.height
+      cfg.minimumFrameInterval = CMTime(value: 1, timescale: 1)
+      cfg.queueDepth = 1
+      cfg.scalesToFit = true
+      cfg.showsCursor = false
+
+      let cgImage = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: cfg)
+      let text: String = await withCheckedContinuation { cont in
+        ocrQueue.async {
+          Self.runOcr(image: cgImage) { ocrText, _ in cont.resume(returning: ocrText) }
+        }
+      }
+      let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+      if trimmed.isEmpty { return ScreenContext(app: appName, window: windowTitle, text: "") }
+      return ScreenContext(app: appName, window: windowTitle, text: String(trimmed.prefix(8000)))
+    } catch {
+      NSLog("OpenAGI overlay capture: \(error.localizedDescription)")
+      return nil
     }
   }
 

--- a/mac/Sources/OpenAGI/Overlay/HotkeyManager.swift
+++ b/mac/Sources/OpenAGI/Overlay/HotkeyManager.swift
@@ -1,0 +1,31 @@
+import AppKit
+import Carbon.HIToolbox
+
+// System-wide hotkey via Carbon RegisterEventHotKey (needs no Accessibility
+// permission). Default: ⌥Space. Fires onHotkey on the main actor.
+@MainActor
+final class HotkeyManager {
+  static let shared = HotkeyManager()
+  private var ref: EventHotKeyRef?
+  private var handler: EventHandlerRef?
+  var onHotkey: () -> Void = {}
+
+  func register() {
+    var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: OSType(kEventHotKeyPressed))
+    InstallEventHandler(GetApplicationEventTarget(), { _, _, userData -> OSStatus in
+      let me = Unmanaged<HotkeyManager>.fromOpaque(userData!).takeUnretainedValue()
+      Task { @MainActor in me.onHotkey() }
+      return noErr
+    }, 1, &eventType, Unmanaged.passUnretained(self).toOpaque(), &handler)
+
+    let hotKeyID = EventHotKeyID(signature: OSType(0x4F41_4749), id: 1)
+    let status = RegisterEventHotKey(UInt32(kVK_Space), UInt32(optionKey), hotKeyID, GetApplicationEventTarget(), 0, &ref)
+    if status != noErr { NSLog("OpenAGI: hotkey registration failed (\(status)) — tray-only") }
+  }
+
+  func unregister() {
+    if let ref { UnregisterEventHotKey(ref) }
+    if let handler { RemoveEventHandler(handler) }
+    ref = nil; handler = nil
+  }
+}

--- a/mac/Sources/OpenAGI/Overlay/OverlayController.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayController.swift
@@ -1,0 +1,88 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class OverlayController {
+  static let shared = OverlayController()
+  private var panel: NSPanel?
+
+  private static let enabledKey = "openagi.overlay.enabled"
+  private static let frameKey = "openagi.overlay.originX"
+
+  static var isEnabled: Bool {
+    UserDefaults.standard.object(forKey: enabledKey) == nil ? true : UserDefaults.standard.bool(forKey: enabledKey)
+  }
+  static func setEnabled(_ on: Bool) {
+    UserDefaults.standard.set(on, forKey: enabledKey)
+    if on { shared.show() } else { shared.hide() }
+  }
+
+  func startIfEnabled() { if Self.isEnabled { show() } }
+
+  func show() {
+    if panel == nil { panel = makePanel() }
+    positionPanel()
+    panel?.orderFrontRegardless()
+  }
+
+  func hide() { panel?.orderOut(nil) }
+
+  func toggle() {
+    if panel?.isVisible == true {
+      OverlayState.shared.expanded.toggle()
+      sizeToContent()
+    } else {
+      OverlayState.shared.expanded = true
+      show(); sizeToContent()
+    }
+  }
+
+  private func makePanel() -> NSPanel {
+    let p = NSPanel(
+      contentRect: NSRect(x: 0, y: 0, width: 320, height: 60),
+      styleMask: [.nonactivatingPanel, .borderless, .fullSizeContentView],
+      backing: .buffered, defer: false)
+    p.isFloatingPanel = true
+    p.level = .statusBar
+    p.hidesOnDeactivate = false
+    p.isMovableByWindowBackground = true
+    p.backgroundColor = .clear
+    p.hasShadow = true
+    p.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+    let host = NSHostingView(rootView: OverlayView(onCollapse: { [weak self] in self?.sizeToContent() }))
+    host.translatesAutoresizingMaskIntoConstraints = true
+    p.contentView = host
+    return p
+  }
+
+  private func sizeToContent() {
+    guard let p = panel, let host = p.contentView else { return }
+    let fitting = host.fittingSize
+    var frame = p.frame
+    let newH = max(44, fitting.height)
+    frame.origin.y += (frame.height - newH)
+    frame.size.height = newH
+    frame.size.width = OverlayState.shared.expanded ? 320 : 44
+    p.setFrame(frame, display: true, animate: false)
+  }
+
+  private func positionPanel() {
+    guard let p = panel, let screen = NSScreen.main else { return }
+    let d = UserDefaults.standard
+    if d.object(forKey: Self.frameKey) != nil {
+      let x = d.double(forKey: Self.frameKey)
+      let y = d.double(forKey: "openagi.overlay.originY")
+      p.setFrameOrigin(NSPoint(x: x, y: y))
+    } else {
+      let vf = screen.visibleFrame
+      p.setFrameOrigin(NSPoint(x: vf.maxX - 360, y: vf.minY + 80))
+    }
+    sizeToContent()
+  }
+
+  func persistPosition() {
+    guard let p = panel else { return }
+    UserDefaults.standard.set(Double(p.frame.origin.x), forKey: Self.frameKey)
+    UserDefaults.standard.set(Double(p.frame.origin.y), forKey: "openagi.overlay.originY")
+  }
+}

--- a/mac/Sources/OpenAGI/Overlay/OverlayController.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayController.swift
@@ -31,14 +31,16 @@ final class OverlayController {
     if panel?.isVisible == true {
       OverlayState.shared.expanded.toggle()
       sizeToContent()
+      if OverlayState.shared.expanded { panel?.makeKey() }
     } else {
       OverlayState.shared.expanded = true
       show(); sizeToContent()
+      panel?.makeKey()
     }
   }
 
   private func makePanel() -> NSPanel {
-    let p = NSPanel(
+    let p = KeyableOverlayPanel(
       contentRect: NSRect(x: 0, y: 0, width: 320, height: 60),
       styleMask: [.nonactivatingPanel, .borderless, .fullSizeContentView],
       backing: .buffered, defer: false)
@@ -85,4 +87,11 @@ final class OverlayController {
     UserDefaults.standard.set(Double(p.frame.origin.x), forKey: Self.frameKey)
     UserDefaults.standard.set(Double(p.frame.origin.y), forKey: "openagi.overlay.originY")
   }
+}
+
+// Borderless NSPanels return false for canBecomeKey by default; override so the
+// Quick Ask field can receive keystrokes. .nonactivatingPanel keeps the owning
+// app from activating, so summoning never steals focus from the user's app.
+final class KeyableOverlayPanel: NSPanel {
+  override var canBecomeKey: Bool { true }
 }

--- a/mac/Sources/OpenAGI/Overlay/OverlayController.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayController.swift
@@ -27,7 +27,10 @@ final class OverlayController {
 
   func hide() { panel?.orderOut(nil) }
 
+  var panelWindowNumber: Int? { panel?.windowNumber }
+
   func toggle() {
+    guard Self.isEnabled else { return }
     if panel?.isVisible == true {
       OverlayState.shared.expanded.toggle()
       sizeToContent()
@@ -51,7 +54,10 @@ final class OverlayController {
     p.backgroundColor = .clear
     p.hasShadow = true
     p.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
-    let host = NSHostingView(rootView: OverlayView(onCollapse: { [weak self] in self?.sizeToContent() }))
+    let host = NSHostingView(rootView: OverlayView(
+      onCollapse: { [weak self] in self?.sizeToContent() },
+      onExpand: { [weak self] in DispatchQueue.main.async { self?.sizeToContent() } }
+    ))
     host.translatesAutoresizingMaskIntoConstraints = true
     p.contentView = host
     return p

--- a/mac/Sources/OpenAGI/Overlay/OverlayState.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayState.swift
@@ -1,0 +1,32 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class OverlayState: ObservableObject {
+  static let shared = OverlayState()
+
+  @Published var expanded = false
+  @Published var question = ""
+  @Published var answer: String = ""
+  @Published var isLoading = false
+  @Published var error: String? = nil
+  @Published var contextNote: String? = nil
+
+  func ask() async {
+    let q = question.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !q.isEmpty else { return }
+    isLoading = true; error = nil; answer = ""
+    let ctx = await ScreenCapturer.shared.captureFocusedText()
+    if let ctx, !ctx.text.isEmpty {
+      contextNote = "reading \(ctx.app)"
+    } else {
+      contextNote = "no screen context"
+    }
+    do {
+      answer = try await AppState.shared.askOverlay(text: q, screenContext: ctx)
+    } catch {
+      self.error = error.localizedDescription
+    }
+    isLoading = false
+  }
+}

--- a/mac/Sources/OpenAGI/Overlay/OverlayState.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayState.swift
@@ -16,7 +16,7 @@ final class OverlayState: ObservableObject {
     let q = question.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !q.isEmpty else { return }
     isLoading = true; error = nil; answer = ""
-    let ctx = await ScreenCapturer.shared.captureFocusedText()
+    let ctx = await ScreenCapturer.shared.captureFocusedText(excludingWindowNumber: OverlayController.shared.panelWindowNumber)
     if let ctx, !ctx.text.isEmpty {
       contextNote = "reading \(ctx.app)"
     } else {

--- a/mac/Sources/OpenAGI/Overlay/OverlayView.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayView.swift
@@ -5,6 +5,7 @@ struct OverlayView: View {
   @ObservedObject var app = AppState.shared
   @FocusState private var fieldFocused: Bool
   var onCollapse: () -> Void = {}
+  var onExpand: () -> Void = {}
 
   var body: some View {
     if state.expanded {
@@ -15,7 +16,7 @@ struct OverlayView: View {
   }
 
   private var pill: some View {
-    Button(action: { state.expanded = true }) {
+    Button(action: { state.expanded = true; onExpand() }) {
       ZStack {
         Circle().fill(Color.accentColor).frame(width: 16, height: 16)
         if !app.nudges.isEmpty {

--- a/mac/Sources/OpenAGI/Overlay/OverlayView.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayView.swift
@@ -57,6 +57,25 @@ struct OverlayView: View {
         Button("Continue in chat") { app.openDashboard(path: "/?tab=chat") }
           .font(.caption).buttonStyle(.plain).foregroundStyle(.blue)
       }
+      if !app.nudges.isEmpty {
+        Divider()
+        Text("Nudges").font(.system(size: 10, weight: .semibold)).foregroundStyle(.secondary)
+        ForEach(app.nudges.prefix(4)) { n in
+          HStack(alignment: .top, spacing: 6) {
+            VStack(alignment: .leading, spacing: 1) {
+              Text(n.title).font(.system(size: 11, weight: .medium))
+              if !n.body.isEmpty { Text(n.body).font(.system(size: 10)).foregroundStyle(.secondary).lineLimit(2) }
+            }
+            Spacer()
+            Button(action: { app.openDashboard(path: "/?tab=chat&suggestion=\(n.id)") }) {
+              Image(systemName: "arrow.up.right.square")
+            }.buttonStyle(.plain).help("Review in chat")
+            Button(action: { app.nudges.removeAll { $0.id == n.id } }) {
+              Image(systemName: "xmark")
+            }.buttonStyle(.plain).help("Dismiss")
+          }
+        }
+      }
     }
     .padding(12)
     .frame(width: 320)

--- a/mac/Sources/OpenAGI/Overlay/OverlayView.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct OverlayView: View {
   @ObservedObject var state = OverlayState.shared
   @ObservedObject var app = AppState.shared
+  @FocusState private var fieldFocused: Bool
   var onCollapse: () -> Void = {}
 
   var body: some View {
@@ -42,6 +43,7 @@ struct OverlayView: View {
       }
       TextField("Ask about what you're looking at…", text: $state.question)
         .textFieldStyle(.roundedBorder)
+        .focused($fieldFocused)
         .disabled(app.status == .down)
         .onSubmit { Task { await state.ask() } }
       if let note = state.contextNote {
@@ -80,5 +82,7 @@ struct OverlayView: View {
     .padding(12)
     .frame(width: 320)
     .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+    .onAppear { fieldFocused = true }
+    .onChange(of: state.expanded) { _, expanded in if expanded { fieldFocused = true } }
   }
 }

--- a/mac/Sources/OpenAGI/Overlay/OverlayView.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct OverlayView: View {
+  @ObservedObject var state = OverlayState.shared
+  @ObservedObject var app = AppState.shared
+  var onCollapse: () -> Void = {}
+
+  var body: some View {
+    if state.expanded {
+      expandedPanel
+    } else {
+      pill
+    }
+  }
+
+  private var pill: some View {
+    Button(action: { state.expanded = true }) {
+      ZStack {
+        Circle().fill(Color.accentColor).frame(width: 16, height: 16)
+        if !app.nudges.isEmpty {
+          Text("\(app.nudges.count)")
+            .font(.system(size: 9, weight: .bold)).foregroundColor(.white)
+        }
+      }
+      .padding(8)
+    }
+    .buttonStyle(.plain)
+    .background(.ultraThinMaterial, in: Circle())
+  }
+
+  private var expandedPanel: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack {
+        Text("Ask OpenAGI").font(.caption).foregroundStyle(.secondary)
+        Spacer()
+        Button(action: { state.expanded = false; onCollapse() }) {
+          Image(systemName: "xmark.circle.fill").foregroundStyle(.tertiary)
+        }.buttonStyle(.plain)
+      }
+      if app.status == .down {
+        Text("OpenAGI is offline").font(.caption).foregroundStyle(.red)
+      }
+      TextField("Ask about what you're looking at…", text: $state.question)
+        .textFieldStyle(.roundedBorder)
+        .disabled(app.status == .down)
+        .onSubmit { Task { await state.ask() } }
+      if let note = state.contextNote {
+        Text(note).font(.system(size: 10)).foregroundStyle(.tertiary)
+      }
+      if state.isLoading {
+        ProgressView().controlSize(.small)
+      } else if let err = state.error {
+        Text(err).font(.caption).foregroundStyle(.red)
+      } else if !state.answer.isEmpty {
+        ScrollView { Text(state.answer).font(.callout).textSelection(.enabled).frame(maxWidth: .infinity, alignment: .leading) }
+          .frame(maxHeight: 220)
+        Button("Continue in chat") { app.openDashboard(path: "/?tab=chat") }
+          .font(.caption).buttonStyle(.plain).foregroundStyle(.blue)
+      }
+    }
+    .padding(12)
+    .frame(width: 320)
+    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+  }
+}

--- a/mac/Sources/OpenAGI/TrayController.swift
+++ b/mac/Sources/OpenAGI/TrayController.swift
@@ -206,6 +206,11 @@ struct TrayMenu: View {
       Button(UpdateController.shared.isEnabled ? "Check for updates…" : "About auto-updates…") {
         UpdateController.shared.checkForUpdates()
       }
+      Button("Quick Ask  ⌥Space") { OverlayController.shared.toggle() }
+      Toggle("Enable Quick Ask", isOn: Binding(
+        get: { OverlayController.isEnabled },
+        set: { OverlayController.setEnabled($0) }
+      ))
       Toggle("Open at Login", isOn: Binding(
         get: { LoginItem.isEnabled },
         set: { LoginItem.setEnabled($0) }

--- a/src/abi-runtime.js
+++ b/src/abi-runtime.js
@@ -929,5 +929,13 @@ export function createDurableRuntime(options = {}) {
   });
   const mcpConfigPath = options.mcpConfigPath ?? path.join(dataDir, "mcp.json");
   runtime.mcp.loadConfigFile(mcpConfigPath);
+  // Reconnect previously-authorized MCP servers on boot, silently — servers
+  // with a cached OAuth token / bearer key / stdio command come back "live"
+  // instead of showing "idle" until someone clicks Connect. Never opens a
+  // browser: OAuth servers without a usable token just stay idle. Non-blocking
+  // and best-effort so a slow/dead server can't hold up startup.
+  if (options.autoConnectMcp !== false && runtime.mcp?.connectAll) {
+    Promise.resolve().then(() => runtime.mcp.connectAll({ silent: true })).catch(() => {});
+  }
   return runtime;
 }

--- a/src/agent-host.js
+++ b/src/agent-host.js
@@ -105,7 +105,7 @@ export class AgentHost {
         }
       })),
       messages: sessionBefore.messages,
-      instructions: this.instructionsForAgent(agent, output, intuitions, ambientContext),
+      instructions: this.instructionsForAgent(agent, output, intuitions, ambientContext, input.metadata?.screenContext ?? null),
       tools,
       toolRegistry,
       context: {
@@ -241,7 +241,7 @@ export class AgentHost {
     };
   }
 
-  instructionsForAgent(agent, output, intuitions = [], ambientContext = null) {
+  instructionsForAgent(agent, output, intuitions = [], ambientContext = null, screenContext = null) {
     const intuitionBlock = intuitions.length > 0
       ? `\nIntuitions (distilled long-term principles, may apply):\n${intuitions.map((i) => `- (${i.score.toFixed(2)}) ${i.text}`).join("\n")}\n`
       : "";
@@ -264,6 +264,8 @@ export class AgentHost {
       ambientBlock = lines.join("\n") + "\n";
     }
 
+    const screenBlock = formatScreenContextBlock(screenContext);
+
     return `${agent.systemPrompt ? `${agent.systemPrompt}\n\n` : ""}You are ${agent.name}, an always-on OpenAGI agent.
 
 Your job is to help through the ABI loop:
@@ -274,7 +276,7 @@ Your job is to help through the ABI loop:
 Current decision: ${output.scrutiny.action}
 Reasons:
 ${output.scrutiny.reasons.map((reason) => `- ${reason}`).join("\n")}
-${intuitionBlock}${ambientBlock}
+${intuitionBlock}${ambientBlock}${screenBlock}
 Answer the user plainly. If a specialist was created, mention its name and scope.`;
   }
 
@@ -307,6 +309,18 @@ Stay inside the bounded scope. If the user's request falls outside it, say so an
       sessions: this.store.listSessions()
     };
   }
+}
+
+// Format the fresh focused-window context the floating widget attaches to a
+// message (metadata.screenContext = { app, window, text }) into a labeled
+// prompt block. Returns "" when absent/empty. Pure + exported for testing.
+export function formatScreenContextBlock(screenContext) {
+  if (!screenContext || typeof screenContext.text !== "string" || !screenContext.text.trim()) return "";
+  const where = screenContext.window
+    ? `${screenContext.app || "?"} · ${screenContext.window}`
+    : (screenContext.app || "active window");
+  const body = screenContext.text.slice(0, 4000);
+  return `\nActive window the user is looking at right now (${where}):\n${body}\nGround your answer in this if it's relevant; don't quote it back verbatim.\n`;
 }
 
 // Maps a provider class to a short user-facing label. Avoids leaking

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -836,11 +836,12 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
             ]
           },
         ];
-        // featured ids already shown as full multi-path cards above —
-        // skip them in the browse-catalog section to avoid duplication.
+        // Featured integrations (BuildBetter, Linear, Rize, …) are ALSO listed
+        // in the browse catalog below — intentionally a duplicate, flagged so
+        // the UI can say "this is the MCP version of an integration you also
+        // have a non-MCP (API) path for above".
         const featuredIds = new Set(integrations.map((i) => i.id));
         const catalog = MCP_CATALOG
-          .filter((entry) => !featuredIds.has(entry.id))
           .map((entry) => ({
             id: entry.id,
             name: entry.name,
@@ -852,7 +853,8 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
             apiKeyHelp: entry.apiKeyHelp ?? null,
             apiKeyConfigured: entry.apiKeyEnvVar ? Boolean(process.env[entry.apiKeyEnvVar]) : true,
             connectable: entry.status === "available" && Boolean(entry.register),
-            configured: mcpInCatalog(entry.id)
+            configured: mcpInCatalog(entry.id),
+            featured: featuredIds.has(entry.id)
           }));
         return sendJson(res, 200, { integrations, catalog, categories: CATEGORIES });
       }
@@ -2692,6 +2694,10 @@ function renderSkillDetail(skill) {
 
 async function refreshMcp() {
   const servers = await fetchJson("/mcp");
+  // Preserve scroll position across the full rebuild below — otherwise every
+  // SSE "mcp" event (e.g. a connect finishing) snaps the list back to the top.
+  const mcpScroller = sidebarList.scrollHeight > sidebarList.clientHeight ? sidebarList : sidebarList.parentElement;
+  const mcpSavedScroll = mcpScroller ? mcpScroller.scrollTop : 0;
   sidebarList.innerHTML = "";
   // Always-visible Register button at the top of the MCP sidebar so the
   // user has an unambiguous entry point — separate from the magical
@@ -2727,6 +2733,8 @@ async function refreshMcp() {
     li.addEventListener("click", () => renderMcpDetail(s));
     sidebarList.appendChild(li);
   }
+  // Restore the pre-rebuild scroll position now that the list is repopulated.
+  if (mcpScroller) mcpScroller.scrollTop = mcpSavedScroll;
   // Show a hero "Register your first MCP" CTA in the main pane when empty.
   if (servers.length === 0) {
     main.innerHTML = \`
@@ -3635,8 +3643,9 @@ async function renderIntegrations() {
       <div class="ui-card" style="display: flex; flex-direction: column; gap: var(--space-2);">
         <div style="display: flex; align-items: flex-start; gap: var(--space-2);">
           <div class="ui-grow">
-            <div style="font-weight: 600; font-size: 13px;">\${escapeHtml(e.name)}</div>
+            <div style="font-weight: 600; font-size: 13px; display:flex; align-items:center; gap:6px;"><span>\${escapeHtml(e.name)}</span><span class="badge" style="background:rgba(96,165,250,.16); color:#7fb3ff; border-color:rgba(96,165,250,.35); font-size:9px;">MCP</span></div>
             <div class="ui-meta" style="margin-top: 2px;">\${escapeHtml(e.description ?? "")}</div>
+            \${e.featured ? '<div class="ui-meta" style="margin-top:3px; opacity:.85;">↑ Also available as a non-MCP (direct API) integration above</div>' : ""}
           </div>
           \${badge}
         </div>
@@ -3656,6 +3665,11 @@ async function renderIntegrations() {
     const envBlock = p.envKeys?.length > 0
       ? \`<div class="muted" style="font-size:11px; margin-top:4px;">env: <code>\${p.envKeys.map(escapeHtml).join("</code> · <code>")}</code></div>\`
       : "";
+    // Make the integration TYPE unmistakable: an MCP path vs a non-MCP
+    // (direct API / file-drop) path. Two integrations can offer both.
+    const kindBadge = p.kind === "mcp"
+      ? '<span class="badge" style="background:rgba(96,165,250,.16); color:#7fb3ff; border-color:rgba(96,165,250,.35);">MCP</span>'
+      : '<span class="badge" style="opacity:.65;">non-MCP</span>';
     let actions = "";
     let editForm = "";
     if (p.kind === "api" && p.envKeys?.length > 0) {
@@ -3688,7 +3702,7 @@ async function renderIntegrations() {
       <div style="border:1px solid var(--line); border-radius:6px; padding:10px 12px; margin-top:6px;">
         <div class="row between" style="align-items:center; gap:8px;">
           <div style="flex:1; min-width:0;">
-            <div style="font-weight:500; font-size:13px;">\${escapeHtml(p.label)}</div>
+            <div style="font-weight:500; font-size:13px; display:flex; align-items:center; gap:6px;">\${kindBadge}<span>\${escapeHtml(p.label)}</span></div>
             \${p.detail ? \`<div class="muted" style="font-size:11px; margin-top:2px;">\${escapeHtml(p.detail)}</div>\` : ""}
             \${envBlock}
             \${lastSync}

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -1203,17 +1203,21 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
         // Fire-and-forget so the OAuth dance doesn't block the HTTP response.
         // Dashboard polls /mcp and listens for SSE 'mcp' events to learn when
         // it's done (or if an OAuth URL needs to be opened).
-        if (!runtime.mcp.isConnecting?.(name)) {
-          runtime.mcp.connect(name)
-            .then((status) => {
-              pendingOauth.delete(name);
-              events.emit("mcp", { op: "connected", name, tools: status?.tools ?? [] });
-            })
-            .catch((error) => {
-              events.emit("mcp", { op: "connect-error", name, error: error.message });
-            });
-          events.emit("mcp", { op: "connecting", name });
-        }
+        //
+        // Always call connect(): the registry dedups in-flight attempts itself,
+        // and a manual (interactive) connect made while a silent boot reconnect
+        // is in flight must chain an interactive attempt after it — the silent
+        // attempt can't open a browser and fails OAUTH_INTERACTIVE_REQUIRED,
+        // which used to leave the Connect click doing nothing.
+        runtime.mcp.connect(name)
+          .then((status) => {
+            pendingOauth.delete(name);
+            events.emit("mcp", { op: "connected", name, tools: status?.tools ?? [] });
+          })
+          .catch((error) => {
+            events.emit("mcp", { op: "connect-error", name, error: error.message });
+          });
+        events.emit("mcp", { op: "connecting", name });
         return sendJson(res, 202, { name, status: "connecting" });
       }
       if (method === "POST" && pathname.match(/^\/mcp\/clear-auth\/[^/]+$/)) {

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -295,7 +295,13 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
         if (!bb.ok) return sendJson(res, 401, { error: "unauthorized", reason: bb.reason });
         await readJson(req).catch(() => ({})); // drain body; we don't trust it for ingestion
         const source = runtime.buildBetterTaskSource;
-        if (!source?.triggerSync) return sendJson(res, 503, { error: "buildbetter source not configured" });
+        // The source is always registered (so a mid-session MCP login works
+        // without restart), so also check it's actually configured — otherwise
+        // a sync would no-op. Returning 503 (not a false 202) lets BuildBetter
+        // retry the delivery once credentials land.
+        if (!source?.triggerSync || !source.isConfigured?.()) {
+          return sendJson(res, 503, { error: "buildbetter source not configured" });
+        }
         // Don't block the webhook response on the full sync — ack fast,
         // sync in the background (BuildBetter expects a quick 200).
         source.triggerSync().then(
@@ -1631,6 +1637,8 @@ function renderApp() {
     .badge.ok { color: var(--accent); }
     .badge.warn { color: var(--warn); }
     .badge.err { color: var(--err); }
+    .badge.mcp { background: rgba(96,165,250,.16); color: #7fb3ff; border-color: rgba(96,165,250,.35); }
+    .badge.muted { opacity: .65; }
     pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; color: var(--text); }
     input, select, textarea {
       background: var(--bg); color: var(--text); border: 1px solid var(--line);
@@ -3643,7 +3651,7 @@ async function renderIntegrations() {
       <div class="ui-card" style="display: flex; flex-direction: column; gap: var(--space-2);">
         <div style="display: flex; align-items: flex-start; gap: var(--space-2);">
           <div class="ui-grow">
-            <div style="font-weight: 600; font-size: 13px; display:flex; align-items:center; gap:6px;"><span>\${escapeHtml(e.name)}</span><span class="badge" style="background:rgba(96,165,250,.16); color:#7fb3ff; border-color:rgba(96,165,250,.35); font-size:9px;">MCP</span></div>
+            <div style="font-weight: 600; font-size: 13px; display:flex; align-items:center; gap:6px;"><span>\${escapeHtml(e.name)}</span><span class="badge mcp" style="font-size:9px;">MCP</span></div>
             <div class="ui-meta" style="margin-top: 2px;">\${escapeHtml(e.description ?? "")}</div>
             \${e.featured ? '<div class="ui-meta" style="margin-top:3px; opacity:.85;">↑ Also available as a non-MCP (direct API) integration above</div>' : ""}
           </div>
@@ -3668,8 +3676,8 @@ async function renderIntegrations() {
     // Make the integration TYPE unmistakable: an MCP path vs a non-MCP
     // (direct API / file-drop) path. Two integrations can offer both.
     const kindBadge = p.kind === "mcp"
-      ? '<span class="badge" style="background:rgba(96,165,250,.16); color:#7fb3ff; border-color:rgba(96,165,250,.35);">MCP</span>'
-      : '<span class="badge" style="opacity:.65;">non-MCP</span>';
+      ? '<span class="badge mcp">MCP</span>'
+      : '<span class="badge muted">non-MCP</span>';
     let actions = "";
     let editForm = "";
     if (p.kind === "api" && p.envKeys?.length > 0) {

--- a/src/integrations/buildbetter-tasks.js
+++ b/src/integrations/buildbetter-tasks.js
@@ -93,25 +93,20 @@ export class BuildBetterTaskSource {
     }
   }
 
-  // Silently obtain a Bearer token from the cached OAuth connection. Never
-  // triggers the interactive browser flow — if there's no cache, returns null
-  // so a headless poller degrades gracefully instead of hanging on consent.
+  // Silently obtain a Bearer token from the cached OAuth connection. Delegates
+  // to the canonical token lifecycle in McpOAuthClient (cached-or-refresh, no
+  // browser): ensureToken({interactive:false}) returns a valid token or throws
+  // OAUTH_INTERACTIVE_REQUIRED / a refresh error, both of which mean "no token"
+  // for a headless poller. Sharing this keeps us from drifting from how the
+  // live MCP client refreshes the same cache.
   async _oauthToken() {
     const client = this._oauth();
     if (!client) return null;
-    let cache;
-    try { cache = client.loadCache(); } catch { return null; }
-    if (!cache) return null;
     try {
-      if (cache.access_token && !client.isExpired(cache)) return cache.access_token;
-      if (cache.refresh_token && cache.discovery && cache.client) {
-        await client.refresh(cache);
-        return client.loadCache()?.access_token ?? null;
-      }
+      return await client.ensureToken({ interactive: false });
     } catch {
-      // refresh failed (revoked / network) — treat OAuth as unavailable.
+      return null;
     }
-    return null;
   }
 
   // Resolve auth headers: API key wins (preserves existing setups), else the
@@ -323,6 +318,11 @@ export class BuildBetterTaskSource {
   async syncTranscripts({ now = new Date() } = {}) {
     if (!(await this.authHeaders())) return { skipped: true, reason: "no BuildBetter auth (set BUILDBETTER_API_KEY or connect BuildBetter via MCP)" };
     if (!this.runtime?.observations?.record) return { skipped: true, reason: "no observation store" };
+    // Transcripts are filtered to calls YOU attended, so without an identity
+    // getRecentCalls matches nothing — skip with a clear reason instead of
+    // silently recording zero transcripts (mirrors syncSignals).
+    await this.ensureIdentity();
+    if (!this.userEmail && !this.userName) return { skipped: true, reason: "could not determine your BuildBetter identity (set BUILDBETTER_USER_EMAIL or BUILDBETTER_USER_NAME)" };
 
     const sinceIso = new Date(now.getTime() - LOOKBACK_DAYS * 86400 * 1000).toISOString();
     let calls;

--- a/src/integrations/buildbetter-tasks.js
+++ b/src/integrations/buildbetter-tasks.js
@@ -402,12 +402,15 @@ export function registerBuildBetterTaskSource(runtime, options = {}) {
     oauthResourceUrl: rec?.resourceUrl ?? (rec?.url ? originOf(rec.url) : undefined),
     ...options
   });
-  if (!source.isConfigured()) {
-    return {
-      registered: false,
-      reason: "no BuildBetter auth — set BUILDBETTER_API_KEY or connect BuildBetter from the MCP tab"
-    };
-  }
+  // Register the source + cron even when no credentials exist yet. Auth can
+  // arrive mid-session — the user connects BuildBetter from the MCP tab and an
+  // OAuth token cache appears — and the poller + webhook must start working
+  // without a daemon restart. sync() self-gates on authHeaders(), so an
+  // unconfigured source just no-ops each tick (a cheap cache check) until
+  // credentials show up. Previously this returned early and left
+  // runtime.buildBetterTaskSource unset, so a later MCP login was ignored
+  // until restart (the cron reported "no buildbetter source", webhook 503'd).
+  runtime.buildBetterTaskSource = source;
   if (runtime.cron?.addJob) {
     runtime.cron.addJob({
       id: "buildbetter-task-sync",
@@ -417,8 +420,7 @@ export function registerBuildBetterTaskSource(runtime, options = {}) {
       intervalMs: POLL_INTERVAL_MS
     });
   }
-  runtime.buildBetterTaskSource = source;
-  return { registered: true };
+  return { registered: true, idle: !source.isConfigured() };
 }
 
 // Origin (scheme + host) of an MCP server URL, for the OAuth resource id.

--- a/src/integrations/buildbetter-tasks.js
+++ b/src/integrations/buildbetter-tasks.js
@@ -1,16 +1,33 @@
 // BuildBetter → TaskStore source. Pulls action items / commitments /
 // follow-ups from the user's recent calls (extractions tagged action_item,
 // follow_up, task, commitment, priority). Polls every 15 min.
-// Env-gated — silently no-ops if BUILDBETTER_API_KEY is unset.
 //
-// User identity (whose attendee the action item is "for") comes from
-// BUILDBETTER_USER_EMAIL or BUILDBETTER_USER_NAME. If neither is set,
-// the integration registers but warns once and stays idle.
+// Auth — two paths, in precedence order:
+//   1. BUILDBETTER_API_KEY  → X-BuildBetter-Api-Key header.
+//   2. The BuildBetter MCP OAuth connection (from the dashboard MCP tab) →
+//      Authorization: Bearer <token>, silently refreshed, no browser needed.
+//      With no API key set at all, connecting BuildBetter once via MCP is
+//      enough for this poller to run.
+//
+// User identity (whose attendee the action item is "for") is auto-derived
+// from the API key / OAuth session via the `me` GraphQL query. It only falls
+// back to BUILDBETTER_USER_EMAIL / BUILDBETTER_USER_NAME when `me` can't
+// pinpoint a single user (e.g. an org-scoped key).
 //
 // Adapted from autolist's apps/api/src/lib/integrations/buildbetter.ts
 // to OpenAGI's task store + integration registry pattern.
 
+import { McpOAuthClient } from "../mcp-oauth.js";
+import { resolveDataDir } from "../data-dir.js";
+
 const BUILDBETTER_ENDPOINT = "https://api.buildbetter.app/v1/graphql";
+// Origin of the BuildBetter MCP server, used to build the OAuth client that
+// reads the token cached under <dataDir>/mcp/auth/buildbetter.json. The actual
+// silent refresh uses the discovery metadata stored in that cache, so this
+// only needs to be correct enough to satisfy the constructor — prod and
+// staging tokens both refresh fine once the cache exists.
+const BUILDBETTER_MCP_RESOURCE_URL = "https://mcp.buildbetter.app";
+const ME_QUERY = "query Me { me { person { first_name last_name email } } }";
 const POLL_INTERVAL_MS = 15 * 60 * 1000;
 const LOOKBACK_DAYS = 7;
 
@@ -20,6 +37,17 @@ export class BuildBetterTaskSource {
     this.apiKey = options.apiKey ?? process.env.BUILDBETTER_API_KEY ?? null;
     this.userEmail = options.userEmail ?? process.env.BUILDBETTER_USER_EMAIL ?? null;
     this.userName = options.userName ?? process.env.BUILDBETTER_USER_NAME ?? null;
+    // OAuth fallback (option 2): reuse the BuildBetter MCP connection. The
+    // client is built lazily so we never touch the filesystem / construct it
+    // when an API key is set. dataDir + resourceUrl come from the MCP registry
+    // when available so we read the exact same token cache the MCP client wrote.
+    this.dataDir = options.dataDir ?? resolveDataDir();
+    this.oauthResourceUrl = options.oauthResourceUrl ?? BUILDBETTER_MCP_RESOURCE_URL;
+    this.oauthClient = options.oauthClient ?? null;
+    this._oauthTried = false;
+    // Identity auto-derivation (option 1): once we've successfully asked `me`,
+    // don't ask again this process — even if it returned no user.
+    this._identityResolved = false;
     this.lastSyncedAt = null;
     // Coalescing state for webhook-triggered syncs: if a sync is already
     // running when a ping arrives, we don't start a second — we just flag
@@ -31,17 +59,98 @@ export class BuildBetterTaskSource {
   }
 
   isConfigured() {
-    return Boolean(this.apiKey) && Boolean(this.userEmail || this.userName);
+    // Identity is auto-derived now, so auth alone is enough: an API key, or a
+    // previously-completed BuildBetter MCP OAuth connection.
+    return Boolean(this.apiKey) || this._hasOAuthCache();
+  }
+
+  // Lazily build the OAuth client. Returns null if it can't be constructed.
+  _oauth() {
+    if (this.oauthClient) return this.oauthClient;
+    if (this._oauthTried) return null;
+    this._oauthTried = true;
+    try {
+      this.oauthClient = new McpOAuthClient({
+        name: "buildbetter",
+        resourceUrl: this.oauthResourceUrl,
+        dataDir: this.dataDir
+      });
+    } catch {
+      this.oauthClient = null;
+    }
+    return this.oauthClient;
+  }
+
+  // Sync probe: is there a usable cached OAuth token/refresh token on disk?
+  _hasOAuthCache() {
+    const client = this._oauth();
+    if (!client) return false;
+    try {
+      const cache = client.loadCache();
+      return Boolean(cache?.access_token || cache?.refresh_token);
+    } catch {
+      return false;
+    }
+  }
+
+  // Silently obtain a Bearer token from the cached OAuth connection. Never
+  // triggers the interactive browser flow — if there's no cache, returns null
+  // so a headless poller degrades gracefully instead of hanging on consent.
+  async _oauthToken() {
+    const client = this._oauth();
+    if (!client) return null;
+    let cache;
+    try { cache = client.loadCache(); } catch { return null; }
+    if (!cache) return null;
+    try {
+      if (cache.access_token && !client.isExpired(cache)) return cache.access_token;
+      if (cache.refresh_token && cache.discovery && cache.client) {
+        await client.refresh(cache);
+        return client.loadCache()?.access_token ?? null;
+      }
+    } catch {
+      // refresh failed (revoked / network) — treat OAuth as unavailable.
+    }
+    return null;
+  }
+
+  // Resolve auth headers: API key wins (preserves existing setups), else the
+  // reused MCP OAuth token. Returns null when neither is available.
+  async authHeaders() {
+    // BuildBetter's exact header spelling per their docs.
+    if (this.apiKey) return { "X-BuildBetter-Api-Key": this.apiKey };
+    const token = await this._oauthToken();
+    if (token) return { authorization: `Bearer ${token}` };
+    return null;
+  }
+
+  // Best-effort: fill userEmail / userName from the authenticated session via
+  // the `me` query. No-op once we already have an identity, or once we've
+  // asked successfully (an org-scoped key legitimately returns no user — we
+  // don't keep re-asking, we just fall back to the env-provided identity).
+  async ensureIdentity() {
+    if (this.userEmail || this.userName) return;
+    if (this._identityResolved) return;
+    try {
+      const data = await this.query(ME_QUERY);
+      this._identityResolved = true; // we successfully asked; don't repeat
+      const p = data?.me?.person;
+      if (p?.email) this.userEmail = p.email;
+      const fullName = [p?.first_name, p?.last_name].filter(Boolean).join(" ").trim();
+      if (!this.userEmail && fullName) this.userName = fullName;
+    } catch {
+      // transient (network / auth) — leave unresolved so we retry next sync.
+    }
   }
 
   async query(graphql, variables = {}) {
+    const auth = await this.authHeaders();
+    if (!auth) {
+      throw new Error("BuildBetter: no auth (set BUILDBETTER_API_KEY or connect BuildBetter from the MCP tab)");
+    }
     const res = await fetch(BUILDBETTER_ENDPOINT, {
       method: "POST",
-      headers: {
-        "content-type": "application/json",
-        // BuildBetter's exact header spelling per their docs.
-        "X-BuildBetter-Api-Key": this.apiKey
-      },
+      headers: { "content-type": "application/json", ...auth },
       body: JSON.stringify({ query: graphql, variables })
     });
     if (!res.ok) throw new Error(`BuildBetter API ${res.status}`);
@@ -52,6 +161,8 @@ export class BuildBetterTaskSource {
 
   // Step 1: find recent calls the user attended.
   async getRecentCalls(sinceIso) {
+    // Auto-derive who "you" are before filtering by attendee.
+    await this.ensureIdentity();
     const query = `
       query RecentCalls($since: timestamptz!, $limit: Int!) {
         interview(
@@ -117,9 +228,10 @@ export class BuildBetterTaskSource {
    * Run one sync pass. Returns { created, updated, scanned } or skip reason.
    */
   async syncSignals({ now = new Date() } = {}) {
-    if (!this.apiKey) return { skipped: true, reason: "BUILDBETTER_API_KEY not set" };
-    if (!this.userEmail && !this.userName) return { skipped: true, reason: "BUILDBETTER_USER_EMAIL or BUILDBETTER_USER_NAME required" };
+    if (!(await this.authHeaders())) return { skipped: true, reason: "no BuildBetter auth (set BUILDBETTER_API_KEY or connect BuildBetter via MCP)" };
     if (!this.runtime?.tasks?.add) return { skipped: true, reason: "task store not available" };
+    await this.ensureIdentity();
+    if (!this.userEmail && !this.userName) return { skipped: true, reason: "could not determine your BuildBetter identity (set BUILDBETTER_USER_EMAIL or BUILDBETTER_USER_NAME)" };
 
     const sinceIso = new Date(now.getTime() - LOOKBACK_DAYS * 86400 * 1000).toISOString();
 
@@ -209,7 +321,7 @@ export class BuildBetterTaskSource {
 
   // Record one transcript observation per recent call, deduped by ref.
   async syncTranscripts({ now = new Date() } = {}) {
-    if (!this.apiKey) return { skipped: true, reason: "BUILDBETTER_API_KEY not set" };
+    if (!(await this.authHeaders())) return { skipped: true, reason: "no BuildBetter auth (set BUILDBETTER_API_KEY or connect BuildBetter via MCP)" };
     if (!this.runtime?.observations?.record) return { skipped: true, reason: "no observation store" };
 
     const sinceIso = new Date(now.getTime() - LOOKBACK_DAYS * 86400 * 1000).toISOString();
@@ -281,13 +393,19 @@ export class BuildBetterTaskSource {
 }
 
 export function registerBuildBetterTaskSource(runtime, options = {}) {
-  const source = options.source ?? new BuildBetterTaskSource({ runtime, ...options });
+  // Reuse the MCP registry's view of the BuildBetter server (if connected) so
+  // the OAuth fallback reads the exact token cache the MCP client wrote.
+  const rec = runtime?.mcp?.servers?.get?.("buildbetter");
+  const source = options.source ?? new BuildBetterTaskSource({
+    runtime,
+    dataDir: runtime?.mcp?.dataDir,
+    oauthResourceUrl: rec?.resourceUrl ?? (rec?.url ? originOf(rec.url) : undefined),
+    ...options
+  });
   if (!source.isConfigured()) {
     return {
       registered: false,
-      reason: source.apiKey
-        ? "BUILDBETTER_USER_EMAIL or BUILDBETTER_USER_NAME required"
-        : "BUILDBETTER_API_KEY not set"
+      reason: "no BuildBetter auth — set BUILDBETTER_API_KEY or connect BuildBetter from the MCP tab"
     };
   }
   if (runtime.cron?.addJob) {
@@ -301,4 +419,9 @@ export function registerBuildBetterTaskSource(runtime, options = {}) {
   }
   runtime.buildBetterTaskSource = source;
   return { registered: true };
+}
+
+// Origin (scheme + host) of an MCP server URL, for the OAuth resource id.
+function originOf(u) {
+  try { return new URL(u).origin; } catch { return BUILDBETTER_MCP_RESOURCE_URL; }
 }

--- a/src/integrations/buildbetter-tasks.js
+++ b/src/integrations/buildbetter-tasks.js
@@ -17,16 +17,12 @@
 // Adapted from autolist's apps/api/src/lib/integrations/buildbetter.ts
 // to OpenAGI's task store + integration registry pattern.
 
-import { McpOAuthClient } from "../mcp-oauth.js";
-import { resolveDataDir } from "../data-dir.js";
-
 const BUILDBETTER_ENDPOINT = "https://api.buildbetter.app/v1/graphql";
-// Origin of the BuildBetter MCP server, used to build the OAuth client that
-// reads the token cached under <dataDir>/mcp/auth/buildbetter.json. The actual
-// silent refresh uses the discovery metadata stored in that cache, so this
-// only needs to be correct enough to satisfy the constructor — prod and
-// staging tokens both refresh fine once the cache exists.
-const BUILDBETTER_MCP_RESOURCE_URL = "https://mcp.buildbetter.app";
+// The MCP server id this integration reuses for OAuth (option 2): when no API
+// key is set, the poller borrows the token the user already granted to the
+// BuildBetter MCP server, via the shared registry primitives
+// runtime.mcp.silentTokenFor() / hasOAuthToken().
+const BUILDBETTER_MCP_ID = "buildbetter";
 const ME_QUERY = "query Me { me { person { first_name last_name email } } }";
 const POLL_INTERVAL_MS = 15 * 60 * 1000;
 const LOOKBACK_DAYS = 7;
@@ -37,14 +33,6 @@ export class BuildBetterTaskSource {
     this.apiKey = options.apiKey ?? process.env.BUILDBETTER_API_KEY ?? null;
     this.userEmail = options.userEmail ?? process.env.BUILDBETTER_USER_EMAIL ?? null;
     this.userName = options.userName ?? process.env.BUILDBETTER_USER_NAME ?? null;
-    // OAuth fallback (option 2): reuse the BuildBetter MCP connection. The
-    // client is built lazily so we never touch the filesystem / construct it
-    // when an API key is set. dataDir + resourceUrl come from the MCP registry
-    // when available so we read the exact same token cache the MCP client wrote.
-    this.dataDir = options.dataDir ?? resolveDataDir();
-    this.oauthResourceUrl = options.oauthResourceUrl ?? BUILDBETTER_MCP_RESOURCE_URL;
-    this.oauthClient = options.oauthClient ?? null;
-    this._oauthTried = false;
     // Identity auto-derivation (option 1): once we've successfully asked `me`,
     // don't ask again this process — even if it returned no user.
     this._identityResolved = false;
@@ -60,61 +48,18 @@ export class BuildBetterTaskSource {
 
   isConfigured() {
     // Identity is auto-derived now, so auth alone is enough: an API key, or a
-    // previously-completed BuildBetter MCP OAuth connection.
-    return Boolean(this.apiKey) || this._hasOAuthCache();
-  }
-
-  // Lazily build the OAuth client. Returns null if it can't be constructed.
-  _oauth() {
-    if (this.oauthClient) return this.oauthClient;
-    if (this._oauthTried) return null;
-    this._oauthTried = true;
-    try {
-      this.oauthClient = new McpOAuthClient({
-        name: "buildbetter",
-        resourceUrl: this.oauthResourceUrl,
-        dataDir: this.dataDir
-      });
-    } catch {
-      this.oauthClient = null;
-    }
-    return this.oauthClient;
-  }
-
-  // Sync probe: is there a usable cached OAuth token/refresh token on disk?
-  _hasOAuthCache() {
-    const client = this._oauth();
-    if (!client) return false;
-    try {
-      const cache = client.loadCache();
-      return Boolean(cache?.access_token || cache?.refresh_token);
-    } catch {
-      return false;
-    }
-  }
-
-  // Silently obtain a Bearer token from the cached OAuth connection. Delegates
-  // to the canonical token lifecycle in McpOAuthClient (cached-or-refresh, no
-  // browser): ensureToken({interactive:false}) returns a valid token or throws
-  // OAUTH_INTERACTIVE_REQUIRED / a refresh error, both of which mean "no token"
-  // for a headless poller. Sharing this keeps us from drifting from how the
-  // live MCP client refreshes the same cache.
-  async _oauthToken() {
-    const client = this._oauth();
-    if (!client) return null;
-    try {
-      return await client.ensureToken({ interactive: false });
-    } catch {
-      return null;
-    }
+    // previously-completed BuildBetter MCP OAuth connection (token cached on
+    // disk, probed via the shared registry primitive).
+    return Boolean(this.apiKey) || Boolean(this.runtime?.mcp?.hasOAuthToken?.(BUILDBETTER_MCP_ID));
   }
 
   // Resolve auth headers: API key wins (preserves existing setups), else the
-  // reused MCP OAuth token. Returns null when neither is available.
+  // BuildBetter MCP OAuth token reused via the registry (silent, never opens a
+  // browser). Returns null when neither is available.
   async authHeaders() {
     // BuildBetter's exact header spelling per their docs.
     if (this.apiKey) return { "X-BuildBetter-Api-Key": this.apiKey };
-    const token = await this._oauthToken();
+    const token = await this.runtime?.mcp?.silentTokenFor?.(BUILDBETTER_MCP_ID);
     if (token) return { authorization: `Bearer ${token}` };
     return null;
   }
@@ -393,15 +338,7 @@ export class BuildBetterTaskSource {
 }
 
 export function registerBuildBetterTaskSource(runtime, options = {}) {
-  // Reuse the MCP registry's view of the BuildBetter server (if connected) so
-  // the OAuth fallback reads the exact token cache the MCP client wrote.
-  const rec = runtime?.mcp?.servers?.get?.("buildbetter");
-  const source = options.source ?? new BuildBetterTaskSource({
-    runtime,
-    dataDir: runtime?.mcp?.dataDir,
-    oauthResourceUrl: rec?.resourceUrl ?? (rec?.url ? originOf(rec.url) : undefined),
-    ...options
-  });
+  const source = options.source ?? new BuildBetterTaskSource({ runtime, ...options });
   // Register the source + cron even when no credentials exist yet. Auth can
   // arrive mid-session — the user connects BuildBetter from the MCP tab and an
   // OAuth token cache appears — and the poller + webhook must start working
@@ -420,10 +357,5 @@ export function registerBuildBetterTaskSource(runtime, options = {}) {
       intervalMs: POLL_INTERVAL_MS
     });
   }
-  return { registered: true, idle: !source.isConfigured() };
-}
-
-// Origin (scheme + host) of an MCP server URL, for the OAuth resource id.
-function originOf(u) {
-  try { return new URL(u).origin; } catch { return BUILDBETTER_MCP_RESOURCE_URL; }
+  return { registered: true };
 }

--- a/src/mcp-http-client.js
+++ b/src/mcp-http-client.js
@@ -55,11 +55,10 @@ export class McpHttpClient {
 
   async connect({ interactive = true } = {}) {
     if (this.connected) return { tools: this.tools, serverInfo: this.serverInfo };
-    // Applies for the duration of this connect's requests; controls whether an
-    // OAuth token miss may open a browser (true) or must fail fast (false).
-    this._interactiveAuth = interactive;
     if (this.logDir) ensureDir(this.logDir);
     try {
+      // `interactive` is threaded per-request (not latched on the instance) so
+      // a silent boot connect can't leave later tool calls unable to re-auth.
       this.serverInfo = await this.request(
         "initialize",
         {
@@ -67,11 +66,11 @@ export class McpHttpClient {
           capabilities: { tools: {} },
           clientInfo: { name: "openagi", version: "0.2.0" }
         },
-        { timeoutMs: this.initializeTimeoutMs }
+        { timeoutMs: this.initializeTimeoutMs, interactive }
       );
       // notifications/initialized has no response.
-      await this.notify("notifications/initialized", {});
-      const list = await this.request("tools/list", {});
+      await this.notify("notifications/initialized", {}, { interactive });
+      const list = await this.request("tools/list", {}, { interactive });
       this.tools = list?.tools ?? [];
       this.connected = true;
       this.lastError = null;
@@ -94,21 +93,21 @@ export class McpHttpClient {
     return this.request("tools/call", { name: toolName, arguments: args });
   }
 
-  notify(method, params) {
-    return this.send({ jsonrpc: "2.0", method, params }, { isNotification: true });
+  notify(method, params, options = {}) {
+    return this.send({ jsonrpc: "2.0", method, params }, { isNotification: true, interactive: options.interactive });
   }
 
   async request(method, params, options = {}) {
     const id = this.nextId++;
     const message = { jsonrpc: "2.0", id, method, params };
-    return this.send(message, { timeoutMs: options.timeoutMs });
+    return this.send(message, { timeoutMs: options.timeoutMs, interactive: options.interactive });
   }
 
   /**
    * Send a JSON-RPC message. Awaits response unless `isNotification` is set.
    * On 401 with an oauth client: refresh once, retry once.
    */
-  async send(message, { isNotification = false, timeoutMs = this.timeoutMs, retried = false } = {}) {
+  async send(message, { isNotification = false, timeoutMs = this.timeoutMs, retried = false, interactive = true } = {}) {
     const headers = {
       "content-type": "application/json",
       accept: "application/json, text/event-stream",
@@ -116,7 +115,7 @@ export class McpHttpClient {
     };
     if (this.bearerToken) headers.authorization = `Bearer ${this.bearerToken}`;
     if (this.oauth) {
-      const token = await this.oauth.ensureToken({ interactive: this._interactiveAuth ?? true });
+      const token = await this.oauth.ensureToken({ interactive });
       headers.authorization = `Bearer ${token}`;
     }
     if (this.sessionId) headers["mcp-session-id"] = this.sessionId;
@@ -146,7 +145,7 @@ export class McpHttpClient {
       // Force a re-auth on next call.
       const cache = this.oauth.loadCache();
       if (cache) this.oauth.saveCache({ ...cache, access_token: null, expires_at: 0 });
-      return this.send(message, { isNotification, timeoutMs, retried: true });
+      return this.send(message, { isNotification, timeoutMs, retried: true, interactive });
     }
 
     if (response.status === 202) {

--- a/src/mcp-http-client.js
+++ b/src/mcp-http-client.js
@@ -53,8 +53,11 @@ export class McpHttpClient {
     };
   }
 
-  async connect() {
+  async connect({ interactive = true } = {}) {
     if (this.connected) return { tools: this.tools, serverInfo: this.serverInfo };
+    // Applies for the duration of this connect's requests; controls whether an
+    // OAuth token miss may open a browser (true) or must fail fast (false).
+    this._interactiveAuth = interactive;
     if (this.logDir) ensureDir(this.logDir);
     try {
       this.serverInfo = await this.request(
@@ -113,7 +116,7 @@ export class McpHttpClient {
     };
     if (this.bearerToken) headers.authorization = `Bearer ${this.bearerToken}`;
     if (this.oauth) {
-      const token = await this.oauth.ensureToken();
+      const token = await this.oauth.ensureToken({ interactive: this._interactiveAuth ?? true });
       headers.authorization = `Bearer ${token}`;
     }
     if (this.sessionId) headers["mcp-session-id"] = this.sessionId;

--- a/src/mcp-oauth.js
+++ b/src/mcp-oauth.js
@@ -27,7 +27,14 @@ export class McpOAuthClient {
     if (!options.resourceUrl) throw new Error("McpOAuthClient requires resourceUrl");
     this.name = options.name ?? "mcp";
     this.resourceUrl = stripTrailingSlash(options.resourceUrl);
-    this.scope = options.scope ?? DEFAULT_SCOPE;
+    // The scope we'd *prefer*. The scope actually requested is narrowed at
+    // discovery time to what the server advertises as supported — servers that
+    // advertise none (e.g. Rize) get no scope param at all, instead of a
+    // hardcoded set they'd reject with `invalid_scope`. A scope passed
+    // explicitly (e.g. from a catalog entry) is treated as authoritative and
+    // sent as-is.
+    this.preferredScope = options.scope ?? DEFAULT_SCOPE;
+    this.scopeExplicit = options.scope != null;
     this.dataDir = options.dataDir ?? resolveDataDir();
     this.cachePath = path.join(this.dataDir, "mcp", "auth", `${this.name}.json`);
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -83,10 +90,26 @@ export class McpOAuthClient {
   /**
    * Authorization code + PKCE flow. Returns once tokens are saved to cache.
    */
+  // Narrow the requested scope to what this server actually supports. RFC 9728
+  // (protected resource) and RFC 8414 (auth server) both may advertise
+  // `scopes_supported`. We request the intersection of our preferred scopes
+  // with what's advertised; if the server advertises nothing, we omit `scope`
+  // entirely and let the server apply its own default. Returns null = "omit".
+  resolveScope(discovery) {
+    if (this.scopeExplicit) return this.preferredScope; // caller forced it
+    const supported = discovery?.resourceMeta?.scopes_supported
+      ?? discovery?.serverMeta?.scopes_supported;
+    if (!Array.isArray(supported)) return null;
+    const want = this.preferredScope.split(/\s+/).filter(Boolean);
+    const inter = want.filter((s) => supported.includes(s));
+    return inter.length ? inter.join(" ") : null;
+  }
+
   async authorize() {
     const discovery = await this.discover();
+    const scope = this.resolveScope(discovery);
     const cache = this.loadCache() ?? {};
-    const client = this.staticClient ?? cache.client ?? (await this.registerClient(discovery));
+    const client = this.staticClient ?? cache.client ?? (await this.registerClient(discovery, scope));
 
     const codeVerifier = base64url(randomBytes(48));
     const codeChallenge = base64url(createHash("sha256").update(codeVerifier).digest());
@@ -103,7 +126,9 @@ export class McpOAuthClient {
     authUrl.searchParams.set("code_challenge", codeChallenge);
     authUrl.searchParams.set("code_challenge_method", "S256");
     authUrl.searchParams.set("state", state);
-    authUrl.searchParams.set("scope", this.scope);
+    // Only send `scope` when we have one the server supports — sending an
+    // unsupported scope (or a hardcoded default) is what triggers invalid_scope.
+    if (scope) authUrl.searchParams.set("scope", scope);
     authUrl.searchParams.set("resource", this.resourceUrl);
 
     this.printAuthUrlFn({ name: this.name, url: authUrl.toString() });
@@ -180,7 +205,7 @@ export class McpOAuthClient {
       refresh_token: tokens.refresh_token ?? this.loadCache()?.refresh_token ?? null,
       token_type: tokens.token_type ?? "Bearer",
       expires_at,
-      scope: tokens.scope ?? this.scope,
+      scope: tokens.scope ?? this.preferredScope,
       discovery,
       client
     });
@@ -230,20 +255,29 @@ export class McpOAuthClient {
    * Dynamic client registration (RFC 7591). Returns the registered client
    * descriptor, including client_id (and client_secret if confidential).
    */
-  async registerClient(discovery) {
+  async registerClient(discovery, scope = null) {
     if (!discovery.serverMeta.registration_endpoint) {
       throw new Error("Authorization server has no registration_endpoint and no static client_id was provided");
     }
+    // Only register grant types the server actually supports — Rize, for
+    // example, advertises authorization_code only, so registering
+    // refresh_token can be rejected.
+    const supportedGrants = discovery.serverMeta.grant_types_supported;
+    const grant_types = Array.isArray(supportedGrants)
+      ? ["authorization_code", "refresh_token"].filter((g) => supportedGrants.includes(g))
+      : ["authorization_code", "refresh_token"];
+    if (!grant_types.includes("authorization_code")) grant_types.push("authorization_code");
     const body = {
       client_name: "OpenAGI",
       client_uri: "https://github.com/Spshulem/openAGI",
       redirect_uris: redirectUriCandidates(),
-      grant_types: ["authorization_code", "refresh_token"],
+      grant_types,
       response_types: ["code"],
       token_endpoint_auth_method: "none",
-      scope: this.scope,
       application_type: "native"
     };
+    // Only advertise a scope at registration if we have a server-supported one.
+    if (scope) body.scope = scope;
     const response = await fetch(discovery.serverMeta.registration_endpoint, {
       method: "POST",
       headers: { "content-type": "application/json", accept: "application/json" },

--- a/src/mcp-oauth.js
+++ b/src/mcp-oauth.js
@@ -105,9 +105,15 @@ export class McpOAuthClient {
   // entirely and let the server apply its own default. Returns null = "omit".
   resolveScope(discovery) {
     if (this.scopeExplicit) return this.preferredScope; // caller forced it
-    const supported = discovery?.resourceMeta?.scopes_supported
-      ?? discovery?.serverMeta?.scopes_supported;
-    if (!Array.isArray(supported)) return null;
+    // Prefer the resource's advertised scopes, but fall through to the auth
+    // server's when the resource advertises an EMPTY list (an empty array is
+    // not nullish, so a plain `??` would wrongly stop at it).
+    const resourceScopes = discovery?.resourceMeta?.scopes_supported;
+    const serverScopes = discovery?.serverMeta?.scopes_supported;
+    const supported = (Array.isArray(resourceScopes) && resourceScopes.length) ? resourceScopes
+      : (Array.isArray(serverScopes) && serverScopes.length) ? serverScopes
+      : null;
+    if (!supported) return null;
     const want = this.preferredScope.split(/\s+/).filter(Boolean);
     const inter = want.filter((s) => supported.includes(s));
     return inter.length ? inter.join(" ") : null;

--- a/src/mcp-oauth.js
+++ b/src/mcp-oauth.js
@@ -64,7 +64,7 @@ export class McpOAuthClient {
    * Return a valid access token. Uses cached if not expired, refreshes if it
    * has a refresh_token, otherwise runs the full authorization code flow.
    */
-  async ensureToken() {
+  async ensureToken({ interactive = true } = {}) {
     const cache = this.loadCache() ?? {};
     if (cache.access_token && !this.isExpired(cache)) {
       return cache.access_token;
@@ -77,6 +77,14 @@ export class McpOAuthClient {
         // fall through to full flow
         cache.refresh_token = null;
       }
+    }
+    // Non-interactive callers (e.g. silent reconnect on daemon boot) must never
+    // trigger the browser flow — surface a typed error so the caller can leave
+    // the server "idle" with a Connect button instead of popping a window.
+    if (!interactive) {
+      const err = new Error(`OAuth authorization required for ${this.name}`);
+      err.code = "OAUTH_INTERACTIVE_REQUIRED";
+      throw err;
     }
     await this.authorize();
     return this.loadCache().access_token;

--- a/src/mcp-registry.js
+++ b/src/mcp-registry.js
@@ -312,19 +312,22 @@ export class McpRegistry {
   }
 
   async connectAll({ silent = false } = {}) {
+    const targets = [...this.servers].filter(([, server]) => {
+      if (!server.enabled) return false;
+      if (server.transport === "stdio" && !server.command) return false;
+      if (server.transport === "http" && !server.url) return false;
+      return server.transport === "stdio" || server.transport === "http";
+    });
+    const attempt = (name) => this.connect(name, { silent }).then(
+      (status) => ({ name, ok: true, status }),
+      (error) => ({ name, ok: false, error: error.message, code: error.code ?? null })
+    );
+    // Silent boot reconnect runs concurrently (no browser, so no popup storm)
+    // to pay max-latency, not sum. Interactive connect-all stays sequential so
+    // we never open several OAuth browser tabs at once.
+    if (silent) return Promise.all(targets.map(([name]) => attempt(name)));
     const results = [];
-    for (const [name, server] of this.servers) {
-      if (!server.enabled) continue;
-      if (server.transport === "stdio" && !server.command) continue;
-      if (server.transport === "http" && !server.url) continue;
-      if (server.transport !== "stdio" && server.transport !== "http") continue;
-      try {
-        const status = await this.connect(name, { silent });
-        results.push({ name, ok: true, status });
-      } catch (error) {
-        results.push({ name, ok: false, error: error.message, code: error.code ?? null });
-      }
-    }
+    for (const [name] of targets) results.push(await attempt(name));
     return results;
   }
 

--- a/src/mcp-registry.js
+++ b/src/mcp-registry.js
@@ -294,7 +294,15 @@ export class McpRegistry {
   hasOAuthToken(name) {
     try {
       const cache = readJsonFile(path.join(this.dataDir, "mcp", "auth", `${name}.json`), null);
-      return Boolean(cache?.access_token || cache?.refresh_token);
+      if (!cache) return false;
+      // Mirror what ensureToken({interactive:false}) can actually do: a
+      // refresh_token can always mint a fresh access token silently, but a
+      // bare access_token only counts while unexpired (same 30s safety margin
+      // as McpOAuthClient.isExpired) — otherwise integrations report
+      // "configured", ack webhooks, and then silently fail to authenticate.
+      if (cache.refresh_token) return true;
+      if (!cache.access_token || !cache.expires_at) return false;
+      return Date.now() < cache.expires_at - 30_000;
     } catch {
       return false;
     }

--- a/src/mcp-registry.js
+++ b/src/mcp-registry.js
@@ -235,14 +235,69 @@ export class McpRegistry {
   }
 
   async connect(name, { silent = false } = {}) {
-    if (this.connecting.has(name)) return this.connecting.get(name);
+    const inflight = this.connecting.get(name);
+    if (inflight) {
+      // An interactive (non-silent) in-flight connect serves any caller. A
+      // silent in-flight connect serves silent callers. But an interactive
+      // caller must NOT be handed a silent attempt (which fails fast without
+      // opening a browser) — wait for it, then connect interactively if the
+      // silent attempt didn't already get us connected.
+      if (!inflight.silent || silent) return inflight.promise;
+      return inflight.promise.then(
+        (status) => status,
+        () => this.connect(name, { silent: false })
+      );
+    }
     const promise = this.doConnect(name, { silent });
-    this.connecting.set(name, promise);
+    const entry = { promise, silent };
+    this.connecting.set(name, entry);
     // The caller awaits `promise` and handles its rejection; this cleanup chain
     // is separate, so swallow its copy of the rejection to avoid an
     // unhandledRejection when a connect fails (e.g. silent boot reconnect).
-    promise.finally(() => this.connecting.delete(name)).catch(() => {});
+    promise.finally(() => {
+      if (this.connecting.get(name) === entry) this.connecting.delete(name);
+    }).catch(() => {});
     return promise;
+  }
+
+  /**
+   * Silently obtain a Bearer token for a connected OAuth MCP server, reusing
+   * the registry's own OAuth client (or the cached token on disk) — never opens
+   * a browser. Returns null when there's no usable token. This is the shared
+   * primitive integrations use to call a vendor's REST/GraphQL API with the
+   * same login the user already granted to that vendor's MCP server.
+   */
+  async silentTokenFor(name) {
+    let oauth = this.clients.get(name)?.oauth ?? null;
+    if (!oauth) {
+      const server = this.servers.get(name);
+      if (server?.auth !== "oauth" || !server.url) return null;
+      oauth = new McpOAuthClient({
+        name: server.name,
+        resourceUrl: server.resourceUrl ?? deriveResourceUrl(server.url),
+        scope: server.scope,
+        dataDir: this.dataDir
+      });
+    }
+    try {
+      return await oauth.ensureToken({ interactive: false });
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Sync probe: is there a usable OAuth token cached on disk for this server
+   * (so an integration can report itself "configured" without a network call)?
+   * Reads the same <dataDir>/mcp/auth/<name>.json the OAuth client writes.
+   */
+  hasOAuthToken(name) {
+    try {
+      const cache = readJsonFile(path.join(this.dataDir, "mcp", "auth", `${name}.json`), null);
+      return Boolean(cache?.access_token || cache?.refresh_token);
+    } catch {
+      return false;
+    }
   }
 
   async doConnect(name, { silent = false } = {}) {

--- a/src/mcp-registry.js
+++ b/src/mcp-registry.js
@@ -234,15 +234,18 @@ export class McpRegistry {
     return this.connecting.has(name);
   }
 
-  async connect(name) {
+  async connect(name, { silent = false } = {}) {
     if (this.connecting.has(name)) return this.connecting.get(name);
-    const promise = this.doConnect(name);
+    const promise = this.doConnect(name, { silent });
     this.connecting.set(name, promise);
-    promise.finally(() => this.connecting.delete(name));
+    // The caller awaits `promise` and handles its rejection; this cleanup chain
+    // is separate, so swallow its copy of the rejection to avoid an
+    // unhandledRejection when a connect fails (e.g. silent boot reconnect).
+    promise.finally(() => this.connecting.delete(name)).catch(() => {});
     return promise;
   }
 
-  async doConnect(name) {
+  async doConnect(name, { silent = false } = {}) {
     const server = this.servers.get(name);
     if (!server) throw new Error(`Unknown MCP server: ${name}`);
     if (!server.enabled) throw new Error(`MCP server ${name} is disabled.`);
@@ -302,12 +305,13 @@ export class McpRegistry {
       }
       this.clients.set(name, client);
     }
-    await client.connect();
+    // silent → never open a browser for OAuth; fail fast if a token isn't cached.
+    await client.connect({ interactive: !silent });
     this.exposeAsTools(server.name);
     return client.status();
   }
 
-  async connectAll() {
+  async connectAll({ silent = false } = {}) {
     const results = [];
     for (const [name, server] of this.servers) {
       if (!server.enabled) continue;
@@ -315,10 +319,10 @@ export class McpRegistry {
       if (server.transport === "http" && !server.url) continue;
       if (server.transport !== "stdio" && server.transport !== "http") continue;
       try {
-        const status = await this.connect(name);
+        const status = await this.connect(name, { silent });
         results.push({ name, ok: true, status });
       } catch (error) {
-        results.push({ name, ok: false, error: error.message });
+        results.push({ name, ok: false, error: error.message, code: error.code ?? null });
       }
     }
     return results;

--- a/src/setup-wizard.js
+++ b/src/setup-wizard.js
@@ -272,9 +272,10 @@ export function renderWizard({ proposedToken } = {}) {
         <summary>BuildBetter — call action items become tasks</summary>
         <div style="padding-top:10px;" class="grid">
           <p class="sub">Pulls action_item / commitment / follow_up extractions from your recent calls. Polls every 15 min, and (optionally) syncs instantly via webhook.</p>
-          <div><label>BUILDBETTER_API_KEY</label><input type="password" name="BUILDBETTER_API_KEY" autocomplete="off"></div>
-          <div><label>BUILDBETTER_USER_EMAIL <span class="sub">(or use BUILDBETTER_USER_NAME below)</span></label><input type="email" name="BUILDBETTER_USER_EMAIL" placeholder="you@example.com"></div>
-          <div><label>BUILDBETTER_USER_NAME <span class="sub">(alternative to email)</span></label><input type="text" name="BUILDBETTER_USER_NAME" placeholder="Your Name"></div>
+          <p class="sub">Already connected BuildBetter on the <code>MCP</code> tab? You can leave everything below blank — OpenAGI reuses that login.</p>
+          <div><label>BUILDBETTER_API_KEY <span class="sub">(optional if connected via MCP)</span></label><input type="password" name="BUILDBETTER_API_KEY" autocomplete="off"></div>
+          <div><label>BUILDBETTER_USER_EMAIL <span class="sub">(optional — auto-detected from your login)</span></label><input type="email" name="BUILDBETTER_USER_EMAIL" placeholder="you@example.com"></div>
+          <div><label>BUILDBETTER_USER_NAME <span class="sub">(optional — only needed if auto-detect can't pinpoint you)</span></label><input type="text" name="BUILDBETTER_USER_NAME" placeholder="Your Name"></div>
           <div><label>BUILDBETTER_WEBHOOK_SECRET <span class="sub">(optional — enables instant push)</span></label><input type="password" name="BUILDBETTER_WEBHOOK_SECRET" autocomplete="off" placeholder="a long random string"><p class="sub">Set this, then point a BuildBetter webhook at <code>&lt;your public URL&gt;/webhooks/buildbetter?secret=…</code> (shown on the Channels tab once a public URL is set) to sync the moment a call is processed instead of waiting for the poll.</p></div>
         </div>
       </details>

--- a/test/abi-runtime.test.js
+++ b/test/abi-runtime.test.js
@@ -3215,7 +3215,7 @@ test("webhooks: /webhooks/buildbetter requires secret, then triggers a sync (202
   const { createHostedInterface } = await import("../src/hosted-interface.js");
   let synced = 0;
   const runtime = {
-    buildBetterTaskSource: { triggerSync: async () => { synced += 1; return { created: 1 }; } },
+    buildBetterTaskSource: { isConfigured: () => true, triggerSync: async () => { synced += 1; return { created: 1 }; } },
     events: { on: () => {}, emit: () => {} }
   };
   const app = createHostedInterface(runtime, { port: 0, buildBetterWebhookSecret: "hook-secret" });
@@ -3241,5 +3241,22 @@ test("webhooks: /webhooks/buildbetter requires secret, then triggers a sync (202
   await new Promise((r) => setTimeout(r, 30));
   assert.ok(synced >= 1, "sync triggered by webhook");
 
+  await app.close();
+});
+
+test("webhooks: /webhooks/buildbetter 503s (not a false 202) when the source is unconfigured", async () => {
+  const { createHostedInterface } = await import("../src/hosted-interface.js");
+  let synced = 0;
+  const runtime = {
+    // Source is registered (so a mid-session MCP login works) but has no creds yet.
+    buildBetterTaskSource: { isConfigured: () => false, triggerSync: async () => { synced += 1; } },
+    events: { on: () => {}, emit: () => {} }
+  };
+  const app = createHostedInterface(runtime, { port: 0, buildBetterWebhookSecret: "hook-secret" });
+  const address = await app.listen();
+  const resp = await fetch(`${address.url}/webhooks/buildbetter?secret=hook-secret`, { method: "POST", headers: { "content-type": "application/json" }, body: "{}" });
+  assert.equal(resp.status, 503, "unconfigured → 503 so BuildBetter retries, not a swallowed 202");
+  await new Promise((r) => setTimeout(r, 20));
+  assert.equal(synced, 0, "no sync attempted while unconfigured");
   await app.close();
 });

--- a/test/agent-host-screen-context.test.js
+++ b/test/agent-host-screen-context.test.js
@@ -1,0 +1,27 @@
+// test/agent-host-screen-context.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { formatScreenContextBlock } from "../src/agent-host.js";
+
+test("formats a labeled active-window block from screenContext", () => {
+  const block = formatScreenContextBlock({ app: "Safari", window: "Spec — Notion", text: "the deadline is Friday" });
+  assert.match(block, /Active window the user is looking at right now \(Safari · Spec — Notion\)/);
+  assert.match(block, /the deadline is Friday/);
+});
+
+test("returns empty string for missing/empty screenContext", () => {
+  assert.equal(formatScreenContextBlock(null), "");
+  assert.equal(formatScreenContextBlock({ app: "X" }), "");
+  assert.equal(formatScreenContextBlock({ text: "   " }), "");
+});
+
+test("truncates very long screen text to 4000 chars", () => {
+  const block = formatScreenContextBlock({ app: "X", text: "a".repeat(5000) });
+  const body = block.split("\n").find((l) => l.startsWith("aaaa"));
+  assert.ok(body.length <= 4000, `body should be <= 4000, got ${body.length}`);
+});
+
+test("falls back to 'active window' when app is absent", () => {
+  const block = formatScreenContextBlock({ text: "hello" });
+  assert.match(block, /\(active window\)/);
+});

--- a/test/buildbetter-auth.test.js
+++ b/test/buildbetter-auth.test.js
@@ -74,42 +74,35 @@ test("authHeaders uses the API key when set", async () => {
 });
 
 test("authHeaders falls back to a reused OAuth bearer token", async () => {
+  // _oauthToken delegates to the canonical ensureToken({interactive:false}).
   const fakeOauth = {
-    loadCache: () => ({ access_token: "tok", expires_at: Date.now() + 600_000 }),
-    isExpired: () => false,
-    refresh: async () => { throw new Error("should not refresh a fresh token"); }
+    ensureToken: async ({ interactive }) => {
+      assert.equal(interactive, false, "poller must never open a browser");
+      return "tok";
+    }
   };
   const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
   assert.deepEqual(await src.authHeaders(), { authorization: "Bearer tok" });
 });
 
-test("authHeaders returns null with no api key and no OAuth cache", async () => {
-  const fakeOauth = { loadCache: () => null, isExpired: () => true, refresh: async () => {} };
+test("authHeaders returns null when ensureToken can't get a token without a browser", async () => {
+  const fakeOauth = {
+    ensureToken: async () => { const e = new Error("no token"); e.code = "OAUTH_INTERACTIVE_REQUIRED"; throw e; }
+  };
   const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
   assert.equal(await src.authHeaders(), null);
 });
 
-test("_oauthToken silently refreshes an expired token (no browser flow)", async () => {
-  let refreshed = false;
-  const fakeOauth = {
-    loadCache() {
-      return refreshed
-        ? { access_token: "new", expires_at: Date.now() + 600_000 }
-        : { access_token: "old", expires_at: 0, refresh_token: "r", discovery: {}, client: {} };
-    },
-    isExpired(c) { return (c.expires_at ?? 0) <= Date.now(); },
-    refresh: async () => { refreshed = true; }
-  };
+test("_oauthToken delegates to ensureToken({interactive:false}) and returns its token", async () => {
+  let calledWith;
+  const fakeOauth = { ensureToken: async (opts) => { calledWith = opts; return "fresh-token"; } };
   const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
-  assert.equal(await src._oauthToken(), "new");
+  assert.equal(await src._oauthToken(), "fresh-token");
+  assert.deepEqual(calledWith, { interactive: false }, "must request a silent token, never interactive");
 });
 
-test("_oauthToken never triggers interactive auth when nothing is cached", async () => {
-  const fakeOauth = {
-    loadCache: () => null,
-    isExpired: () => true,
-    refresh: async () => { throw new Error("must not refresh"); }
-  };
+test("_oauthToken returns null when ensureToken throws (no usable cache / refresh failed)", async () => {
+  const fakeOauth = { ensureToken: async () => { throw new Error("refresh failed"); } };
   const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
   assert.equal(await src._oauthToken(), null);
 });

--- a/test/buildbetter-auth.test.js
+++ b/test/buildbetter-auth.test.js
@@ -1,0 +1,127 @@
+// test/buildbetter-auth.test.js
+// Covers the two auth improvements:
+//   1. Identity is auto-derived from the `me` query (no manual email/name).
+//   2. The poller can reuse the BuildBetter MCP OAuth connection (Bearer token,
+//      silently refreshed) instead of an API key.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { BuildBetterTaskSource } from "../src/integrations/buildbetter-tasks.js";
+
+// Isolate from any real BuildBetter env in the host so the OAuth path is
+// reachable when we don't pass an API key.
+delete process.env.BUILDBETTER_API_KEY;
+delete process.env.BUILDBETTER_USER_EMAIL;
+delete process.env.BUILDBETTER_USER_NAME;
+
+// — Option 1: identity auto-derivation via `me` —
+
+test("ensureIdentity auto-derives email from the me query", async () => {
+  const src = new BuildBetterTaskSource({ apiKey: "k" }); // no email/name given
+  src.query = async (q) => {
+    assert.match(q, /\bme\b/);
+    return { me: { person: { first_name: "Spencer", last_name: "Shulem", email: "spencer@buildbetter.app" } } };
+  };
+  await src.ensureIdentity();
+  assert.equal(src.userEmail, "spencer@buildbetter.app");
+});
+
+test("ensureIdentity falls back to full name when me has no email", async () => {
+  const src = new BuildBetterTaskSource({ apiKey: "k" });
+  src.query = async () => ({ me: { person: { first_name: "Ada", last_name: "Lovelace", email: null } } });
+  await src.ensureIdentity();
+  assert.equal(src.userEmail, null);
+  assert.equal(src.userName, "Ada Lovelace");
+});
+
+test("ensureIdentity is a no-op when identity is already known", async () => {
+  const src = new BuildBetterTaskSource({ apiKey: "k", userEmail: "me@x.com" });
+  let called = 0;
+  src.query = async () => { called += 1; return {}; };
+  await src.ensureIdentity();
+  assert.equal(called, 0, "must not hit the API when we already know who you are");
+});
+
+test("ensureIdentity does not re-query after a null me (org-scoped key)", async () => {
+  const src = new BuildBetterTaskSource({ apiKey: "k" });
+  let called = 0;
+  src.query = async () => { called += 1; return { me: null }; };
+  await src.ensureIdentity();
+  await src.ensureIdentity();
+  assert.equal(called, 1, "asked once, then falls back to env identity without re-asking");
+  assert.equal(src.userEmail, null);
+});
+
+test("ensureIdentity retries after a thrown (transient) error", async () => {
+  const src = new BuildBetterTaskSource({ apiKey: "k" });
+  let called = 0;
+  src.query = async () => {
+    called += 1;
+    if (called === 1) throw new Error("network");
+    return { me: { person: { first_name: "Grace", last_name: "Hopper", email: "grace@x.com" } } };
+  };
+  await src.ensureIdentity();
+  assert.equal(src.userEmail, null, "first attempt failed → still unresolved");
+  await src.ensureIdentity();
+  assert.equal(src.userEmail, "grace@x.com", "second attempt succeeds");
+  assert.equal(called, 2);
+});
+
+// — Option 2: reuse the MCP OAuth connection —
+
+test("authHeaders uses the API key when set", async () => {
+  const src = new BuildBetterTaskSource({ apiKey: "secret" });
+  assert.deepEqual(await src.authHeaders(), { "X-BuildBetter-Api-Key": "secret" });
+});
+
+test("authHeaders falls back to a reused OAuth bearer token", async () => {
+  const fakeOauth = {
+    loadCache: () => ({ access_token: "tok", expires_at: Date.now() + 600_000 }),
+    isExpired: () => false,
+    refresh: async () => { throw new Error("should not refresh a fresh token"); }
+  };
+  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+  assert.deepEqual(await src.authHeaders(), { authorization: "Bearer tok" });
+});
+
+test("authHeaders returns null with no api key and no OAuth cache", async () => {
+  const fakeOauth = { loadCache: () => null, isExpired: () => true, refresh: async () => {} };
+  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+  assert.equal(await src.authHeaders(), null);
+});
+
+test("_oauthToken silently refreshes an expired token (no browser flow)", async () => {
+  let refreshed = false;
+  const fakeOauth = {
+    loadCache() {
+      return refreshed
+        ? { access_token: "new", expires_at: Date.now() + 600_000 }
+        : { access_token: "old", expires_at: 0, refresh_token: "r", discovery: {}, client: {} };
+    },
+    isExpired(c) { return (c.expires_at ?? 0) <= Date.now(); },
+    refresh: async () => { refreshed = true; }
+  };
+  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+  assert.equal(await src._oauthToken(), "new");
+});
+
+test("_oauthToken never triggers interactive auth when nothing is cached", async () => {
+  const fakeOauth = {
+    loadCache: () => null,
+    isExpired: () => true,
+    refresh: async () => { throw new Error("must not refresh"); }
+  };
+  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+  assert.equal(await src._oauthToken(), null);
+});
+
+test("isConfigured is true with only a reused OAuth connection", () => {
+  const fakeOauth = { loadCache: () => ({ refresh_token: "r" }), isExpired: () => true };
+  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+  assert.equal(src.isConfigured(), true);
+});
+
+test("isConfigured is false with neither api key nor OAuth cache", () => {
+  const fakeOauth = { loadCache: () => null, isExpired: () => true };
+  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+  assert.equal(src.isConfigured(), false);
+});

--- a/test/buildbetter-auth.test.js
+++ b/test/buildbetter-auth.test.js
@@ -73,48 +73,30 @@ test("authHeaders uses the API key when set", async () => {
   assert.deepEqual(await src.authHeaders(), { "X-BuildBetter-Api-Key": "secret" });
 });
 
-test("authHeaders falls back to a reused OAuth bearer token", async () => {
-  // _oauthToken delegates to the canonical ensureToken({interactive:false}).
-  const fakeOauth = {
-    ensureToken: async ({ interactive }) => {
-      assert.equal(interactive, false, "poller must never open a browser");
-      return "tok";
-    }
-  };
-  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+test("authHeaders falls back to the BuildBetter MCP OAuth token via the registry", async () => {
+  let askedFor;
+  const mcp = { silentTokenFor: async (name) => { askedFor = name; return "tok"; } };
+  const src = new BuildBetterTaskSource({ apiKey: null, runtime: { mcp } });
   assert.deepEqual(await src.authHeaders(), { authorization: "Bearer tok" });
+  assert.equal(askedFor, "buildbetter", "reuses the buildbetter MCP server's token");
 });
 
-test("authHeaders returns null when ensureToken can't get a token without a browser", async () => {
-  const fakeOauth = {
-    ensureToken: async () => { const e = new Error("no token"); e.code = "OAUTH_INTERACTIVE_REQUIRED"; throw e; }
-  };
-  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
-  assert.equal(await src.authHeaders(), null);
+test("authHeaders returns null when the registry has no silent token", async () => {
+  const src1 = new BuildBetterTaskSource({ apiKey: null, runtime: { mcp: { silentTokenFor: async () => null } } });
+  assert.equal(await src1.authHeaders(), null);
+  // ...and when there's no registry at all.
+  const src2 = new BuildBetterTaskSource({ apiKey: null, runtime: {} });
+  assert.equal(await src2.authHeaders(), null);
 });
 
-test("_oauthToken delegates to ensureToken({interactive:false}) and returns its token", async () => {
-  let calledWith;
-  const fakeOauth = { ensureToken: async (opts) => { calledWith = opts; return "fresh-token"; } };
-  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
-  assert.equal(await src._oauthToken(), "fresh-token");
-  assert.deepEqual(calledWith, { interactive: false }, "must request a silent token, never interactive");
-});
-
-test("_oauthToken returns null when ensureToken throws (no usable cache / refresh failed)", async () => {
-  const fakeOauth = { ensureToken: async () => { throw new Error("refresh failed"); } };
-  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
-  assert.equal(await src._oauthToken(), null);
-});
-
-test("isConfigured is true with only a reused OAuth connection", () => {
-  const fakeOauth = { loadCache: () => ({ refresh_token: "r" }), isExpired: () => true };
-  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+test("isConfigured is true with only a reused OAuth connection (registry reports a cached token)", () => {
+  const src = new BuildBetterTaskSource({ apiKey: null, runtime: { mcp: { hasOAuthToken: () => true } } });
   assert.equal(src.isConfigured(), true);
 });
 
-test("isConfigured is false with neither api key nor OAuth cache", () => {
-  const fakeOauth = { loadCache: () => null, isExpired: () => true };
-  const src = new BuildBetterTaskSource({ apiKey: null, oauthClient: fakeOauth });
+test("isConfigured is false with neither api key nor a cached OAuth token", () => {
+  const src = new BuildBetterTaskSource({ apiKey: null, runtime: { mcp: { hasOAuthToken: () => false } } });
   assert.equal(src.isConfigured(), false);
+  // No registry at all → also false.
+  assert.equal(new BuildBetterTaskSource({ apiKey: null, runtime: {} }).isConfigured(), false);
 });

--- a/test/buildbetter-transcripts.test.js
+++ b/test/buildbetter-transcripts.test.js
@@ -41,6 +41,20 @@ test("ingestMode defaults to signals", () => {
   if (prev !== undefined) process.env.BUILDBETTER_INGEST_MODE = prev;
 });
 
+test("syncTranscripts skips with a reason when identity can't be determined (no silent empty)", async () => {
+  const observations = fakeObservations();
+  // Auth present (api key) but no email/name, and `me` returns no user.
+  const src = new BuildBetterTaskSource({ apiKey: "k", runtime: { observations } });
+  src.query = async () => ({ me: { person: null } });
+  let fetched = 0;
+  src.getTranscript = async () => { fetched += 1; return "x"; };
+  const res = await src.syncTranscripts({ now: new Date("2026-06-02T00:00:00Z") });
+  assert.equal(res.skipped, true);
+  assert.match(res.reason, /identity/i);
+  assert.equal(observations._rows.length, 0, "records nothing");
+  assert.equal(fetched, 0, "never even fetches transcripts");
+});
+
 test("getTranscript assembles speaker-labeled lines, falling back to Speaker N", async () => {
   const src = new BuildBetterTaskSource({ apiKey: "k", userEmail: "me@x.com" });
   src.query = async () => ({

--- a/test/mcp-boot-reconnect.test.js
+++ b/test/mcp-boot-reconnect.test.js
@@ -42,13 +42,22 @@ test("connectAll({silent:true}) leaves an un-authorized OAuth server idle withou
   assert.equal(server.connected, false);
 });
 
-test("hasOAuthToken reflects the cached token on disk", () => {
+test("hasOAuthToken reflects a SILENTLY USABLE cached token on disk", () => {
   const reg = new McpRegistry({ dataDir: tmp, configPath: null });
   assert.equal(reg.hasOAuthToken("nope-no-cache"), false);
-  writeTokenCache("hbtcache", { access_token: "a" });
-  assert.equal(reg.hasOAuthToken("hbtcache"), true);
+  // A refresh token can always mint a new access token silently.
   writeTokenCache("hbtrefresh", { refresh_token: "r" });
   assert.equal(reg.hasOAuthToken("hbtrefresh"), true);
+  // A live access token (unexpired) counts.
+  writeTokenCache("hbtlive", { access_token: "a", expires_at: Date.now() + 600_000 });
+  assert.equal(reg.hasOAuthToken("hbtlive"), true);
+  // An expired (or unknown-expiry) access token with no refresh token does NOT:
+  // silentTokenFor() can't use it, so reporting "configured" would ack webhooks
+  // and then silently drop them.
+  writeTokenCache("hbtexpired", { access_token: "a", expires_at: Date.now() - 1000 });
+  assert.equal(reg.hasOAuthToken("hbtexpired"), false);
+  writeTokenCache("hbtcache", { access_token: "a" });
+  assert.equal(reg.hasOAuthToken("hbtcache"), false);
 });
 
 test("silentTokenFor returns a cached, unexpired token without a browser", async () => {

--- a/test/mcp-boot-reconnect.test.js
+++ b/test/mcp-boot-reconnect.test.js
@@ -5,11 +5,18 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
+import fs from "node:fs";
 import path from "node:path";
 import { McpOAuthClient } from "../src/mcp-oauth.js";
 import { McpRegistry } from "../src/mcp-registry.js";
 
 const tmp = path.join(os.tmpdir(), `openagi-boot-test-${process.pid}`);
+
+function writeTokenCache(name, cache) {
+  const dir = path.join(tmp, "mcp", "auth");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${name}.json`), JSON.stringify(cache));
+}
 
 test("ensureToken({interactive:false}) fails fast instead of opening a browser", async () => {
   const client = new McpOAuthClient({ resourceUrl: "https://example.test", dataDir: tmp });
@@ -33,4 +40,46 @@ test("connectAll({silent:true}) leaves an un-authorized OAuth server idle withou
   // And it must not report as connected.
   const server = reg.listServers().find((s) => s.name === "rize");
   assert.equal(server.connected, false);
+});
+
+test("hasOAuthToken reflects the cached token on disk", () => {
+  const reg = new McpRegistry({ dataDir: tmp, configPath: null });
+  assert.equal(reg.hasOAuthToken("nope-no-cache"), false);
+  writeTokenCache("hbtcache", { access_token: "a" });
+  assert.equal(reg.hasOAuthToken("hbtcache"), true);
+  writeTokenCache("hbtrefresh", { refresh_token: "r" });
+  assert.equal(reg.hasOAuthToken("hbtrefresh"), true);
+});
+
+test("silentTokenFor returns a cached, unexpired token without a browser", async () => {
+  const reg = new McpRegistry({ dataDir: tmp, configPath: null });
+  reg.registerServer({ name: "bb", url: "https://mcp.buildbetter.app/sse", auth: "oauth", trustLevel: "trusted" });
+  writeTokenCache("bb", { access_token: "live-token", expires_at: Date.now() + 600_000 });
+  assert.equal(await reg.silentTokenFor("bb"), "live-token");
+});
+
+test("silentTokenFor returns null for an un-authorized / unknown server (never prompts)", async () => {
+  const reg = new McpRegistry({ dataDir: tmp, configPath: null });
+  reg.registerServer({ name: "bb2", url: "https://mcp.buildbetter.app/sse", auth: "oauth", trustLevel: "trusted" });
+  assert.equal(await reg.silentTokenFor("bb2"), null);   // registered, no token cached
+  assert.equal(await reg.silentTokenFor("ghost"), null); // not registered at all
+});
+
+test("an interactive connect is not swallowed by an in-flight silent connect", async () => {
+  const reg = new McpRegistry({ dataDir: tmp, configPath: null });
+  reg.registerServer({ name: "x", url: "https://mcp.x.test/sse", auth: "oauth", trustLevel: "trusted" });
+  const calls = [];
+  reg.doConnect = async (_name, { silent }) => {
+    calls.push(silent);
+    if (silent) { const e = new Error("need browser"); e.code = "OAUTH_INTERACTIVE_REQUIRED"; throw e; }
+    return { connected: true };
+  };
+  // Silent boot attempt in-flight, then a user clicks Connect (interactive).
+  const silentP = reg.connect("x", { silent: true });
+  const interactiveP = reg.connect("x", { silent: false });
+  const [silentR, interactiveR] = await Promise.allSettled([silentP, interactiveP]);
+  assert.equal(silentR.status, "rejected", "silent attempt fails fast");
+  assert.equal(interactiveR.status, "fulfilled", "interactive attempt still runs");
+  assert.deepEqual(interactiveR.value, { connected: true });
+  assert.deepEqual(calls, [true, false], "both attempts ran; interactive was not handed the silent failure");
 });

--- a/test/mcp-boot-reconnect.test.js
+++ b/test/mcp-boot-reconnect.test.js
@@ -1,0 +1,36 @@
+// test/mcp-boot-reconnect.test.js
+// The daemon reconnects MCP servers on boot, but must do so SILENTLY — an
+// OAuth server without a cached token has to fail fast (no browser), leaving
+// it "idle" with a Connect button, never blocking startup.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { McpOAuthClient } from "../src/mcp-oauth.js";
+import { McpRegistry } from "../src/mcp-registry.js";
+
+const tmp = path.join(os.tmpdir(), `openagi-boot-test-${process.pid}`);
+
+test("ensureToken({interactive:false}) fails fast instead of opening a browser", async () => {
+  const client = new McpOAuthClient({ resourceUrl: "https://example.test", dataDir: tmp });
+  await assert.rejects(
+    () => client.ensureToken({ interactive: false }),
+    (e) => e.code === "OAUTH_INTERACTIVE_REQUIRED",
+    "must throw the typed interactive-required error, not call authorize()"
+  );
+});
+
+test("connectAll({silent:true}) leaves an un-authorized OAuth server idle without prompting", async () => {
+  const reg = new McpRegistry({ dataDir: tmp, configPath: null });
+  reg.registerServer({ name: "rize", url: "https://mcp.rize.io/sse", auth: "oauth", trustLevel: "trusted" });
+
+  // If silent mode were broken, this would hang on a 5-min browser callback.
+  const results = await reg.connectAll({ silent: true });
+  const rize = results.find((r) => r.name === "rize");
+  assert.equal(rize.ok, false);
+  assert.equal(rize.code, "OAUTH_INTERACTIVE_REQUIRED");
+
+  // And it must not report as connected.
+  const server = reg.listServers().find((s) => s.name === "rize");
+  assert.equal(server.connected, false);
+});

--- a/test/mcp-http-interactive.test.js
+++ b/test/mcp-http-interactive.test.js
@@ -1,0 +1,40 @@
+// test/mcp-http-interactive.test.js
+// Regression for the latched-interactive bug: the OAuth "may I open a browser?"
+// flag must be per-request, not stored on the client at connect time. A silent
+// boot connect must not leave later tool calls unable to re-authorize.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { McpHttpClient } from "../src/mcp-http-client.js";
+
+test("interactive flag is threaded per-call, not latched on the client", async () => {
+  const seen = [];
+  const fakeOauth = {
+    ensureToken: async ({ interactive }) => { seen.push(interactive); return "tok"; }
+  };
+  const client = new McpHttpClient({ name: "x", url: "https://example.test/mcp", oauth: fakeOauth });
+
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, opts) => {
+    const req = JSON.parse(opts.body);
+    return new Response(
+      JSON.stringify({ jsonrpc: "2.0", id: req.id, result: { tools: [] } }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  };
+  try {
+    await client.connect({ interactive: false }); // silent boot connect
+    const duringConnect = [...seen];
+    seen.length = 0;
+    await client.callTool("foo", {}); // a later tool call, no explicit flag
+    assert.ok(
+      duringConnect.length >= 1 && duringConnect.every((i) => i === false),
+      "every request in a silent connect must be non-interactive"
+    );
+    assert.deepEqual(
+      seen, [true],
+      "a tool call after a silent connect must default back to interactive (can re-auth)"
+    );
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});

--- a/test/mcp-oauth-scope.test.js
+++ b/test/mcp-oauth-scope.test.js
@@ -1,0 +1,62 @@
+// test/mcp-oauth-scope.test.js
+// Regression test for the `invalid_scope` OAuth failure: the client must
+// narrow the requested scope to what each server advertises, and omit `scope`
+// entirely for servers (like Rize) that advertise none — instead of always
+// sending a hardcoded openid/profile/email/offline_access set.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { McpOAuthClient } from "../src/mcp-oauth.js";
+
+const dataDir = path.join(os.tmpdir(), `openagi-oauth-test-${process.pid}`);
+const make = (opts = {}) => new McpOAuthClient({ resourceUrl: "https://example.test", dataDir, ...opts });
+
+test("Rize-style server (no scopes advertised) → omit scope entirely", () => {
+  const client = make();
+  // Real shapes pulled from mcp.rize.io: protected-resource has no
+  // scopes_supported; auth-server metadata has no scopes_supported either.
+  const discovery = {
+    resourceMeta: { resource: "https://mcp.rize.io/mcp", authorization_servers: ["https://mcp.rize.io"] },
+    serverMeta: { issuer: "https://mcp.rize.io", grant_types_supported: ["authorization_code"] }
+  };
+  assert.equal(client.resolveScope(discovery), null);
+});
+
+test("BuildBetter-style resource scopes → intersection with preferred (drops extras like service_account)", () => {
+  const client = make();
+  const discovery = {
+    resourceMeta: { scopes_supported: ["openid", "profile", "email", "offline_access", "service_account"] },
+    serverMeta: {}
+  };
+  assert.equal(client.resolveScope(discovery), "openid profile email offline_access");
+});
+
+test("auth-server scopes_supported is used when the resource doesn't advertise", () => {
+  const client = make();
+  const discovery = {
+    resourceMeta: {},
+    serverMeta: { scopes_supported: ["openid", "email", "read:stuff"] }
+  };
+  assert.equal(client.resolveScope(discovery), "openid email");
+});
+
+test("no overlap between preferred and supported → omit scope", () => {
+  const client = make();
+  const discovery = { resourceMeta: { scopes_supported: ["read:repo", "write:repo"] }, serverMeta: {} };
+  assert.equal(client.resolveScope(discovery), null);
+});
+
+test("an explicitly-configured scope is treated as authoritative and sent as-is", () => {
+  const client = make({ scope: "custom:scope another" });
+  // Even though the server advertises something else, an explicit catalog
+  // scope wins (the integration author knows what that server needs).
+  const discovery = { resourceMeta: { scopes_supported: ["openid"] }, serverMeta: {} };
+  assert.equal(client.resolveScope(discovery), "custom:scope another");
+});
+
+test("empty resource scopes_supported array → omit scope", () => {
+  const client = make();
+  const discovery = { resourceMeta: { scopes_supported: [] }, serverMeta: {} };
+  assert.equal(client.resolveScope(discovery), null);
+});

--- a/test/mcp-oauth-scope.test.js
+++ b/test/mcp-oauth-scope.test.js
@@ -60,3 +60,14 @@ test("empty resource scopes_supported array → omit scope", () => {
   const discovery = { resourceMeta: { scopes_supported: [] }, serverMeta: {} };
   assert.equal(client.resolveScope(discovery), null);
 });
+
+test("empty resource scopes_supported falls through to the auth server's scopes (not the empty array)", () => {
+  const client = make();
+  // resourceMeta advertises an EMPTY list but the auth server advertises real
+  // scopes — a naive `??` would keep [] and wrongly omit the scope.
+  const discovery = {
+    resourceMeta: { scopes_supported: [] },
+    serverMeta: { scopes_supported: ["openid", "email"] }
+  };
+  assert.equal(client.resolveScope(discovery), "openid email");
+});


### PR DESCRIPTION
## Summary
A native macOS always-on-top floating pill ("Quick Ask") that expands to ask OpenAGI from anywhere, grounded in the window you're looking at, with a global hotkey + tray toggle and proactive nudges. Closes the last of the three littlebird.ai gaps (web search + transcripts already shipped on the base branch).

Spec: `docs/superpowers/specs/2026-06-05-floating-widget-design.md` · Plan: `docs/superpowers/plans/2026-06-05-floating-widget.md`. Built task-by-task with per-task review; final holistic review = ready to merge.

> **Stacked on #1** (`feat/external-knowledge-sources`) — base will be retargeted to `main` once #1 merges. Also includes your own `cbd92ca` (BuildBetter poller identity/OAuth) which was already on this branch.

## What it does
- **⌥Space** (or tray → "Quick Ask") summons a floating pill that expands into an ask box over any app (incl. fullscreen), without stealing focus. Field is focused on summon, so you can type immediately.
- Each ask does an on-device **OCR grab of the focused window** (reuses the existing ScreenCapturer + Vision pipeline), attached to the message as `metadata.screenContext`; the daemon's `agent-host` injects it into the turn so the answer is grounded in what's on screen.
- **Privacy:** honors the existing capture **exclusion list** (1Password/banking never read); needs Screen Recording permission, and degrades gracefully to "no screen context" without it.
- **Nudges:** proactive suggestions show as a badge + list in the pill (open in chat or dismiss).
- Tray toggle **"Enable Quick Ask"** (on by default); panel position persists.

## Implementation
- **Daemon (JS):** `agent-host` `formatScreenContextBlock` + `metadata.screenContext` injection — additive (zero change to non-overlay channels), with a unit test.
- **macOS (Swift):** `ScreenCapturer.captureFocusedText()`, `AppState.askOverlay` + nudge state, `Overlay/{OverlayController,OverlayView,OverlayState,HotkeyManager}.swift`, AppDelegate + TrayController wiring.

## Tests / verification
- `node --test` → **157 pass**. `cd mac && swift build` → **clean**.
- The macOS UI can't be unit-tested here; the one JS seam is covered. Manual smoke checklist below (for the packaged app).

## Manual smoke checklist
- [ ] ⌥Space toggles the pill/panel from any app (incl. a fullscreen app); field is focused — you can type without clicking.
- [ ] Panel floats above other windows and doesn't steal focus (keep typing in the app behind it).
- [ ] Asking about the visible window returns an answer reflecting on-screen content (Screen Recording granted).
- [ ] With an excluded app frontmost (1Password), the panel notes "no screen context" and nothing is OCR'd.
- [ ] A proactive suggestion shows a badge on the pill and appears in the Nudges list.
- [ ] "Enable Quick Ask" off hides the widget; on shows it; position persists across restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)