### PR TITLE
fix: scrutiny calibration survives restarts — persisted weights + audit history

### DIFF
--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -3306,7 +3306,7 @@ async function renderScrutiny() {
     .join("");
   main.innerHTML = \`
     <div class="pane">
-      <h2>Scrutiny <span class="muted" style="font-size:14px;font-weight:400;">· cycle \${fitter.cycles ?? 0} · \${fitter.autoApply ? "auto-apply" : "warmup"}</span></h2>
+      <h2>Scrutiny <span class="muted" style="font-size:14px;font-weight:400;">· cycle \${fitter.cycles ?? 0} · \${fitter.autoApply ? "auto-apply" : "warmup"}\${fitter.restoredWeightsAt ? \` · calibrated \${escapeHtml(new Date(fitter.restoredWeightsAt).toLocaleDateString())}\` : ""}</span></h2>
       <div class="row" style="gap:8px;margin-bottom:14px;">
         <button id="fitBtn">Run fit now</button>
         <button class="secondary" id="judgeBtn">Run LLM judge</button>

--- a/src/scrutiny-fitter.js
+++ b/src/scrutiny-fitter.js
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { ensureDir, readJsonFile, writeJsonAtomic } from "./file-utils.js";
+import { appendJsonLine, ensureDir, readJsonFile, writeJsonAtomic } from "./file-utils.js";
 import { nowIso } from "./utils.js";
 import { resolveDataDir } from "./data-dir.js";
 
@@ -27,12 +27,18 @@ export class ScrutinyFitter {
     this.dir = options.dir ?? path.join(resolveDataDir(), "scrutiny");
     this.statePath = path.join(this.dir, "fitter-state.json");
     this.pendingPath = path.join(this.dir, "pending-changes.json");
+    this.weightsPath = path.join(this.dir, "weights.json");
+    this.historyPath = path.join(this.dir, "weight-history.jsonl");
     this.minSamples = options.minSamples ?? DEFAULT_MIN_SAMPLES;
     this.maxDeltaPerCycle = options.maxDeltaPerCycle ?? DEFAULT_MAX_DELTA;
     this.warmupCycles = options.warmupCycles ?? DEFAULT_WARMUP;
     ensureDir(this.dir);
     this.state = readJsonFile(this.statePath, { version: 1, cycles: 0, lastRunAt: null, judgeSignals: [] });
     this.pending = readJsonFile(this.pendingPath, { version: 1, proposals: [] });
+    // Judge weights are constructed from hardcoded defaults every boot;
+    // without this restore, every fitted adjustment would silently vanish
+    // on daemon restart and calibration could never accumulate.
+    this.restoredWeightsAt = this.restoreWeights();
   }
 
   status() {
@@ -42,8 +48,61 @@ export class ScrutinyFitter {
       autoApply: this.state.cycles >= this.warmupCycles,
       lastRunAt: this.state.lastRunAt,
       pendingProposals: this.pending.proposals.length,
-      pendingJudgeSignals: this.state.judgeSignals.length
+      pendingJudgeSignals: this.state.judgeSignals.length,
+      restoredWeightsAt: this.restoredWeightsAt
     };
+  }
+
+  /**
+   * Load the last-applied weights from disk into the live judges. Called at
+   * construction (after the panel exists on the runtime). Judges present in
+   * the file but absent from the panel (or vice versa) are skipped, so an
+   * older weights file degrades gracefully. Returns the file's appliedAt
+   * timestamp when something was restored, else null.
+   */
+  restoreWeights() {
+    const judges = this.runtime?.scrutiny?.judges;
+    if (!judges) return null;
+    const saved = readJsonFile(this.weightsPath, null);
+    if (!saved?.judges) return null;
+    let restored = false;
+    for (const [name, weights] of Object.entries(saved.judges)) {
+      const judge = judges[name];
+      if (!judge || typeof weights !== "object") continue;
+      const sane = DIMENSIONS.every((dim) => typeof weights[dim] === "number" && Number.isFinite(weights[dim]));
+      if (!sane) continue;
+      judge.weights = { ...weights };
+      restored = true;
+    }
+    return restored ? (saved.appliedAt ?? null) : null;
+  }
+
+  /**
+   * Apply proposal weights to the live judges AND persist: weights.json so
+   * the calibration survives restarts, plus an append-only audit line per
+   * judge in weight-history.jsonl ("why did my agent's judgment change").
+   */
+  _applyAndPersist(proposals, { source, cycle, at = nowIso() } = {}) {
+    const judges = this.runtime?.scrutiny?.judges ?? {};
+    const applied = {};
+    for (const [judgeName, proposal] of Object.entries(proposals)) {
+      const judge = judges[judgeName];
+      if (!judge) continue;
+      judge.weights = { ...proposal.to };
+      applied[judgeName] = { ...proposal.to };
+      appendJsonLine(this.historyPath, {
+        at,
+        source,
+        cycle,
+        judge: judgeName,
+        from: proposal.from,
+        to: proposal.to
+      });
+    }
+    if (Object.keys(applied).length > 0) {
+      writeJsonAtomic(this.weightsPath, { version: 1, appliedAt: at, source, cycle, judges: applied });
+    }
+    return applied;
   }
 
   addJudgeSignal({ judge, deltas, note = null, source = "llm-judge" }) {
@@ -86,9 +145,7 @@ export class ScrutinyFitter {
 
     const autoApply = this.state.cycles > this.warmupCycles;
     if (autoApply) {
-      for (const [judgeName, proposal] of Object.entries(proposals)) {
-        this.runtime.scrutiny.judges[judgeName].weights = proposal.to;
-      }
+      this._applyAndPersist(proposals, { source: "auto-fit", cycle: this.state.cycles, at: this.state.lastRunAt });
     } else {
       this.pending.proposals.push({
         cycle: this.state.cycles,
@@ -117,12 +174,9 @@ export class ScrutinyFitter {
   applyPending(cycle) {
     const entry = this.pending.proposals.find((p) => p.cycle === cycle);
     if (!entry || entry.applied) return null;
-    for (const [judgeName, proposal] of Object.entries(entry.proposals)) {
-      const judge = this.runtime.scrutiny.judges?.[judgeName];
-      if (judge) judge.weights = proposal.to;
-    }
-    entry.applied = true;
     entry.appliedAt = nowIso();
+    this._applyAndPersist(entry.proposals, { source: "manual-apply", cycle: entry.cycle, at: entry.appliedAt });
+    entry.applied = true;
     this.persistPending();
     return entry;
   }

--- a/test/abi-runtime.test.js
+++ b/test/abi-runtime.test.js
@@ -674,6 +674,77 @@ test("scrutiny fitter stages proposals during warmup, auto-applies after", () =>
     `expected evidence weight to grow, got before=${before.evidence}, after=${runtime.scrutiny.judges.pragmatic.weights.evidence}`);
 });
 
+test("fitted scrutiny weights persist to disk and restore into a fresh panel", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-fit-persist-"));
+  const runtime = createDefaultRuntime();
+  for (let i = 0; i < 60; i += 1) {
+    const dims = {
+      environment: Math.random(),
+      company: Math.random(),
+      evidence: 0.3 + Math.random() * 0.7,
+      memory: Math.random(),
+      uncertainty: Math.random()
+    };
+    const o = runtime.outcomes.record({ kind: "agent-reply", scrutinyAction: "act", scrutinyDimensions: dims });
+    runtime.outcomes.resolve(o.id, Math.min(1, dims.evidence + 0.05 * Math.random()), "system-inferred");
+  }
+  const fitter = new ScrutinyFitter({ runtime, dir, warmupCycles: 0 });
+  const r = fitter.fit();
+  assert.equal(r.autoApplied, true);
+  const applied = { ...runtime.scrutiny.judges.pragmatic.weights };
+
+  // Persisted: weights.json holds the applied weights, history has one audit
+  // line per judge with from/to.
+  const saved = JSON.parse(fs.readFileSync(path.join(dir, "weights.json"), "utf8"));
+  assert.deepEqual(saved.judges.pragmatic, applied);
+  assert.equal(saved.source, "auto-fit");
+  const history = fs.readFileSync(path.join(dir, "weight-history.jsonl"), "utf8").trim().split("\n").map(JSON.parse);
+  assert.equal(history.length, 3, "one history line per judge");
+  assert.ok(history.every((h) => h.source === "auto-fit" && h.from && h.to));
+
+  // Restart simulation: a fresh runtime boots with hardcoded default weights;
+  // constructing the fitter on the same dir must restore the calibration.
+  const reboot = createDefaultRuntime();
+  assert.notDeepEqual(reboot.scrutiny.judges.pragmatic.weights, applied, "fresh panel starts at defaults");
+  const fitter2 = new ScrutinyFitter({ runtime: reboot, dir });
+  assert.ok(fitter2.restoredWeightsAt, "restore should report the appliedAt stamp");
+  assert.deepEqual(reboot.scrutiny.judges.pragmatic.weights, applied, "weights survive restart");
+  assert.deepEqual(reboot.scrutiny.judges.cautious.weights, saved.judges.cautious);
+
+  fs.rmSync(dir, { recursive: true });
+});
+
+test("manually applying a staged warmup proposal persists the same way", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-fit-manual-"));
+  const runtime = createDefaultRuntime();
+  for (let i = 0; i < 50; i += 1) {
+    const dims = { environment: 0.5, company: 0.5, evidence: 0.4 + (i % 2) * 0.4, memory: 0.5, uncertainty: 0.5 };
+    const o = runtime.outcomes.record({ kind: "agent-reply", scrutinyAction: "act", scrutinyDimensions: dims });
+    runtime.outcomes.resolve(o.id, dims.evidence, "system-inferred");
+  }
+  const fitter = new ScrutinyFitter({ runtime, dir, warmupCycles: 5 });
+  const r = fitter.fit(); // staged, not applied
+  assert.equal(r.autoApplied, false);
+
+  const entry = fitter.applyPending(1);
+  assert.ok(entry?.applied);
+  const saved = JSON.parse(fs.readFileSync(path.join(dir, "weights.json"), "utf8"));
+  assert.equal(saved.source, "manual-apply");
+  assert.deepEqual(saved.judges.pragmatic, runtime.scrutiny.judges.pragmatic.weights);
+
+  fs.rmSync(dir, { recursive: true });
+});
+
+test("fitter restore is a no-op without a weights file", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-fit-empty-"));
+  const runtime = createDefaultRuntime();
+  const defaults = { ...runtime.scrutiny.judges.pragmatic.weights };
+  const fitter = new ScrutinyFitter({ runtime, dir });
+  assert.equal(fitter.restoredWeightsAt, null);
+  assert.deepEqual(runtime.scrutiny.judges.pragmatic.weights, defaults);
+  fs.rmSync(dir, { recursive: true });
+});
+
 test("scrutiny fitter judge signal averages with correlation deltas", () => {
   const runtime = createDefaultRuntime();
   for (let i = 0; i < 50; i += 1) {


### PR DESCRIPTION
Scope 2 from the feature audit: close the adaptation loop for real.

## The bug
The weekly `ScrutinyFitter` applies fitted weight adjustments to the in-memory judge objects only. `ScrutinyPanel` constructs from hardcoded default weights on every boot, so **every restart silently discarded all accumulated calibration** — the system stayed the static scrutinizer the whitepaper argues against, no matter how many fit cycles ran.

## Changes
- Applied weights (auto-fit after warmup **and** manual `applyPending`) persist to `scrutiny/weights.json`; the fitter restores them into the live judges at construction. Stale/garbled entries degrade gracefully (skipped per-judge, per-dimension sanity check).
- Append-only audit trail in `scrutiny/weight-history.jsonl` — one `{at, source, cycle, judge, from, to}` line per applied judge.
- `status()` exposes `restoredWeightsAt`; the Scrutiny tab header shows "calibrated <date>" when running on restored weights.

## Tests
- Round-trip: fit → persist → fresh runtime (default weights) → fitter construction restores the calibration.
- Manual warmup apply persists identically (`source: manual-apply`).
- No-op restore without a weights file.
- Full suite: 197/197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)