### PR TITLE
feat: credit usage audit log — Credits dashboard + recall_spend

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ For Docker, run [Watchtower](https://containrrr.dev/watchtower/) alongside the O
 | **Telegram** | Webhook (`/channels/telegram/webhook`) or long polling (`TELEGRAM_POLLING=1`). |
 | **Persistent state** | All under `.openagi/`: memory (JSONL audit + atomic snapshot), cron jobs, agent/session store, specialist workspaces, MCP logs. |
 
+### Credits
+
+The **Credits** dashboard tab shows today's LLM spend vs the daily cap (`OPENAGI_DAILY_USD_LIMIT`), totals broken down **by activity** (chat / autopilot / cron / overlay / sms) and **by model**, a **30-day spend chart**, and a per-call **audit log** — each row records time, model, activity type, agent, cost, and tools called, so you can see exactly what cost credits and why.
+
+Ask the agent in chat via the **`recall_spend`** tool ("why did I spend $4 today?") — it reads the same ledger.
+
+Data is a local rolling 30-day ledger at `~/.openagi/budget/ledger.jsonl`. It stores cost + attribution only — **no message content**.
+
 ---
 
 ## Remote access (SMS, Telegram, tunneling)

--- a/docs/superpowers/plans/2026-06-06-credit-audit-log.md
+++ b/docs/superpowers/plans/2026-06-06-credit-audit-log.md
@@ -1,0 +1,486 @@
+# Credit Usage Audit Log — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A per-call LLM credit (USD) audit log — what cost credits, when, and why (activity/agent/session/tools) — surfaced as a Credits dashboard view (totals + spend chart + audit log) and a `recall_spend` agent tool.
+
+**Architecture:** A focused append-only `CreditLedger` (JSONL, 30-day window). `BudgetGuard` already prices each call; it appends a line item with the context `model-provider` passes. A new endpoint + agent tool + dashboard view read it.
+
+**Tech Stack:** Node 22 ESM, `node:test`. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-credit-audit-log-design.md`
+
+---
+
+# Phase 1 — data + agent (no dashboard UI)
+
+### Task 1: `CreditLedger`
+
+**Files:** Create `src/credit-ledger.js`; create `test/credit-ledger.test.js`.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/credit-ledger.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { CreditLedger } from "../src/credit-ledger.js";
+
+function tmpLedger(opts = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ledger-"));
+  return new CreditLedger({ storePath: path.join(dir, "ledger.jsonl"), ...opts });
+}
+const entry = (over = {}) => ({
+  model: "claude-opus-4-7", usd: 0.05, channel: "chat", agentId: "main",
+  sessionId: "s1", from: "user", tools: ["web_search"],
+  tokens: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0 }, ...over
+});
+
+test("records and queries entries newest-first", () => {
+  const L = tmpLedger();
+  L.record(entry({ usd: 0.01, at: "2026-06-05T10:00:00.000Z" }));
+  L.record(entry({ usd: 0.02, at: "2026-06-06T10:00:00.000Z" }));
+  const rows = L.query({ days: 30, now: new Date("2026-06-06T12:00:00.000Z") });
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0].usd, 0.02); // newest first
+  assert.equal(rows[0].channel, "chat");
+});
+
+test("query window excludes entries older than `days`", () => {
+  const L = tmpLedger();
+  L.record(entry({ at: "2026-05-01T10:00:00.000Z" })); // ~36 days before now
+  L.record(entry({ at: "2026-06-06T10:00:00.000Z" }));
+  const rows = L.query({ days: 30, now: new Date("2026-06-06T12:00:00.000Z") });
+  assert.equal(rows.length, 1);
+});
+
+test("analytics groups by day, model, activity", () => {
+  const L = tmpLedger();
+  L.record(entry({ usd: 0.10, channel: "autopilot", model: "claude-opus-4-7", at: "2026-06-06T09:00:00.000Z" }));
+  L.record(entry({ usd: 0.04, channel: "chat", model: "gpt-5", at: "2026-06-06T10:00:00.000Z" }));
+  L.record(entry({ usd: 0.01, channel: "chat", model: "gpt-5", at: "2026-06-05T10:00:00.000Z" }));
+  const a = L.analytics({ days: 30, now: new Date("2026-06-06T12:00:00.000Z") });
+  assert.equal(a.totalCalls, 3);
+  assert.equal(a.totalUsd, 0.15);
+  assert.equal(a.byActivity.find((x) => x.activity === "autopilot").usd, 0.10);
+  assert.equal(a.byActivity[0].activity, "autopilot"); // sorted by usd desc
+  assert.equal(a.byModel.find((x) => x.model === "gpt-5").calls, 2);
+  assert.deepEqual(a.byDay.map((d) => d.date), ["2026-06-05", "2026-06-06"]); // chronological
+});
+
+test("compacts when the file exceeds the byte threshold, keeping the window", () => {
+  const L = tmpLedger({ compactBytes: 1 }); // force compaction every write
+  L.record(entry({ at: "2026-05-01T10:00:00.000Z" })); // old
+  L.record(entry({ at: "2026-06-06T10:00:00.000Z", now: new Date("2026-06-06T10:00:00.000Z") }));
+  // After a compaction triggered with a recent `now`, the 36-day-old row is gone from disk.
+  const onDisk = fs.readFileSync(L.storePath, "utf8").split("\n").filter(Boolean);
+  assert.equal(onDisk.length, 1);
+});
+
+test("tolerates a missing/corrupt file", () => {
+  const L = tmpLedger();
+  assert.deepEqual(L.query(), []);
+  fs.writeFileSync(L.storePath, "not json\n{bad\n");
+  assert.deepEqual(L.query(), []);
+});
+```
+
+- [ ] **Step 2: Run it — verify FAIL**
+
+`node --test test/credit-ledger.test.js` → module not found.
+
+- [ ] **Step 3: Implement `src/credit-ledger.js`**
+
+```js
+// src/credit-ledger.js
+import fs from "node:fs";
+import path from "node:path";
+import { ensureDir } from "./file-utils.js";
+import { resolveDataDir } from "./data-dir.js";
+
+const RETENTION_DAYS = 30;
+const COMPACT_BYTES = 4 * 1024 * 1024; // compact when the file grows past ~4MB
+
+// Append-only per-call credit (USD) ledger. record() is O(1) append (it runs in
+// the hot path of every LLM call); old entries are filtered out of query()/
+// analytics() by the rolling window, and the file is compacted only when it
+// grows large. Stores no message content — just cost + attribution.
+export class CreditLedger {
+  constructor(options = {}) {
+    this.storePath = options.storePath ?? path.join(resolveDataDir(), "budget", "ledger.jsonl");
+    this.retentionDays = options.retentionDays ?? RETENTION_DAYS;
+    this.compactBytes = options.compactBytes ?? COMPACT_BYTES;
+    ensureDir(path.dirname(this.storePath));
+  }
+
+  _cutoff(days, now) {
+    return new Date(now.getTime() - days * 86400 * 1000).toISOString();
+  }
+
+  _readAll() {
+    let text;
+    try { text = fs.readFileSync(this.storePath, "utf8"); } catch { return []; }
+    const out = [];
+    for (const line of text.split("\n")) {
+      if (!line.trim()) continue;
+      try { out.push(JSON.parse(line)); } catch { /* skip corrupt line */ }
+    }
+    return out;
+  }
+
+  record(entry = {}, { now = new Date() } = {}) {
+    const row = {
+      at: entry.at ?? now.toISOString(),
+      model: entry.model ?? null,
+      tokens: entry.tokens ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      usd: Number(entry.usd ?? 0),
+      channel: entry.channel ?? null,
+      agentId: entry.agentId ?? null,
+      sessionId: entry.sessionId ?? null,
+      from: entry.from ?? null,
+      tools: Array.isArray(entry.tools) ? entry.tools : []
+    };
+    fs.appendFileSync(this.storePath, JSON.stringify(row) + "\n");
+    this._maybeCompact(now);
+    return row;
+  }
+
+  _maybeCompact(now) {
+    let size = 0;
+    try { size = fs.statSync(this.storePath).size; } catch { return; }
+    if (size < this.compactBytes) return;
+    const cutoff = this._cutoff(this.retentionDays, now);
+    const kept = this._readAll().filter((r) => (r.at ?? "") >= cutoff);
+    fs.writeFileSync(this.storePath, kept.map((r) => JSON.stringify(r)).join("\n") + (kept.length ? "\n" : ""));
+  }
+
+  query({ days = this.retentionDays, now = new Date() } = {}) {
+    const cutoff = this._cutoff(days, now);
+    return this._readAll()
+      .filter((r) => (r.at ?? "") >= cutoff)
+      .sort((a, b) => (b.at ?? "").localeCompare(a.at ?? ""));
+  }
+
+  analytics({ days = this.retentionDays, now = new Date() } = {}) {
+    const rows = this.query({ days, now });
+    const byDay = {}, byModel = {}, byActivity = {};
+    let totalUsd = 0, totalCalls = 0;
+    for (const r of rows) {
+      const day = (r.at ?? "").slice(0, 10);
+      const model = r.model ?? "unknown";
+      const activity = r.channel ?? "unknown";
+      const usd = Number(r.usd ?? 0);
+      totalUsd += usd; totalCalls += 1;
+      (byDay[day] ??= { date: day, usd: 0, calls: 0 });        byDay[day].usd += usd; byDay[day].calls += 1;
+      (byModel[model] ??= { model, usd: 0, calls: 0 });        byModel[model].usd += usd; byModel[model].calls += 1;
+      (byActivity[activity] ??= { activity, usd: 0, calls: 0 }); byActivity[activity].usd += usd; byActivity[activity].calls += 1;
+    }
+    const round = (o) => ({ ...o, usd: Number(o.usd.toFixed(4)) });
+    return {
+      totalUsd: Number(totalUsd.toFixed(4)),
+      totalCalls,
+      byDay: Object.values(byDay).sort((a, b) => a.date.localeCompare(b.date)).map(round),
+      byModel: Object.values(byModel).sort((a, b) => b.usd - a.usd).map(round),
+      byActivity: Object.values(byActivity).sort((a, b) => b.usd - a.usd).map(round)
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run it — verify PASS** (`node --test test/credit-ledger.test.js`), then full suite `node --test`.
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/credit-ledger.js test/credit-ledger.test.js
+git commit -m "feat: CreditLedger — per-call cost line items (30-day JSONL)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `BudgetGuard.record(usage, model, meta)` appends a ledger entry
+
+**Files:** Modify `src/budget-guard.js`; create `test/budget-guard-ledger.test.js`.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/budget-guard-ledger.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { BudgetGuard } from "../src/budget-guard.js";
+import { CreditLedger } from "../src/credit-ledger.js";
+
+function tmp() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bg-"));
+  const ledger = new CreditLedger({ storePath: path.join(dir, "ledger.jsonl") });
+  const guard = new BudgetGuard({ storePath: path.join(dir, "usage.json"), ledger });
+  return { guard, ledger };
+}
+
+test("record(meta) writes a ledger entry carrying the context", () => {
+  const { guard, ledger } = tmp();
+  guard.record({ input_tokens: 1000, output_tokens: 500 }, "claude-opus-4-7", {
+    channel: "autopilot", agentId: "main", sessionId: "s9", from: "cron", tools: ["web_search", "add_task"]
+  });
+  const rows = ledger.query({ days: 1 });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].channel, "autopilot");
+  assert.deepEqual(rows[0].tools, ["web_search", "add_task"]);
+  assert.equal(rows[0].model, "claude-opus-4-7");
+  assert.ok(rows[0].usd > 0);
+  assert.equal(rows[0].tokens.input, 1000);
+});
+
+test("record without meta still aggregates and does not throw (back-compat)", () => {
+  const { guard, ledger } = tmp();
+  const res = guard.record({ input_tokens: 100, output_tokens: 50 }, "gpt-5");
+  assert.ok(res.added > 0);
+  // a ledger row is still written, just with null context
+  const rows = ledger.query({ days: 1 });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].channel, null);
+});
+```
+
+- [ ] **Step 2: Run — verify FAIL** (`node --test test/budget-guard-ledger.test.js`): `meta` ignored, no ledger.
+
+- [ ] **Step 3: Implement**
+
+In `src/budget-guard.js`:
+- Add imports at top: `import { nowIso } from "./utils.js";` and `import { CreditLedger } from "./credit-ledger.js";`
+- In the constructor, after `this.state = ...`, add:
+  ```js
+  this.ledger = options.ledger ?? new CreditLedger({ storePath: path.join(path.dirname(this.storePath), "ledger.jsonl") });
+  ```
+- Change `record(usage, model)` to `record(usage, model, meta = {})`. After the daily-aggregate block (after `day.calls += 1;` and before `this.persist();`), append the ledger entry (best-effort — never let a ledger failure break the model call):
+  ```js
+  try {
+    this.ledger?.record({
+      at: nowIso(),
+      model,
+      tokens,
+      usd,
+      channel: meta.channel ?? null,
+      agentId: meta.agentId ?? null,
+      sessionId: meta.sessionId ?? null,
+      from: meta.from ?? null,
+      tools: Array.isArray(meta.tools) ? meta.tools : []
+    });
+  } catch { /* ledger is best-effort; never break a reply over it */ }
+  ```
+
+- [ ] **Step 4: Run — verify PASS**, then full suite `node --test`.
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/budget-guard.js test/budget-guard-ledger.test.js
+git commit -m "feat: BudgetGuard.record appends a credit-ledger line item
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `model-provider` threads context + tool names into `record`
+
+**Files:** Modify `src/model-provider.js`.
+
+- [ ] **Step 1:** Both providers call `this.budgetGuard?.record(json.usage, this.model);` (Anthropic ~line 253, OpenAI ~line 146). At each site, `context` and the local `toolCalls` array are in scope. Replace each call with:
+
+```js
+      this.budgetGuard?.record(json.usage, this.model, {
+        channel: context.channel,
+        agentId: context.agentId,
+        sessionId: context.sessionId,
+        from: context.from,
+        tools: toolCalls.map((c) => c.name)
+      });
+```
+
+Verify at each site that `toolCalls` is the in-scope array of `{ name, ... }` (it is — both providers build it before recording). Use grep to find both: `grep -n "budgetGuard?.record" src/model-provider.js`.
+
+- [ ] **Step 2:** Run the full suite `node --test` → all green (no provider unit test calls the network; existing tests must still pass). Also import-smoke: `node -e "import('./src/model-provider.js').then(()=>console.log('ok'))"`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/model-provider.js
+git commit -m "feat: pass activity/agent/session/tools context to budget record
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `GET /budget/ledger` endpoint
+
+**Files:** Modify `src/hosted-interface.js` (routing section only — NOT the renderApp template).
+
+- [ ] **Step 1:** Find the existing budget route: `grep -n 'pathname === "/budget"' src/hosted-interface.js` (around line 340). Immediately after that line, add a sibling route:
+
+```js
+      if (method === "GET" && pathname === "/budget/ledger") {
+        const ledger = runtime.budget?.ledger;
+        if (!ledger) return sendJson(res, 200, { error: "no-ledger" });
+        const days = Math.max(1, Math.min(90, Number.parseInt(url.searchParams.get("days") ?? "30", 10) || 30));
+        return sendJson(res, 200, { days, entries: ledger.query({ days }), analytics: ledger.analytics({ days }) });
+      }
+```
+
+Confirm how the existing routes read query params (the file already parses a `url`/`pathname`; match the existing pattern — if it uses `new URL(req.url, base)`, reuse that `url.searchParams`; if query parsing differs, follow the local convention). Do NOT touch any template-literal/renderApp code.
+
+- [ ] **Step 2:** Smoke-test the route wiring with a runtime:
+```bash
+node -e "import('./src/index.js').then(async ({createDurableRuntime, createHostedInterface})=>{const rt=createDurableRuntime({});const app=createHostedInterface(rt,{host:'127.0.0.1',port:0});const {port}=await app.listen();const r=await fetch('http://127.0.0.1:'+port+'/budget/ledger?days=7');console.log(r.status, JSON.stringify(await r.json()).slice(0,120));process.exit(0)})" 2>&1 | tail -3
+```
+Expected: `200` with `{days:7,entries:[...],analytics:{...}}` (entries likely empty on a fresh runtime). If auth gates the route, the smoke may 401 — that's fine, it confirms the route exists; note it.
+
+- [ ] **Step 3:** `node --test` → still green. Commit:
+```bash
+git add src/hosted-interface.js
+git commit -m "feat: GET /budget/ledger returns credit entries + analytics
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `recall_spend` agent tool
+
+**Files:** Modify `src/tool-registry.js`; create `test/recall-spend.test.js`.
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/recall-spend.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ToolRegistry, registerCoreTools } from "../src/tool-registry.js";
+import { CreditLedger } from "../src/credit-ledger.js";
+
+test("recall_spend summarizes the ledger", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rs-"));
+  const ledger = new CreditLedger({ storePath: path.join(dir, "ledger.jsonl") });
+  ledger.record({ usd: 0.10, channel: "autopilot", model: "claude-opus-4-7", tools: ["web_search"] });
+  ledger.record({ usd: 0.02, channel: "chat", model: "gpt-5", tools: [] });
+  const registry = new ToolRegistry();
+  registerCoreTools(registry, { budget: { ledger } });
+  const { result } = await registry.invoke("recall_spend", { days: 30 });
+  assert.ok(result.totalUsd >= 0.12 - 1e-9);
+  assert.equal(result.byActivity[0].activity, "autopilot");
+  assert.ok(Array.isArray(result.top));
+});
+```
+(If `registerCoreTools` requires a fuller runtime, pass a minimal stub with just `{ budget: { ledger } }` and whatever else it dereferences at registration time — registration only defines the tool; the handler reads `runtime.budget.ledger` at call time.)
+
+- [ ] **Step 2: Run — verify FAIL** (unknown tool `recall_spend`).
+
+- [ ] **Step 3: Implement** — in `src/tool-registry.js`, inside `registerCoreTools(registry, runtime)`, add:
+
+```js
+  registry.register({
+    name: "recall_spend",
+    description: "Summarize LLM credit (USD) usage: how much has been spent, on what activity/model, and the costliest recent calls. Use to answer questions about cost/credits/budget — e.g. 'why did I spend $4 today?'.",
+    parameters: {
+      type: "object",
+      properties: {
+        days: { type: "integer", minimum: 1, maximum: 90, description: "Look-back window in days (default 1 = today)." }
+      },
+      additionalProperties: false
+    },
+    handler: async (args) => {
+      const ledger = runtime.budget?.ledger;
+      if (!ledger) return { error: "no credit ledger available" };
+      const days = args.days ?? 1;
+      const analytics = ledger.analytics({ days });
+      const top = ledger.query({ days })
+        .slice()
+        .sort((a, b) => (b.usd ?? 0) - (a.usd ?? 0))
+        .slice(0, 10)
+        .map((r) => ({ at: r.at, model: r.model, activity: r.channel, agentId: r.agentId, usd: Number((r.usd ?? 0).toFixed(4)), tools: r.tools ?? [] }));
+      return { days, totalUsd: analytics.totalUsd, calls: analytics.totalCalls, byActivity: analytics.byActivity, byModel: analytics.byModel, top };
+    }
+  });
+```
+
+- [ ] **Step 4: Run — verify PASS**, then full suite `node --test`.
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tool-registry.js test/recall-spend.test.js
+git commit -m "feat: recall_spend tool — answer credit/cost questions from the ledger
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+# Phase 2 — Credits dashboard view
+
+### Task 6: Evolve the Budget tab into "Credits"
+
+**Files:** Modify `src/hosted-interface.js` (the `renderApp` template + the client-side tab JS).
+
+> ⚠️ **Template-literal trap (repo memory):** `renderApp` is a giant Node template literal that emits the dashboard HTML+JS. Any `${...}` you add that should appear literally in the *client* JS must be written escaped (`\${...}`), and do not introduce stray backticks. Mirror exactly how the existing `renderBudget`/budget tab code is written (find it: `grep -n "budget" src/hosted-interface.js` and read the existing tab's render + fetch code before editing). Build the new view in the SAME style.
+
+- [ ] **Step 1:** Locate the existing Budget tab rendering and its data fetch (it calls `/budget`). Read it fully to learn the established escaping + DOM-building idiom used elsewhere in `renderApp`.
+
+- [ ] **Step 2:** Rename the nav label to **Credits** (the `<button data-tab="budget" ...>Budget</button>` at ~line 1832 → `>Credits<`; keep `data-tab="budget"` to avoid touching the tab-routing JS, OR rename to `credits` consistently in the nav + the client tab switch + the render function — pick one and be consistent).
+
+- [ ] **Step 3:** Extend the tab's render to fetch `/budget/ledger?days=30` and render three blocks, matching the existing dashboard component styling (cards/tokens):
+  1. **Header (existing):** today's spend vs cap (keep).
+  2. **Grouped totals:** `analytics.byActivity` and `analytics.byModel` as small labeled rows (e.g. "autopilot — $4.10 (12 calls)").
+  3. **Spend-over-time chart:** an inline **SVG** bar chart over `analytics.byDay` (last 30). No library — compute bar heights from `usd` relative to the max; render `<rect>`s in a fixed-size `<svg>`. Keep it ~120px tall.
+  4. **Audit log:** a scrollable list of `entries` (newest first): `time · model · activity · agent · $X.XXXX · tools`. Cap the rendered rows (e.g. first 200) with a note if truncated.
+
+  Escape all interpolations per the trap above. Reuse the existing fetch helper the dashboard uses for `/budget`.
+
+- [ ] **Step 4: Verify the file still parses / route renders.** Run:
+```bash
+node -e "import('./src/hosted-interface.js').then(()=>console.log('module ok'))"
+node -e "import('./src/index.js').then(async ({createDurableRuntime, createHostedInterface})=>{const rt=createDurableRuntime({});const app=createHostedInterface(rt,{host:'127.0.0.1',port:0});const {port}=await app.listen();const r=await fetch('http://127.0.0.1:'+port+'/');console.log('GET /', r.status);process.exit(0)})" 2>&1 | tail -2
+```
+Expected: `module ok` and `GET / 200` (or 401 if auth-gated — either confirms `renderApp` didn't crash at runtime, which is the trap this guards against). Run `node --test` → green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hosted-interface.js
+git commit -m "feat: Credits dashboard — totals, spend chart, and per-call audit log
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Docs
+
+**Files:** Modify `README.md`.
+
+- [ ] **Step 1:** Add a short "Credits / cost audit" note: the Credits tab shows today's spend vs cap, totals by activity/model, a 30-day spend chart, and a per-call audit log (what cost credits and why); ask the agent in chat via `recall_spend` ("why did I spend $X today?"); data is a local 30-day ledger at `~/.openagi/budget/ledger.jsonl` (no message content stored).
+
+- [ ] **Step 2: Commit**
+```bash
+git add README.md
+git commit -m "docs: credit usage audit log (Credits tab + recall_spend)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+- [ ] `node --test` — full suite green (Tasks 1, 2, 5 add real tests).
+- [ ] `node -e "import('./src/index.js').then(()=>console.log('ok'))"` — imports clean.
+- [ ] `grep -rn "recall_spend" src` — tool registered; `grep -rn "ledger" src/budget-guard.js` — wired.

--- a/docs/superpowers/specs/2026-06-06-credit-audit-log-design.md
+++ b/docs/superpowers/specs/2026-06-06-credit-audit-log-design.md
@@ -1,0 +1,144 @@
+# Credit Usage Audit Log — Design
+
+**Date:** 2026-06-06
+**Status:** Approved (brainstorming) — pending implementation plan
+**Branch:** `feat/credit-audit-log` (off `feat/external-knowledge-sources`)
+
+## Goal
+A per-call audit log of LLM credit (USD) usage so the user can see **what** cost
+credits, **when**, and **why** (which activity / agent / session / tools). Today
+`BudgetGuard` only stores daily aggregates (`{input, output, cacheRead, cacheWrite,
+usd, calls}` per day) — there is no per-call record. This adds the line-item ledger,
+a Credits dashboard view with totals + charts, and a `recall_spend` agent tool.
+
+## Decisions (from brainstorming)
+- **What to log:** rich per-call context — time, model, tokens, `$`, plus the why
+  (channel/activity, agent, session, tools called that turn).
+- **Surface:** evolve the existing **Budget** dashboard tab into **Credits**, AND add a
+  `recall_spend` agent tool so the user can ask cost questions in chat.
+- **Depth:** full analytics — line items + grouped totals + spend-over-time charts.
+- **Retention:** rolling **30 days** (capped file).
+
+## Architecture
+A focused `CreditLedger` (append-only JSONL) records one entry per priced LLM call.
+`BudgetGuard` already prices each call and computes the `$`; it composes the ledger and
+appends the line item with the context passed by `model-provider`. The dashboard and a
+new agent tool read the ledger. No new process, no external dependency.
+
+```
+LLM call → BudgetGuard.record(usage, model, meta)
+             ├─ daily aggregate (existing, unchanged)
+             └─ CreditLedger.record({ at, model, tokens, usd, ...meta })
+GET /budget/ledger?days=30 → { entries, analytics }   → Credits dashboard view
+recall_spend tool (chat)   → ledger summary           → "why did I spend $X today?"
+```
+
+## Components
+
+### 1. `CreditLedger` — `src/credit-ledger.js` (new)
+One responsibility: durable per-call cost line items.
+- Storage: JSONL at `path.join(resolveDataDir(), "budget", "ledger.jsonl")`.
+- `record(entry)` — appends `{ at: ISO, model, tokens: {input, output, cacheRead,
+  cacheWrite}, usd, channel, agentId, sessionId, from, tools: string[] }`. Prunes
+  entries older than the retention window on write (rolling 30 days).
+- `query({ days = 30 })` — returns entries within the window, newest first.
+- `analytics({ days = 30 })` — returns grouped totals:
+  - `byDay`: `[{ date, usd, calls }]` (for the spend-over-time chart)
+  - `byModel`: `[{ model, usd, calls }]`
+  - `byActivity`: `[{ activity, usd, calls }]` (activity = channel, e.g. chat /
+    autopilot / cron / overlay / sms)
+  - `totalUsd`, `totalCalls` for the window.
+- Constructor takes `{ storePath, retentionDays = 30 }` for test injection. Degrades
+  safely (missing/corrupt file → empty ledger).
+
+### 2. `BudgetGuard.record(usage, model, meta = {})` — `src/budget-guard.js`
+- Pricing + daily-aggregate logic unchanged.
+- After computing `usd`, append a ledger entry:
+  `this.ledger?.record({ at: nowIso(), model, tokens, usd, channel: meta.channel ?? null,
+  agentId: meta.agentId ?? null, sessionId: meta.sessionId ?? null, from: meta.from ??
+  null, tools: meta.tools ?? [] })`.
+- `meta` is optional → existing callers/tests keep working unchanged.
+- BudgetGuard constructs `this.ledger = options.ledger ?? new CreditLedger({ storePath:
+  <budgetDir>/ledger.jsonl })`. `status()` gains nothing new (the ledger has its own
+  query/analytics); a thin `ledger(opts)` passthrough may be added for the endpoint.
+
+### 3. `model-provider.js` — thread the context (lines ~146 and ~253)
+Both `record(json.usage, this.model)` call sites become:
+```js
+this.budgetGuard?.record(json.usage, this.model, {
+  channel: context.channel, agentId: context.agentId,
+  sessionId: context.sessionId, from: context.from,
+  tools: toolCalls.map((c) => c.name)
+});
+```
+`context` and `toolCalls` are already in scope at both sites.
+
+### 4. Endpoint — `src/hosted-interface.js`
+`GET /budget/ledger?days=30` → `sendJson(200, { entries, analytics })` from
+`runtime.budget.ledger.query(...)` + `.analytics(...)`. Returns `{ error }` when no
+budget/ledger is wired.
+
+### 5. `recall_spend` agent tool — `src/tool-registry.js`
+- Params: `{ days?: integer (default 1) }`.
+- Handler: reads `runtime.budget.ledger.analytics({ days })` + top N costliest entries,
+  returns `{ totalUsd, calls, byActivity, byModel, top: [...] }` so the agent can answer
+  "what's been costing me credits and why".
+- Read-only, no confirmation gate.
+
+### 6. Dashboard: Budget tab → "Credits" — `src/hosted-interface.js`
+Evolve the existing `data-tab="budget"` surface (keep today's spend vs cap header), add:
+- **Grouped totals:** by activity and by model (e.g. "autopilot $4.10 · chat $1.20").
+- **Spend-over-time chart:** lightweight inline **SVG bars** over `byDay` (no charting
+  library) — last 30 days.
+- **Audit log:** a scrollable list of line items — `time · model · activity · agent ·
+  $ · tools`.
+- Rename the tab label to "Credits"; keep `data-tab="budget"` (or switch to
+  `data-tab="credits"` consistently — pick one and update the nav + the client tab JS).
+> ⚠️ This file is template-literal-heavy. Per the repo's known trap, escape any `${...}`
+> added inside `renderApp`'s template literal and avoid stray backticks, or the route
+> crashes at runtime.
+
+## Data flow & privacy
+- The ledger stores: timestamp, model, token counts, `$`, channel/activity, agentId,
+  sessionId, from, and tool **names** — **no message content, no secrets**. Local file
+  under `~/.openagi/budget/`, pruned to 30 days.
+- `analytics`/`query` never leave the machine (local dashboard + local agent tool).
+
+## Error handling
+- Missing/corrupt ledger file → treated as empty (record re-creates it). Never throws
+  into the model-generate path (record is best-effort; a ledger failure must not break a
+  reply — wrap the append in try/catch and swallow, mirroring the existing best-effort
+  pattern around budget).
+- Endpoint/tool with no budget wired → structured `{ error }`.
+
+## Testing
+- **`CreditLedger`** (real unit tests): `record` appends; `query({days})` filters the
+  window; `analytics` groups by day/model/activity correctly; 30-day prune drops old
+  entries; corrupt-file tolerance.
+- **`BudgetGuard.record`**: with `meta`, writes a ledger entry carrying the context;
+  without `meta`, still records the aggregate (back-compat).
+- **`recall_spend`**: returns a correct summary from a seeded ledger.
+- **Endpoint**: `GET /budget/ledger` returns `{ entries, analytics }` (via the existing
+  hosted-interface test pattern, if present; else a focused runtime test).
+- The dashboard JS (template-literal UI) is not unit-testable here — verified by
+  reasoning + manual.
+
+## Out of scope (YAGNI)
+- Tracking non-LLM external costs (web-search/MCP provider charges aren't priced by the
+  app today). The ledger records the **tool names** invoked in a turn for attribution,
+  but not separate $ for them.
+- Per-message content logging.
+- CSV export / external billing integration.
+- Configurable retention UI (30 days is fixed; constructor-overridable).
+
+## Build sequencing (for the plan)
+**Phase 1 — data + agent (no `hosted-interface.js` UI):**
+1. `CreditLedger` + tests.
+2. `BudgetGuard.record(meta)` composes the ledger + test.
+3. `model-provider` threads context/tools into `record`.
+4. `GET /budget/ledger` endpoint.
+5. `recall_spend` tool + test.
+
+**Phase 2 — Credits dashboard view (`hosted-interface.js`):**
+6. Evolve the Budget tab into Credits: grouped totals + inline-SVG spend chart + audit
+   log line items.

--- a/src/budget-guard.js
+++ b/src/budget-guard.js
@@ -1,6 +1,8 @@
 import path from "node:path";
 import { ensureDir, readJsonFile, writeJsonAtomic } from "./file-utils.js";
 import { resolveDataDir } from "./data-dir.js";
+import { nowIso } from "./utils.js";
+import { CreditLedger } from "./credit-ledger.js";
 
 const DEFAULT_PRICES = {
   "claude-sonnet-4-6": { in: 3, out: 15, cacheRead: 0.3, cacheWrite: 3.75 },
@@ -18,6 +20,7 @@ export class BudgetGuard {
     this.prices = { ...DEFAULT_PRICES, ...(options.prices ?? {}) };
     ensureDir(path.dirname(this.storePath));
     this.state = readJsonFile(this.storePath, { version: 1, days: {} });
+    this.ledger = options.ledger ?? new CreditLedger({ storePath: path.join(path.dirname(this.storePath), "ledger.jsonl") });
   }
 
   todayKey() {
@@ -54,7 +57,7 @@ export class BudgetGuard {
     }
   }
 
-  record(usage, model) {
+  record(usage, model, meta = {}) {
     if (!usage) return null;
     const today = this.todayKey();
     if (!this.state.days[today]) this.state.days[today] = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, usd: 0, calls: 0 };
@@ -74,6 +77,20 @@ export class BudgetGuard {
     day.cacheWrite += tokens.cacheWrite;
     day.usd += usd;
     day.calls += 1;
+
+    try {
+      this.ledger?.record({
+        at: nowIso(),
+        model,
+        tokens,
+        usd,
+        channel: meta.channel ?? null,
+        agentId: meta.agentId ?? null,
+        sessionId: meta.sessionId ?? null,
+        from: meta.from ?? null,
+        tools: Array.isArray(meta.tools) ? meta.tools : []
+      });
+    } catch { /* ledger is best-effort; never break a reply over it */ }
 
     this.persist();
     return { added: usd, today: day.usd, limit: this.dailyUsdLimit };

--- a/src/credit-ledger.js
+++ b/src/credit-ledger.js
@@ -21,6 +21,10 @@ export class CreditLedger {
     // compactBytes doesn't read+rewrite the whole file on every append.
     this._nextCompactBytes = this.compactBytes;
     ensureDir(path.dirname(this.storePath));
+    // The ledger holds attribution (from/sessionId/agentId/tools/spend) — not
+    // world-readable. New files are created 0600 (mode on append/write below);
+    // tighten an existing file once at startup in case it predates this.
+    try { if (fs.existsSync(this.storePath)) fs.chmodSync(this.storePath, 0o600); } catch { /* best effort */ }
   }
 
   // Calendar-day cutoff (UTC, matching BudgetGuard.todayKey): the start of the
@@ -57,7 +61,7 @@ export class CreditLedger {
       from: entry.from ?? null,
       tools: Array.isArray(entry.tools) ? entry.tools : []
     };
-    fs.appendFileSync(this.storePath, JSON.stringify(row) + "\n");
+    fs.appendFileSync(this.storePath, JSON.stringify(row) + "\n", { mode: 0o600 });
     this._maybeCompact(now);
     return row;
   }
@@ -68,7 +72,7 @@ export class CreditLedger {
     if (size < this._nextCompactBytes) return;
     const cutoff = this._cutoff(this.retentionDays, now);
     const kept = this._readAll().filter((r) => (r.at ?? "") >= cutoff);
-    fs.writeFileSync(this.storePath, kept.map((r) => JSON.stringify(r)).join("\n") + (kept.length ? "\n" : ""));
+    fs.writeFileSync(this.storePath, kept.map((r) => JSON.stringify(r)).join("\n") + (kept.length ? "\n" : ""), { mode: 0o600 });
     // Re-arm: only compact again after the file roughly doubles past the
     // retained size, so a large-but-legitimate window amortizes the rewrite
     // instead of compacting on every subsequent append.

--- a/src/credit-ledger.js
+++ b/src/credit-ledger.js
@@ -93,7 +93,11 @@ export class CreditLedger {
   }
 
   query({ days = this.retentionDays, now = new Date() } = {}) {
-    const cutoff = this._cutoff(days, now);
+    // Clamp to the retention window: the ledger only promises 30 days, and rows
+    // older than that may still be on disk (pruning runs lazily on record), so a
+    // wider days= must never surface aged-out attribution.
+    const window = Math.min(Math.max(1, days), this.retentionDays);
+    const cutoff = this._cutoff(window, now);
     return this._readAll()
       .filter((r) => (r.at ?? "") >= cutoff)
       .sort((a, b) => (b.at ?? "").localeCompare(a.at ?? ""));

--- a/src/credit-ledger.js
+++ b/src/credit-ledger.js
@@ -20,6 +20,7 @@ export class CreditLedger {
     // size so a ledger whose retained 30-day window legitimately exceeds
     // compactBytes doesn't read+rewrite the whole file on every append.
     this._nextCompactBytes = this.compactBytes;
+    this._lastPruneAt = 0; // epoch ms of the last retention prune (0 → prune on first record)
     ensureDir(path.dirname(this.storePath));
     // The ledger holds attribution (from/sessionId/agentId/tools/spend) — not
     // world-readable. New files are created 0600 (mode on append/write below);
@@ -62,20 +63,30 @@ export class CreditLedger {
       tools: Array.isArray(entry.tools) ? entry.tools : []
     };
     fs.appendFileSync(this.storePath, JSON.stringify(row) + "\n", { mode: 0o600 });
-    this._maybeCompact(now);
+    this._maybeMaintain(now);
     return row;
   }
 
-  _maybeCompact(now) {
+  // Prune to the retention window when the file has grown past the (re-armed)
+  // compaction threshold OR at least once a day — so rows older than the window
+  // are physically removed even on low-volume installs that never hit the size
+  // cap. This enforces the 30-day retention/privacy guarantee on disk, not just
+  // at read time. Appending stays O(1); this only does work when size- or
+  // time-triggered.
+  _maybeMaintain(now) {
     let size = 0;
     try { size = fs.statSync(this.storePath).size; } catch { return; }
-    if (size < this._nextCompactBytes) return;
+    const dueByTime = (now.getTime() - this._lastPruneAt) >= 86400 * 1000;
+    if (size < this._nextCompactBytes && !dueByTime) return;
     const cutoff = this._cutoff(this.retentionDays, now);
-    const kept = this._readAll().filter((r) => (r.at ?? "") >= cutoff);
-    fs.writeFileSync(this.storePath, kept.map((r) => JSON.stringify(r)).join("\n") + (kept.length ? "\n" : ""), { mode: 0o600 });
-    // Re-arm: only compact again after the file roughly doubles past the
-    // retained size, so a large-but-legitimate window amortizes the rewrite
-    // instead of compacting on every subsequent append.
+    const all = this._readAll();
+    const kept = all.filter((r) => (r.at ?? "") >= cutoff);
+    if (kept.length !== all.length) {
+      fs.writeFileSync(this.storePath, kept.map((r) => JSON.stringify(r)).join("\n") + (kept.length ? "\n" : ""), { mode: 0o600 });
+    }
+    this._lastPruneAt = now.getTime();
+    // Re-arm: only size-compact again after the file roughly doubles past the
+    // retained size, so a large-but-legitimate window amortizes the rewrite.
     let newSize = 0;
     try { newSize = fs.statSync(this.storePath).size; } catch { /* ignore */ }
     this._nextCompactBytes = Math.max(this.compactBytes, newSize * 2);

--- a/src/credit-ledger.js
+++ b/src/credit-ledger.js
@@ -1,0 +1,93 @@
+// src/credit-ledger.js
+import fs from "node:fs";
+import path from "node:path";
+import { ensureDir } from "./file-utils.js";
+import { resolveDataDir } from "./data-dir.js";
+
+const RETENTION_DAYS = 30;
+const COMPACT_BYTES = 4 * 1024 * 1024;
+
+// Append-only per-call credit (USD) ledger. record() is O(1) append (it runs in
+// the hot path of every LLM call); old entries are filtered out of query()/
+// analytics() by the rolling window, and the file is compacted only when it
+// grows large. Stores no message content — just cost + attribution.
+export class CreditLedger {
+  constructor(options = {}) {
+    this.storePath = options.storePath ?? path.join(resolveDataDir(), "budget", "ledger.jsonl");
+    this.retentionDays = options.retentionDays ?? RETENTION_DAYS;
+    this.compactBytes = options.compactBytes ?? COMPACT_BYTES;
+    ensureDir(path.dirname(this.storePath));
+  }
+
+  _cutoff(days, now) {
+    return new Date(now.getTime() - days * 86400 * 1000).toISOString();
+  }
+
+  _readAll() {
+    let text;
+    try { text = fs.readFileSync(this.storePath, "utf8"); } catch { return []; }
+    const out = [];
+    for (const line of text.split("\n")) {
+      if (!line.trim()) continue;
+      try { out.push(JSON.parse(line)); } catch { /* skip corrupt line */ }
+    }
+    return out;
+  }
+
+  record(entry = {}, { now = new Date() } = {}) {
+    const row = {
+      at: entry.at ?? now.toISOString(),
+      model: entry.model ?? null,
+      tokens: entry.tokens ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      usd: Number(entry.usd ?? 0),
+      channel: entry.channel ?? null,
+      agentId: entry.agentId ?? null,
+      sessionId: entry.sessionId ?? null,
+      from: entry.from ?? null,
+      tools: Array.isArray(entry.tools) ? entry.tools : []
+    };
+    fs.appendFileSync(this.storePath, JSON.stringify(row) + "\n");
+    this._maybeCompact(now);
+    return row;
+  }
+
+  _maybeCompact(now) {
+    let size = 0;
+    try { size = fs.statSync(this.storePath).size; } catch { return; }
+    if (size < this.compactBytes) return;
+    const cutoff = this._cutoff(this.retentionDays, now);
+    const kept = this._readAll().filter((r) => (r.at ?? "") >= cutoff);
+    fs.writeFileSync(this.storePath, kept.map((r) => JSON.stringify(r)).join("\n") + (kept.length ? "\n" : ""));
+  }
+
+  query({ days = this.retentionDays, now = new Date() } = {}) {
+    const cutoff = this._cutoff(days, now);
+    return this._readAll()
+      .filter((r) => (r.at ?? "") >= cutoff)
+      .sort((a, b) => (b.at ?? "").localeCompare(a.at ?? ""));
+  }
+
+  analytics({ days = this.retentionDays, now = new Date() } = {}) {
+    const rows = this.query({ days, now });
+    const byDay = {}, byModel = {}, byActivity = {};
+    let totalUsd = 0, totalCalls = 0;
+    for (const r of rows) {
+      const day = (r.at ?? "").slice(0, 10);
+      const model = r.model ?? "unknown";
+      const activity = r.channel ?? "unknown";
+      const usd = Number(r.usd ?? 0);
+      totalUsd += usd; totalCalls += 1;
+      (byDay[day] ??= { date: day, usd: 0, calls: 0 });        byDay[day].usd += usd; byDay[day].calls += 1;
+      (byModel[model] ??= { model, usd: 0, calls: 0 });        byModel[model].usd += usd; byModel[model].calls += 1;
+      (byActivity[activity] ??= { activity, usd: 0, calls: 0 }); byActivity[activity].usd += usd; byActivity[activity].calls += 1;
+    }
+    const round = (o) => ({ ...o, usd: Number(o.usd.toFixed(4)) });
+    return {
+      totalUsd: Number(totalUsd.toFixed(4)),
+      totalCalls,
+      byDay: Object.values(byDay).sort((a, b) => a.date.localeCompare(b.date)).map(round),
+      byModel: Object.values(byModel).sort((a, b) => b.usd - a.usd).map(round),
+      byActivity: Object.values(byActivity).sort((a, b) => b.usd - a.usd).map(round)
+    };
+  }
+}

--- a/src/credit-ledger.js
+++ b/src/credit-ledger.js
@@ -16,11 +16,22 @@ export class CreditLedger {
     this.storePath = options.storePath ?? path.join(resolveDataDir(), "budget", "ledger.jsonl");
     this.retentionDays = options.retentionDays ?? RETENTION_DAYS;
     this.compactBytes = options.compactBytes ?? COMPACT_BYTES;
+    // Next size at which compaction runs. Re-armed above the post-compaction
+    // size so a ledger whose retained 30-day window legitimately exceeds
+    // compactBytes doesn't read+rewrite the whole file on every append.
+    this._nextCompactBytes = this.compactBytes;
     ensureDir(path.dirname(this.storePath));
   }
 
+  // Calendar-day cutoff (UTC, matching BudgetGuard.todayKey): the start of the
+  // day that is (days-1) days before `now`. So days=1 means "today" (since UTC
+  // midnight), days=7 means "today + the previous 6 days" — not a rolling N×24h
+  // window, which would bleed yesterday's evening spend into a "today" query.
   _cutoff(days, now) {
-    return new Date(now.getTime() - days * 86400 * 1000).toISOString();
+    const d = new Date(now.getTime());
+    d.setUTCHours(0, 0, 0, 0);
+    d.setUTCDate(d.getUTCDate() - (days - 1));
+    return d.toISOString();
   }
 
   _readAll() {
@@ -54,10 +65,16 @@ export class CreditLedger {
   _maybeCompact(now) {
     let size = 0;
     try { size = fs.statSync(this.storePath).size; } catch { return; }
-    if (size < this.compactBytes) return;
+    if (size < this._nextCompactBytes) return;
     const cutoff = this._cutoff(this.retentionDays, now);
     const kept = this._readAll().filter((r) => (r.at ?? "") >= cutoff);
     fs.writeFileSync(this.storePath, kept.map((r) => JSON.stringify(r)).join("\n") + (kept.length ? "\n" : ""));
+    // Re-arm: only compact again after the file roughly doubles past the
+    // retained size, so a large-but-legitimate window amortizes the rewrite
+    // instead of compacting on every subsequent append.
+    let newSize = 0;
+    try { newSize = fs.statSync(this.storePath).size; } catch { /* ignore */ }
+    this._nextCompactBytes = Math.max(this.compactBytes, newSize * 2);
   }
 
   query({ days = this.retentionDays, now = new Date() } = {}) {

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -341,8 +341,12 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
       if (method === "GET" && pathname === "/budget/ledger") {
         const ledger = runtime.budget?.ledger;
         if (!ledger) return sendJson(res, 200, { error: "no-ledger" });
-        const days = Math.max(1, Math.min(90, Number.parseInt(url.searchParams.get("days") ?? "30", 10) || 30));
-        return sendJson(res, 200, { days, entries: ledger.query({ days }), analytics: ledger.analytics({ days }) });
+        // Cap at the ledger's retention window so the reported `days` always
+        // matches the data actually returned (query/analytics clamp the same way).
+        const maxDays = ledger.retentionDays ?? 30;
+        const requested = Math.max(1, Number.parseInt(url.searchParams.get("days") ?? "30", 10) || 30);
+        const days = Math.min(maxDays, requested);
+        return sendJson(res, 200, { days, requestedDays: requested, retentionDays: maxDays, entries: ledger.query({ days }), analytics: ledger.analytics({ days }) });
       }
 
       // ─── Ambient capture / observations ─────────────────────────────────

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -338,6 +338,12 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
       }
 
       if (method === "GET" && pathname === "/budget") return sendJson(res, 200, runtime.budget?.status?.() ?? { error: "no-budget" });
+      if (method === "GET" && pathname === "/budget/ledger") {
+        const ledger = runtime.budget?.ledger;
+        if (!ledger) return sendJson(res, 200, { error: "no-ledger" });
+        const days = Math.max(1, Math.min(90, Number.parseInt(url.searchParams.get("days") ?? "30", 10) || 30));
+        return sendJson(res, 200, { days, entries: ledger.query({ days }), analytics: ledger.analytics({ days }) });
+      }
 
       // ─── Ambient capture / observations ─────────────────────────────────
       if (method === "POST" && pathname === "/observations") {

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -1833,7 +1833,7 @@ function renderApp() {
             <button data-tab="today" title="What you got done today — completed tasks, skills run, actions approved, time tracked, themes.">Today</button>
             <button data-tab="activity" title="Ambient capture log — what you were doing on screen (if capture is enabled).">Activity</button>
             <button data-tab="computer-use" title="Computer use (beta) — every action the agent intended to take, with the reasoning it gave.">Computer Use</button>
-            <button data-tab="budget" title="Today's LLM spend + 14-day history.">Budget</button>
+            <button data-tab="budget" title="Today's LLM spend + 14-day history.">Credits</button>
             <button data-tab="outcomes" title="Quality scores for completed agent work, 7d + 30d rolling.">Outcomes</button>
             <button data-tab="health" title="Memory saturation, specialist health, MCP status, upcoming cron.">Health</button>
             <button data-tab="scrutiny" title="Directional Adaptive Scrutiny — the 7-axis scorer's calibration + recent verdicts.">Scrutiny</button>
@@ -3136,7 +3136,7 @@ async function renderBudget() {
   const stateClass = pct > 90 ? "err" : pct > 70 ? "warn" : "ok";
   main.innerHTML = \`
     <div class="pane">
-      <h2>Budget</h2>
+      <h2>Credits</h2>
       <div class="card">
         <div class="row between" style="align-items:center;">
           <span class="name">Today · \${escapeHtml(b.today)}</span>
@@ -3162,6 +3162,14 @@ async function renderBudget() {
       <h3>Last 14 days</h3>
       <div id="budgetHistory" class="grid"></div>
       <p class="desc" style="margin-top:12px;">Limit is set via <code>OPENAGI_DAILY_USD_LIMIT</code> in <code>.openagi/.env</code>.</p>
+      <h3>Spend over time (30 days)</h3>
+      <div id="creditChart" class="card"></div>
+      <h3>By activity (30 days)</h3>
+      <div id="creditByActivity" class="grid"></div>
+      <h3>By model (30 days)</h3>
+      <div id="creditByModel" class="grid"></div>
+      <h3>Audit log</h3>
+      <div id="creditLog"></div>
     </div>
   \`;
   const hist = $("budgetHistory");
@@ -3170,6 +3178,43 @@ async function renderBudget() {
     c.className = "card";
     c.innerHTML = \`<div class="row between"><span class="name">\${escapeHtml(d.date)}</span><span class="muted">\${d.calls} call\${d.calls===1?"":"s"}</span></div><div class="stat-value">$\${d.usd.toFixed(4)}</div>\`;
     hist.appendChild(c);
+  }
+  const led = await fetchJson("/budget/ledger?days=30").catch(() => null);
+  if (led && !led.error) {
+    const days = led.analytics.byDay;
+    const maxUsd = Math.max(0.0001, ...days.map((d) => d.usd));
+    const bw = 100 / Math.max(days.length, 1);
+    const bars = days.map((d, i) => {
+      const h = Math.max(1, (d.usd / maxUsd) * 90);
+      return \`<rect x="\${(i * bw).toFixed(2)}" y="\${(100 - h).toFixed(2)}" width="\${(bw * 0.8).toFixed(2)}" height="\${h.toFixed(2)}"><title>\${escapeHtml(d.date)}: $\${d.usd.toFixed(4)} (\${d.calls})</title></rect>\`;
+    }).join("");
+    $("creditChart").innerHTML = \`<svg viewBox="0 0 100 100" preserveAspectRatio="none" style="width:100%;height:120px;fill:var(--accent);">\${bars}</svg>\`;
+
+    const fill = (id, items, key) => {
+      const el = $(id); el.innerHTML = "";
+      for (const it of items) {
+        const c = document.createElement("div"); c.className = "card";
+        c.innerHTML = \`<div class="row between"><span class="name">\${escapeHtml(String(it[key]))}</span><span class="muted">\${it.calls} call\${it.calls === 1 ? "" : "s"}</span></div><div class="stat-value">$\${it.usd.toFixed(4)}</div>\`;
+        el.appendChild(c);
+      }
+    };
+    fill("creditByActivity", led.analytics.byActivity, "activity");
+    fill("creditByModel", led.analytics.byModel, "model");
+
+    const log = $("creditLog");
+    log.innerHTML = "";
+    for (const e of led.entries.slice(0, 200)) {
+      const t = (e.at || "").slice(0, 16).replace("T", " ");
+      const tools = (e.tools || []).join(", ");
+      const row = document.createElement("div"); row.className = "card";
+      row.innerHTML = \`<div class="row between"><span class="name">\${escapeHtml(e.model || "?")}</span><span class="stat-value">$\${Number(e.usd || 0).toFixed(4)}</span></div><div class="muted" style="font-size:11px;">\${escapeHtml(t)} · \${escapeHtml(e.channel || "?")}\${e.agentId ? " · " + escapeHtml(e.agentId) : ""}\${tools ? " · " + escapeHtml(tools) : ""}</div>\`;
+      log.appendChild(row);
+    }
+    if (led.entries.length > 200) {
+      const more = document.createElement("p"); more.className = "desc";
+      more.textContent = "Showing the most recent 200 of " + led.entries.length + " calls.";
+      log.appendChild(more);
+    }
   }
 }
 

--- a/src/model-provider.js
+++ b/src/model-provider.js
@@ -143,12 +143,13 @@ export class OpenAIResponsesProvider {
       });
       const json = await response.json().catch(() => ({}));
       if (!response.ok) throw new Error(json?.error?.message ?? `OpenAI request failed with ${response.status}`);
+      const callTools = (json.output ?? []).filter((item) => item.type === "function_call").map((item) => item.name);
       this.budgetGuard?.record(json.usage, this.model, {
         channel: context.channel,
         agentId: context.agentId,
         sessionId: context.sessionId,
         from: context.from,
-        tools: toolCalls.map((c) => c.name)
+        tools: callTools
       });
       return json;
     } finally {
@@ -256,12 +257,13 @@ export class AnthropicProvider {
       });
       const json = await response.json().catch(() => ({}));
       if (!response.ok) throw new Error(json?.error?.message ?? `Anthropic request failed with ${response.status}`);
+      const callTools = (json.content ?? []).filter((b) => b.type === "tool_use").map((b) => b.name);
       this.budgetGuard?.record(json.usage, this.model, {
         channel: context.channel,
         agentId: context.agentId,
         sessionId: context.sessionId,
         from: context.from,
-        tools: toolCalls.map((c) => c.name)
+        tools: callTools
       });
       return json;
     } finally {

--- a/src/model-provider.js
+++ b/src/model-provider.js
@@ -89,7 +89,7 @@ export class OpenAIResponsesProvider {
         input: conversationInput
       };
       if (toolList.length > 0) body.tools = toolList;
-      response = await this.postResponses(body);
+      response = await this.postResponses(body, context, toolCalls);
 
       const calls = extractFunctionCalls(response);
       if (calls.length === 0) break;
@@ -128,7 +128,7 @@ export class OpenAIResponsesProvider {
     };
   }
 
-  async postResponses(body) {
+  async postResponses(body, context = {}, toolCalls = []) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
@@ -143,7 +143,13 @@ export class OpenAIResponsesProvider {
       });
       const json = await response.json().catch(() => ({}));
       if (!response.ok) throw new Error(json?.error?.message ?? `OpenAI request failed with ${response.status}`);
-      this.budgetGuard?.record(json.usage, this.model);
+      this.budgetGuard?.record(json.usage, this.model, {
+        channel: context.channel,
+        agentId: context.agentId,
+        sessionId: context.sessionId,
+        from: context.from,
+        tools: toolCalls.map((c) => c.name)
+      });
       return json;
     } finally {
       clearTimeout(timeout);
@@ -198,7 +204,7 @@ export class AnthropicProvider {
         system,
         messages: convo,
         ...(tools.length > 0 ? { tools } : {})
-      });
+      }, context, toolCalls);
 
       convo.push({ role: "assistant", content: response.content });
 
@@ -234,7 +240,7 @@ export class AnthropicProvider {
     };
   }
 
-  async postMessages(body) {
+  async postMessages(body, context = {}, toolCalls = []) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
@@ -250,7 +256,13 @@ export class AnthropicProvider {
       });
       const json = await response.json().catch(() => ({}));
       if (!response.ok) throw new Error(json?.error?.message ?? `Anthropic request failed with ${response.status}`);
-      this.budgetGuard?.record(json.usage, this.model);
+      this.budgetGuard?.record(json.usage, this.model, {
+        channel: context.channel,
+        agentId: context.agentId,
+        sessionId: context.sessionId,
+        from: context.from,
+        tools: toolCalls.map((c) => c.name)
+      });
       return json;
     } finally {
       clearTimeout(timeout);

--- a/src/model-provider.js
+++ b/src/model-provider.js
@@ -89,7 +89,7 @@ export class OpenAIResponsesProvider {
         input: conversationInput
       };
       if (toolList.length > 0) body.tools = toolList;
-      response = await this.postResponses(body, context, toolCalls);
+      response = await this.postResponses(body, context);
 
       const calls = extractFunctionCalls(response);
       if (calls.length === 0) break;
@@ -128,7 +128,7 @@ export class OpenAIResponsesProvider {
     };
   }
 
-  async postResponses(body, context = {}, toolCalls = []) {
+  async postResponses(body, context = {}) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
@@ -205,7 +205,7 @@ export class AnthropicProvider {
         system,
         messages: convo,
         ...(tools.length > 0 ? { tools } : {})
-      }, context, toolCalls);
+      }, context);
 
       convo.push({ role: "assistant", content: response.content });
 
@@ -241,7 +241,7 @@ export class AnthropicProvider {
     };
   }
 
-  async postMessages(body, context = {}, toolCalls = []) {
+  async postMessages(body, context = {}) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
     try {

--- a/src/tool-registry.js
+++ b/src/tool-registry.js
@@ -278,14 +278,15 @@ export function registerCoreTools(registry, runtime) {
     parameters: {
       type: "object",
       properties: {
-        days: { type: "integer", minimum: 1, maximum: 90, description: "Look-back window in days (default 1 = today)." }
+        days: { type: "integer", minimum: 1, maximum: 30, description: "Look-back window in days (default 1 = today; the local ledger retains 30 days)." }
       },
       additionalProperties: false
     },
     handler: async (args) => {
       const ledger = runtime.budget?.ledger;
       if (!ledger) return { error: "no credit ledger available" };
-      const days = args.days ?? 1;
+      // Clamp to the retained window so the reported `days` matches the data.
+      const days = Math.min(args.days ?? 1, ledger.retentionDays ?? 30);
       const analytics = ledger.analytics({ days });
       const top = ledger.query({ days })
         .slice()

--- a/src/tool-registry.js
+++ b/src/tool-registry.js
@@ -273,6 +273,30 @@ export function registerCoreTools(registry, runtime) {
   });
 
   registry.register({
+    name: "recall_spend",
+    description: "Summarize LLM credit (USD) usage: how much has been spent, on what activity/model, and the costliest recent calls. Use to answer questions about cost/credits/budget — e.g. 'why did I spend $4 today?'.",
+    parameters: {
+      type: "object",
+      properties: {
+        days: { type: "integer", minimum: 1, maximum: 90, description: "Look-back window in days (default 1 = today)." }
+      },
+      additionalProperties: false
+    },
+    handler: async (args) => {
+      const ledger = runtime.budget?.ledger;
+      if (!ledger) return { error: "no credit ledger available" };
+      const days = args.days ?? 1;
+      const analytics = ledger.analytics({ days });
+      const top = ledger.query({ days })
+        .slice()
+        .sort((a, b) => (b.usd ?? 0) - (a.usd ?? 0))
+        .slice(0, 10)
+        .map((r) => ({ at: r.at, model: r.model, activity: r.channel, agentId: r.agentId, usd: Number((r.usd ?? 0).toFixed(4)), tools: r.tools ?? [] }));
+      return { days, totalUsd: analytics.totalUsd, calls: analytics.totalCalls, byActivity: analytics.byActivity, byModel: analytics.byModel, top };
+    }
+  });
+
+  registry.register({
     name: "list_sessions",
     description: "List recent conversations across channels.",
     parameters: {

--- a/test/budget-guard-ledger.test.js
+++ b/test/budget-guard-ledger.test.js
@@ -1,0 +1,38 @@
+// test/budget-guard-ledger.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { BudgetGuard } from "../src/budget-guard.js";
+import { CreditLedger } from "../src/credit-ledger.js";
+
+function tmp() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bg-"));
+  const ledger = new CreditLedger({ storePath: path.join(dir, "ledger.jsonl") });
+  const guard = new BudgetGuard({ storePath: path.join(dir, "usage.json"), ledger });
+  return { guard, ledger };
+}
+
+test("record(meta) writes a ledger entry carrying the context", () => {
+  const { guard, ledger } = tmp();
+  guard.record({ input_tokens: 1000, output_tokens: 500 }, "claude-opus-4-7", {
+    channel: "autopilot", agentId: "main", sessionId: "s9", from: "cron", tools: ["web_search", "add_task"]
+  });
+  const rows = ledger.query({ days: 1 });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].channel, "autopilot");
+  assert.deepEqual(rows[0].tools, ["web_search", "add_task"]);
+  assert.equal(rows[0].model, "claude-opus-4-7");
+  assert.ok(rows[0].usd > 0);
+  assert.equal(rows[0].tokens.input, 1000);
+});
+
+test("record without meta still aggregates and does not throw (back-compat)", () => {
+  const { guard, ledger } = tmp();
+  const res = guard.record({ input_tokens: 100, output_tokens: 50 }, "gpt-5");
+  assert.ok(res.added > 0);
+  const rows = ledger.query({ days: 1 });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].channel, null);
+});

--- a/test/credit-ledger.test.js
+++ b/test/credit-ledger.test.js
@@ -86,6 +86,13 @@ test("days=7 includes today plus the previous 6 calendar days", () => {
   assert.equal(rows[0].at, "2026-05-31T10:00:00.000Z");
 });
 
+test("creates the ledger file with private 0600 permissions", { skip: process.platform === "win32" }, () => {
+  const L = tmpLedger();
+  L.record(entry());
+  const mode = fs.statSync(L.storePath).mode & 0o777;
+  assert.equal(mode, 0o600, `expected 0600, got 0o${mode.toString(8)}`);
+});
+
 test("re-arms the compaction threshold so it doesn't rewrite on every append", () => {
   const L = tmpLedger({ compactBytes: 1 }); // would compact on every append without re-arming
   const now = new Date("2026-06-06T10:00:00.000Z");

--- a/test/credit-ledger.test.js
+++ b/test/credit-ledger.test.js
@@ -96,6 +96,16 @@ test("enforces 30-day retention on disk even below the compaction threshold", ()
   assert.match(onDisk[0], /2026-06-06T09:00/);
 });
 
+test("clamps query/analytics to the retention window (stale on-disk rows never surface)", () => {
+  const L = tmpLedger();
+  // Write an aged-out row directly, bypassing record()'s prune, to simulate
+  // data still on disk past the window.
+  fs.writeFileSync(L.storePath, JSON.stringify({ at: "2026-04-01T10:00:00.000Z", model: "x", usd: 1, channel: "chat", tools: [] }) + "\n");
+  const now = new Date("2026-06-06T10:00:00.000Z");
+  assert.equal(L.query({ days: 90, now }).length, 0, "days=90 must not return a >30-day-old row");
+  assert.equal(L.analytics({ days: 90, now }).totalCalls, 0);
+});
+
 test("creates the ledger file with private 0600 permissions", { skip: process.platform === "win32" }, () => {
   const L = tmpLedger();
   L.record(entry());

--- a/test/credit-ledger.test.js
+++ b/test/credit-ledger.test.js
@@ -86,6 +86,16 @@ test("days=7 includes today plus the previous 6 calendar days", () => {
   assert.equal(rows[0].at, "2026-05-31T10:00:00.000Z");
 });
 
+test("enforces 30-day retention on disk even below the compaction threshold", () => {
+  const L = tmpLedger({ compactBytes: 10 * 1024 * 1024 }); // never size-compacts
+  const now = new Date("2026-06-06T10:00:00.000Z");
+  L.record(entry({ at: "2026-04-01T10:00:00.000Z" }), { now }); // ~66 days old → pruned
+  L.record(entry({ at: "2026-06-06T09:00:00.000Z" }), { now }); // within window
+  const onDisk = fs.readFileSync(L.storePath, "utf8").split("\n").filter(Boolean);
+  assert.equal(onDisk.length, 1, "old row physically removed despite a small file");
+  assert.match(onDisk[0], /2026-06-06T09:00/);
+});
+
 test("creates the ledger file with private 0600 permissions", { skip: process.platform === "win32" }, () => {
   const L = tmpLedger();
   L.record(entry());

--- a/test/credit-ledger.test.js
+++ b/test/credit-ledger.test.js
@@ -62,3 +62,37 @@ test("tolerates a missing/corrupt file", () => {
   fs.writeFileSync(L.storePath, "not json\n{bad\n");
   assert.deepEqual(L.query(), []);
 });
+
+test("days=1 means today (UTC calendar day), not a rolling 24h window", () => {
+  const L = tmpLedger();
+  // now = today 08:00 UTC. An entry at yesterday 23:00 is within the last 24h
+  // but is NOT today — it must be excluded from a days=1 ("today") query.
+  L.record(entry({ at: "2026-06-05T23:00:00.000Z" })); // yesterday evening
+  L.record(entry({ at: "2026-06-06T02:00:00.000Z" })); // today, early
+  const now = new Date("2026-06-06T08:00:00.000Z");
+  const rows = L.query({ days: 1, now });
+  assert.equal(rows.length, 1, "only today's entry");
+  assert.equal(rows[0].at, "2026-06-06T02:00:00.000Z");
+  assert.equal(L.analytics({ days: 1, now }).totalCalls, 1);
+});
+
+test("days=7 includes today plus the previous 6 calendar days", () => {
+  const L = tmpLedger();
+  L.record(entry({ at: "2026-05-31T10:00:00.000Z" })); // 6 days before the 6th — included
+  L.record(entry({ at: "2026-05-30T10:00:00.000Z" })); // 7 days before — excluded
+  const now = new Date("2026-06-06T08:00:00.000Z");
+  const rows = L.query({ days: 7, now });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].at, "2026-05-31T10:00:00.000Z");
+});
+
+test("re-arms the compaction threshold so it doesn't rewrite on every append", () => {
+  const L = tmpLedger({ compactBytes: 1 }); // would compact on every append without re-arming
+  const now = new Date("2026-06-06T10:00:00.000Z");
+  L.record(entry({ at: "2026-06-06T09:00:00.000Z" }), { now });
+  L.record(entry({ at: "2026-06-06T09:30:00.000Z" }), { now });
+  // After compacting a retained (non-empty) window, the next threshold must
+  // climb above compactBytes so subsequent appends within the headroom skip the
+  // full read+rewrite.
+  assert.ok(L._nextCompactBytes > 1, `expected re-armed threshold > 1, got ${L._nextCompactBytes}`);
+});

--- a/test/credit-ledger.test.js
+++ b/test/credit-ledger.test.js
@@ -1,0 +1,64 @@
+// test/credit-ledger.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { CreditLedger } from "../src/credit-ledger.js";
+
+function tmpLedger(opts = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ledger-"));
+  return new CreditLedger({ storePath: path.join(dir, "ledger.jsonl"), ...opts });
+}
+const entry = (over = {}) => ({
+  model: "claude-opus-4-7", usd: 0.05, channel: "chat", agentId: "main",
+  sessionId: "s1", from: "user", tools: ["web_search"],
+  tokens: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0 }, ...over
+});
+
+test("records and queries entries newest-first", () => {
+  const L = tmpLedger();
+  L.record(entry({ usd: 0.01, at: "2026-06-05T10:00:00.000Z" }));
+  L.record(entry({ usd: 0.02, at: "2026-06-06T10:00:00.000Z" }));
+  const rows = L.query({ days: 30, now: new Date("2026-06-06T12:00:00.000Z") });
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0].usd, 0.02);
+  assert.equal(rows[0].channel, "chat");
+});
+
+test("query window excludes entries older than days", () => {
+  const L = tmpLedger();
+  L.record(entry({ at: "2026-05-01T10:00:00.000Z" }));
+  L.record(entry({ at: "2026-06-06T10:00:00.000Z" }));
+  const rows = L.query({ days: 30, now: new Date("2026-06-06T12:00:00.000Z") });
+  assert.equal(rows.length, 1);
+});
+
+test("analytics groups by day, model, activity", () => {
+  const L = tmpLedger();
+  L.record(entry({ usd: 0.10, channel: "autopilot", model: "claude-opus-4-7", at: "2026-06-06T09:00:00.000Z" }));
+  L.record(entry({ usd: 0.04, channel: "chat", model: "gpt-5", at: "2026-06-06T10:00:00.000Z" }));
+  L.record(entry({ usd: 0.01, channel: "chat", model: "gpt-5", at: "2026-06-05T10:00:00.000Z" }));
+  const a = L.analytics({ days: 30, now: new Date("2026-06-06T12:00:00.000Z") });
+  assert.equal(a.totalCalls, 3);
+  assert.equal(a.totalUsd, 0.15);
+  assert.equal(a.byActivity.find((x) => x.activity === "autopilot").usd, 0.10);
+  assert.equal(a.byActivity[0].activity, "autopilot");
+  assert.equal(a.byModel.find((x) => x.model === "gpt-5").calls, 2);
+  assert.deepEqual(a.byDay.map((d) => d.date), ["2026-06-05", "2026-06-06"]);
+});
+
+test("compacts when the file exceeds the byte threshold, keeping the window", () => {
+  const L = tmpLedger({ compactBytes: 1 });
+  L.record(entry({ at: "2026-05-01T10:00:00.000Z" }), { now: new Date("2026-06-06T10:00:00.000Z") });
+  L.record(entry({ at: "2026-06-06T10:00:00.000Z" }), { now: new Date("2026-06-06T10:00:00.000Z") });
+  const onDisk = fs.readFileSync(L.storePath, "utf8").split("\n").filter(Boolean);
+  assert.equal(onDisk.length, 1);
+});
+
+test("tolerates a missing/corrupt file", () => {
+  const L = tmpLedger();
+  assert.deepEqual(L.query(), []);
+  fs.writeFileSync(L.storePath, "not json\n{bad\n");
+  assert.deepEqual(L.query(), []);
+});

--- a/test/recall-spend.test.js
+++ b/test/recall-spend.test.js
@@ -1,0 +1,22 @@
+// test/recall-spend.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ToolRegistry, registerCoreTools } from "../src/tool-registry.js";
+import { CreditLedger } from "../src/credit-ledger.js";
+
+test("recall_spend summarizes the ledger", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rs-"));
+  const ledger = new CreditLedger({ storePath: path.join(dir, "ledger.jsonl") });
+  ledger.record({ usd: 0.10, channel: "autopilot", model: "claude-opus-4-7", tools: ["web_search"] });
+  ledger.record({ usd: 0.02, channel: "chat", model: "gpt-5", tools: [] });
+  const registry = new ToolRegistry();
+  registerCoreTools(registry, { budget: { ledger } });
+  const { result } = await registry.invoke("recall_spend", { days: 30 });
+  assert.ok(result.totalUsd >= 0.12 - 1e-9);
+  assert.equal(result.byActivity[0].activity, "autopilot");
+  assert.ok(Array.isArray(result.top));
+  assert.equal(result.top[0].activity, "autopilot"); // costliest first
+});


### PR DESCRIPTION
## Summary
A per-call audit log of LLM credit (USD) usage — **what** cost credits, **when**, and **why** (activity / agent / session / tools). Today `BudgetGuard` only kept daily aggregates; this adds the line-item ledger, a **Credits** dashboard view, and a `recall_spend` agent tool.

Spec: `docs/superpowers/specs/2026-06-06-credit-audit-log-design.md` · Plan: `docs/superpowers/plans/2026-06-06-credit-audit-log.md`. Built task-by-task with per-task review; final holistic review = ready to merge.

> **Stacked on #1** (`feat/external-knowledge-sources`) — retarget to `main` once #1 merges.

## What it does
- **Credits tab** (evolved from Budget): today's spend vs cap, totals **by activity** (chat/autopilot/cron/overlay/sms) and **by model**, a 30-day **spend chart** (inline SVG), and a per-call **audit log** (time · model · activity · agent · `$` · tools).
- **`recall_spend` tool:** ask the agent "why did I spend \$4 today?" in chat — it reads the same ledger and answers with totals + breakdown + costliest calls.
- **`GET /budget/ledger?days=N`** → `{ entries, analytics }`.

## How it works
- New `CreditLedger` (`src/credit-ledger.js`): append-only JSONL at `~/.openagi/budget/ledger.jsonl`, rolling **30-day** window, O(1) append (compacts only when large).
- `BudgetGuard.record(usage, model, meta)` computes the `$` (unchanged) and **best-effort** appends a ledger row — wrapped so a ledger failure can never break a model reply.
- `model-provider` threads `{ channel, agentId, sessionId, from, tools }` per call; tool names are derived from each call's own response (accurate per-call attribution).

## Privacy
The ledger stores **cost + attribution only — no message content, no secrets**. Local file, 30-day cap. Dashboard escapes every rendered value.

## Tests / verification
- `node --test` → **153 pass** (new: CreditLedger, BudgetGuard-ledger, recall_spend).
- `GET /budget/ledger` and `GET /` both render 200 (dashboard template verified — no escaping crash).

## Known minor (non-blocking)
- A now-unused `toolCalls` param is still threaded through the two model-provider POST helpers (each recomputes tool names locally); harmless, can be dropped later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)