### PR TITLE
feat: witnessed emergence — proposal-first suggestions, daily-plan notifications, live updates

### DIFF
--- a/mac/Sources/OpenAGI/AppState.swift
+++ b/mac/Sources/OpenAGI/AppState.swift
@@ -289,6 +289,13 @@ final class AppState: ObservableObject {
       let pathPart = date.isEmpty ? "/?tab=today" : "/?tab=today&date=\(urlEncode(date))"
       notify(title: title, body: body, path: pathPart)
     }
+    if event == "daily-plan" {
+      // Morning "here's your day" notification (calendar + focus + what the
+      // agent will draft). Tap routes to the Tasks tab.
+      let title = parseField(data, "title") ?? "Your day"
+      let body = parseField(data, "body") ?? "Tap to see today's plan."
+      notify(title: title, body: body, path: "/?tab=tasks")
+    }
     if event == "pending-action" {
       // Agent queued something that needs approval (gated tool). Land in
       // chat with the action id so the inline approval card renders.

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -1020,6 +1020,8 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
         const { resolveSuggestion } = await import("./suggestion-feed.js");
         const candidate = resolveSuggestion(runtime, id, status);
         if (!candidate) return sendJson(res, 404, { error: "unknown suggestion" });
+        // Let any open dashboard refresh its Suggestions tab live.
+        events.emit("suggestion-resolved", { id, status, category: candidate.category ?? null });
 
         // For MCP suggestions, accepting auto-registers + connects the server.
         if (status === "accepted" && candidate.category === "mcp" && candidate.mcpRegister && runtime.mcp?.registerServer) {
@@ -1034,22 +1036,14 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
           }
         }
         // For task suggestions, accepting creates the task in the right
-        // queue + bucket. The proposal title becomes the task title.
+        // queue + bucket — through the same materializer the observer's
+        // OPENAGI_AUTO_TASKS=1 path uses, so dedup (by suggestionId) and the
+        // draft-only guardrails for agent-queue tasks apply identically.
         if (status === "accepted" && candidate.category === "task" && runtime.tasks?.add) {
-          try {
-            const task = runtime.tasks.add(
-              {
-                title: candidate.title,
-                description: candidate.rationale,
-                bucket: candidate.taskBucket ?? "today",
-                sourceMeta: { suggestionId: id, observedApps: candidate.context?.apps }
-              },
-              { source: "proactive-observer", queue: candidate.taskQueue ?? "user" }
-            );
-            return sendJson(res, 200, { ...candidate, taskId: task.id });
-          } catch (error) {
-            return sendJson(res, 200, { ...candidate, taskCreateError: error.message });
-          }
+          const { materializeTaskFromSuggestion } = await import("./proactive-observer.js");
+          const task = materializeTaskFromSuggestion(runtime, candidate);
+          if (!task) return sendJson(res, 200, { ...candidate, taskCreateError: "could not create task" });
+          return sendJson(res, 200, { ...candidate, taskId: task.id });
         }
         // Story 1 + 6: accepting a skill suggestion materializes it into
         // a real SKILL.md file under the user skills dir. Dispatches by

--- a/src/proactive-observer.js
+++ b/src/proactive-observer.js
@@ -270,13 +270,19 @@ export class ProactiveObserver {
       proposedAt: nowIso(),
       ...record
     };
-    const task = this.materializeTaskSuggestion(candidate);
+    // Proposal-first: task suggestions surface as suggestion cards (notification
+    // + Suggestions tab) for the user to accept, like every other category —
+    // accepting materializes the task (hosted-interface accept endpoint).
+    // OPENAGI_AUTO_TASKS=1 restores the old behavior of silently creating the
+    // task the moment the observer proposes it.
+    const autoCreate = process.env.OPENAGI_AUTO_TASKS === "1";
+    const task = autoCreate ? materializeTaskFromSuggestion(this.runtime, candidate) : null;
     if (task) {
       candidate.status = "accepted";
       candidate.resolvedAt = nowIso();
       candidate.taskId = task.id;
       candidate.taskAutoCreated = true;
-      candidate.note = "Auto-created task from proactive observer.";
+      candidate.note = "Auto-created task from proactive observer (OPENAGI_AUTO_TASKS=1).";
     }
     writeJsonAtomic(path.join(this.suggestDir, `${id}.json`), candidate);
     if (task) {
@@ -302,42 +308,7 @@ export class ProactiveObserver {
   }
 
   materializeTaskSuggestion(candidate) {
-    if (candidate?.category !== "task") return null;
-    if (!candidate.title || !this.runtime?.tasks?.add) return null;
-    const queue = candidate.taskQueue === "agent" ? "agent" : "user";
-    try {
-      const existing = this.runtime.tasks.list?.({ limit: 500 }) ?? [];
-      const duplicate = existing.find((t) => t.sourceMeta?.suggestionId === candidate.id);
-      if (duplicate) return duplicate;
-
-      const descriptionParts = [];
-      if (candidate.rationale) descriptionParts.push(candidate.rationale);
-      if (queue === "agent") {
-        descriptionParts.push(
-          "Produce a draft only. Do NOT send, publish, schedule externally, or take any irreversible action without user approval.",
-          "Leave the result for the user to review."
-        );
-      }
-
-      return this.runtime.tasks.add(
-        {
-          title: candidate.title,
-          description: descriptionParts.join("\n\n").trim(),
-          bucket: candidate.taskBucket ?? "today",
-          priority: queue === "agent" ? 60 : 50,
-          tags: queue === "agent" ? ["observer-proposed", "draft-only"] : ["observer-proposed"],
-          sourceMeta: {
-            suggestionId: candidate.id,
-            autoMaterialized: true,
-            observedApps: candidate.context?.apps ?? null,
-            source: candidate.source ?? "proactive-observer"
-          }
-        },
-        { source: candidate.source ?? "proactive-observer", queue }
-      );
-    } catch {
-      return null;
-    }
+    return materializeTaskFromSuggestion(this.runtime, candidate);
   }
 
   list({ status = "pending" } = {}) {
@@ -723,4 +694,46 @@ function composeRetroContext(runtime) {
     lines.push(`[day] ${head.replace(/^##\s*/, "").slice(0, 200)}`);
   }
   return lines.join("\n");
+}
+
+// Create (or return the existing) task for a task-category suggestion.
+// Shared by the observer's OPENAGI_AUTO_TASKS=1 path and the dashboard's
+// accept endpoint, so both produce identical tasks (same dedup by
+// suggestionId, same draft-only guardrails for agent-queue tasks).
+export function materializeTaskFromSuggestion(runtime, candidate) {
+  if (candidate?.category !== "task") return null;
+  if (!candidate.title || !runtime?.tasks?.add) return null;
+  const queue = candidate.taskQueue === "agent" ? "agent" : "user";
+  try {
+    const existing = runtime.tasks.list?.({ limit: 500 }) ?? [];
+    const duplicate = existing.find((t) => t.sourceMeta?.suggestionId === candidate.id);
+    if (duplicate) return duplicate;
+
+    const descriptionParts = [];
+    if (candidate.rationale) descriptionParts.push(candidate.rationale);
+    if (queue === "agent") {
+      descriptionParts.push(
+        "Produce a draft only. Do NOT send, publish, schedule externally, or take any irreversible action without user approval.",
+        "Leave the result for the user to review."
+      );
+    }
+
+    return runtime.tasks.add(
+      {
+        title: candidate.title,
+        description: descriptionParts.join("\n\n").trim(),
+        bucket: candidate.taskBucket ?? "today",
+        priority: queue === "agent" ? 60 : 50,
+        tags: queue === "agent" ? ["observer-proposed", "draft-only"] : ["observer-proposed"],
+        sourceMeta: {
+          suggestionId: candidate.id,
+          observedApps: candidate.context?.apps ?? null,
+          source: candidate.source ?? "proactive-observer"
+        }
+      },
+      { source: candidate.source ?? "proactive-observer", queue }
+    );
+  } catch {
+    return null;
+  }
 }

--- a/test/abi-runtime.test.js
+++ b/test/abi-runtime.test.js
@@ -2360,7 +2360,9 @@ test("McpRegistry persist surfaces filesystem errors instead of swallowing", asy
   fs.rmSync(dir, { recursive: true });
 });
 
-test("proactive-observer: task proposals materialize into real tasks", async () => {
+test("proactive-observer: task proposals materialize into real tasks with OPENAGI_AUTO_TASKS=1", async (t) => {
+  process.env.OPENAGI_AUTO_TASKS = "1";
+  t.after(() => { delete process.env.OPENAGI_AUTO_TASKS; });
   const { ProactiveObserver } = await import("../src/proactive-observer.js");
   const { TaskStore } = await import("../src/task-store.js");
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-observer-task-"));

--- a/test/proactive-suggestion-flow.test.js
+++ b/test/proactive-suggestion-flow.test.js
@@ -1,0 +1,134 @@
+// Proposal-first suggestion flow: the observer surfaces task ideas as
+// suggestion cards by default (user accepts → task), instead of silently
+// materializing tasks. OPENAGI_AUTO_TASKS=1 restores auto-create.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { ProactiveObserver, materializeTaskFromSuggestion } from "../src/proactive-observer.js";
+
+function makeRuntime() {
+  const added = [];
+  const events = [];
+  return {
+    added,
+    events,
+    tasks: {
+      add(input, opts) {
+        const task = { id: `task_${added.length + 1}`, ...input, queue: opts?.queue ?? "user", source: opts?.source };
+        added.push(task);
+        return task;
+      },
+      list() {
+        return added;
+      }
+    },
+    eventsLog: events,
+    events: { emit: (name, payload) => events.push({ name, payload }) }
+  };
+}
+
+function makeObserver(runtime) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-prop-"));
+  return new ProactiveObserver({ runtime, dataDir: dir });
+}
+
+test("task suggestions are proposals by default — no silent task creation", () => {
+  delete process.env.OPENAGI_AUTO_TASKS;
+  const runtime = makeRuntime();
+  const observer = makeObserver(runtime);
+
+  const { candidate } = observer.persist({
+    source: "proactive-observer",
+    category: "task",
+    title: "Follow up on PR #42",
+    rationale: "Seen open for 3 days",
+    taskQueue: "user",
+    status: "pending"
+  });
+
+  assert.equal(runtime.added.length, 0, "no task should be auto-created");
+  assert.equal(candidate.status, "pending");
+  assert.equal(candidate.taskAutoCreated, undefined);
+  const emitted = runtime.eventsLog.map((e) => e.name);
+  assert.deepEqual(emitted, ["proactive-suggestion"], "should emit a suggestion event, not task-reminder");
+  assert.equal(runtime.eventsLog[0].payload.category, "task");
+
+  // The suggestion file on disk stays pending so the accept endpoint can act on it.
+  const file = path.join(observer.suggestDir, `${candidate.id}.json`);
+  const onDisk = JSON.parse(fs.readFileSync(file, "utf8"));
+  assert.equal(onDisk.status, "pending");
+});
+
+test("OPENAGI_AUTO_TASKS=1 restores silent auto-creation", () => {
+  process.env.OPENAGI_AUTO_TASKS = "1";
+  try {
+    const runtime = makeRuntime();
+    const observer = makeObserver(runtime);
+
+    const { candidate } = observer.persist({
+      source: "proactive-observer",
+      category: "task",
+      title: "Follow up on PR #42",
+      rationale: "Seen open for 3 days",
+      taskQueue: "user",
+      status: "pending"
+    });
+
+    assert.equal(runtime.added.length, 1);
+    assert.equal(candidate.status, "accepted");
+    assert.equal(candidate.taskAutoCreated, true);
+    assert.equal(candidate.taskId, runtime.added[0].id);
+    const emitted = runtime.eventsLog.map((e) => e.name);
+    assert.deepEqual(emitted, ["task-reminder"]);
+  } finally {
+    delete process.env.OPENAGI_AUTO_TASKS;
+  }
+});
+
+test("non-task suggestions emit proactive-suggestion regardless of the flag", () => {
+  process.env.OPENAGI_AUTO_TASKS = "1";
+  try {
+    const runtime = makeRuntime();
+    const observer = makeObserver(runtime);
+    observer.persist({ source: "proactive-observer", category: "skill", title: "Morning standup draft", status: "pending" });
+    assert.equal(runtime.added.length, 0);
+    assert.deepEqual(runtime.eventsLog.map((e) => e.name), ["proactive-suggestion"]);
+  } finally {
+    delete process.env.OPENAGI_AUTO_TASKS;
+  }
+});
+
+test("materializeTaskFromSuggestion dedups by suggestionId", () => {
+  const runtime = makeRuntime();
+  const candidate = { id: "prop_x", category: "task", title: "Do thing", taskQueue: "user" };
+
+  const first = materializeTaskFromSuggestion(runtime, candidate);
+  assert.ok(first);
+  assert.equal(first.sourceMeta.suggestionId, "prop_x");
+
+  const second = materializeTaskFromSuggestion(runtime, candidate);
+  assert.equal(second.id, first.id, "accepting twice must not create a duplicate task");
+  assert.equal(runtime.added.length, 1);
+});
+
+test("agent-queue suggestions carry draft-only guardrails", () => {
+  const runtime = makeRuntime();
+  const task = materializeTaskFromSuggestion(runtime, {
+    id: "prop_y",
+    category: "task",
+    title: "Draft follow-up email",
+    rationale: "Call ended without recap",
+    taskQueue: "agent"
+  });
+  assert.ok(task.description.includes("draft only") || task.description.includes("Produce a draft"));
+  assert.ok(task.tags.includes("draft-only"));
+  assert.equal(task.queue, "agent");
+});
+
+test("materializeTaskFromSuggestion ignores non-task categories", () => {
+  const runtime = makeRuntime();
+  assert.equal(materializeTaskFromSuggestion(runtime, { id: "p", category: "skill", title: "x" }), null);
+  assert.equal(runtime.added.length, 0);
+});


### PR DESCRIPTION
Scope 5 from the feature audit: the proactive loop's outputs now reach the user, and task suggestions are proposals rather than faits accomplis.

## Changes
- **Proposal-first task suggestions** — the observer no longer auto-creates tasks pre-marked "accepted" (which bypassed the suggestion UI entirely, so tasks appeared unexplained). Task ideas now fire a `proactive-suggestion` notification (Mac handler already renders "📋 Task idea") and sit pending until accepted. `OPENAGI_AUTO_TASKS=1` restores auto-create for those who want it.
- **Unified task materialization** — one shared `materializeTaskFromSuggestion()` used by both the observer auto path and the dashboard accept endpoint; the endpoint previously skipped dedup, priority, tags, and the draft-only guardrails for agent-queue tasks.
- **`daily-plan` Mac notification** — the 8:00 morning plan was computed and emitted over SSE but the Mac app only handled `daily-recap`; the plan went nowhere. Added the handler (tap → Tasks tab).
- **`suggestion-resolved` SSE event** on accept/reject/dismiss so an open dashboard updates without refresh.

## Tests
- New `test/proactive-suggestion-flow.test.js` (6 cases).
- Updated the end-to-end observe() test to run under the auto-create flag.
- Full suite: 200/200. Swift app builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)