### PR TITLE
feat: memory corrections lock in, never repeat + fidelity-aware recall

### DIFF
--- a/src/agent-host.js
+++ b/src/agent-host.js
@@ -270,7 +270,7 @@ export class AgentHost {
 
 Your job is to help through the ABI loop:
 1. Apply directional adaptive scrutiny.
-2. Use memory deliberately.
+2. Use memory deliberately. When the user CORRECTS something you previously stored or said (a time, a name, a decision, a preference), call correct_memory with the corrected fact — never just remember a second conflicting version.
 3. Propagate bounded specialists only when repeated or novel high-risk work justifies it.
 
 Current decision: ${output.scrutiny.action}

--- a/src/file-backed-memory-system.js
+++ b/src/file-backed-memory-system.js
@@ -36,6 +36,18 @@ export class FileBackedMemorySystem extends MemorySystem {
     return item;
   }
 
+  correct(input) {
+    // super.correct() routes the new locked item through this.remember()
+    // (already persisted); this extra event captures the supersede mutations
+    // on the stale items and snapshots them.
+    const result = super.correct(input);
+    this.persist("correct", {
+      correctedId: result.item.id,
+      superseded: result.superseded.map((item) => item.id)
+    });
+    return result;
+  }
+
   decay(now = new Date()) {
     const result = super.decay(now);
     if (result.removed.length > 0 || result.promoted.length > 0) {

--- a/src/memory-system.js
+++ b/src/memory-system.js
@@ -49,6 +49,10 @@ export class MemorySystem {
       dangerLevel,
       repetition: clamp(observation.repetition ?? context.repetition ?? 0),
       kind: observation.kind ?? context.kind ?? "raw",
+      // Locked items (user corrections) neither strength-decay nor get
+      // evicted/TTL-deleted; past their tier TTL they promote upward instead,
+      // so a locked-in correction eventually becomes long-term intuition.
+      locked: Boolean(observation.locked ?? context.locked ?? false),
       metadata: {
         ...(observation.metadata ?? {}),
         ...(context.metadata ?? {})
@@ -71,6 +75,9 @@ export class MemorySystem {
     for (const item of this.items.values()) {
       if (!tiers.has(item.tier)) continue;
       if (scope && item.scope && item.scope !== scope && item.scope !== "main") continue;
+      // Superseded items were corrected by the user — never recall the stale
+      // version (the correction itself carries the fact forward).
+      if (item.metadata?.supersededBy) continue;
       const textScore = tokenOverlapScore(queryText, `${item.content} ${item.tags.join(" ")}`);
       const tierWeight = item.tier === "short" ? 1.15 : item.tier === "medium" ? 1 : 0.85;
       const strengthWeight = 0.4 + item.strength * 0.6;
@@ -82,7 +89,13 @@ export class MemorySystem {
       }
       // Principle boost: distilled principles get a small edge in long-tier recall.
       const principleBoost = item.kind === "principle" ? 0.1 : 0;
-      const score = textScore * tierWeight * strengthWeight + dangerBoost + principleBoost;
+      // Corrections outrank whatever they replaced; fidelity finally feeds the
+      // ranking ("the hourglass on the spider"): specific-fidelity items edge
+      // out generic ones when both match. Gated on a real text match so
+      // unrelated corrections/specific items don't surface on every query.
+      const correctionBoost = textScore > 0 && item.kind === "correction" ? 0.3 : 0;
+      const fidelityBoost = textScore > 0 && item.fidelity === "specific" ? 0.05 : 0;
+      const score = textScore * tierWeight * strengthWeight + dangerBoost + principleBoost + correctionBoost + fidelityBoost;
       if (score > 0) scored.push({ item, score });
     }
 
@@ -103,6 +116,64 @@ export class MemorySystem {
     return item;
   }
 
+  /**
+   * Lock in a correction: hide the stale memory from all future retrieval
+   * and store the corrected fact as a locked item ("learn it once, never
+   * make that mistake again"). The stale item(s) are matched by explicit
+   * `id`, or by retrieval on `query` — only the top hit and its near-ties
+   * are superseded, so a fuzzy query can't bury unrelated memories.
+   * Returns { item, superseded } where `item` is the new locked correction.
+   */
+  correct({ id = null, query = null, content, tags = [], scope = "main", source = "correction", metadata = {} } = {}) {
+    const text = String(content ?? "").trim();
+    if (!text) throw new Error("correct() requires the corrected content.");
+
+    const targets = [];
+    if (id) {
+      const item = this.items.get(id);
+      if (item && !item.locked) targets.push(item);
+    } else if (query) {
+      const hits = this.retrieve(query, { limit: 5, scope });
+      const top = hits[0]?.score ?? 0;
+      for (const { item, score } of hits) {
+        if (item.locked || item.kind === "correction") continue;
+        if (score >= 0.15 && score >= top * 0.8) targets.push(item);
+        if (targets.length >= 3) break;
+      }
+    }
+
+    // The correction inherits the staleness-resistant traits of what it
+    // replaces: at least medium tier (corrections must outlive RAM), the
+    // highest tier among its targets, and high specificity.
+    const tierRank = { short: 0, medium: 1, long: 2 };
+    const targetTier = targets.reduce((best, t) => (tierRank[t.tier] > tierRank[best] ? t.tier : best), "medium");
+    const inheritedTags = [...new Set(targets.flatMap((t) => t.tags ?? []))];
+
+    const corrected = this.remember(
+      {
+        source,
+        scope,
+        content: text,
+        tags: [...new Set(["correction", ...inheritedTags, ...tags])],
+        risk: Math.max(0.3, ...targets.map((t) => t.risk ?? 0)),
+        specificity: 0.85,
+        novelty: 0.4,
+        repetition: 0.3,
+        kind: "correction",
+        locked: true,
+        metadata: { ...metadata, corrects: targets.map((t) => t.id) }
+      },
+      { strength: 1.0, tier: targetTier }
+    );
+
+    const at = nowIso();
+    for (const target of targets) {
+      target.metadata = { ...target.metadata, supersededBy: corrected.id, supersededAt: at };
+    }
+
+    return { item: corrected, superseded: targets };
+  }
+
   decay(now = new Date()) {
     const current = now instanceof Date ? now : new Date(now);
     const removed = [];
@@ -113,17 +184,22 @@ export class MemorySystem {
       const ttl = this.ttlMs[item.tier];
 
       if (ageMs <= ttl) {
-        item.strength = clamp(item.strength - this.decayRate(item.tier));
+        // Locked corrections don't fade.
+        if (!item.locked) item.strength = clamp(item.strength - this.decayRate(item.tier));
         continue;
       }
 
-      if (item.tier === "short" && (item.repetition >= 0.55 || item.risk >= 0.7 || item.novelty >= 0.7)) {
+      // Superseded items never promote — a corrected fact must not ride the
+      // promotion path into long-term memory. They expire on tier TTL.
+      const superseded = Boolean(item.metadata?.supersededBy);
+
+      if (!superseded && item.tier === "short" && (item.locked || item.repetition >= 0.55 || item.risk >= 0.7 || item.novelty >= 0.7)) {
         const medium = this.promote(item, "medium", current.toISOString());
         promoted.push(medium);
         continue;
       }
 
-      if (item.tier === "medium" && (item.risk >= 0.8 || item.repetition >= 0.75)) {
+      if (!superseded && item.tier === "medium" && (item.locked || item.risk >= 0.8 || item.repetition >= 0.75)) {
         const long = this.promote(item, "long", current.toISOString());
         promoted.push(long);
         continue;
@@ -219,9 +295,12 @@ export class MemorySystem {
     const tierItems = this.byTier(tier);
     if (tierItems.length <= limit) return;
 
+    // Locked corrections are exempt from cap eviction (low volume by nature;
+    // a tier may briefly exceed its cap rather than forget a correction).
     tierItems
+      .filter((item) => !item.locked)
       .sort((a, b) => a.strength - b.strength || a.lastAccessedAt.localeCompare(b.lastAccessedAt))
-      .slice(0, tierItems.length - limit)
+      .slice(0, Math.max(0, tierItems.length - limit))
       .forEach((item) => this.items.delete(item.id));
   }
 }

--- a/src/tool-registry.js
+++ b/src/tool-registry.js
@@ -171,8 +171,49 @@ export function registerCoreTools(registry, runtime) {
           score: Number(score.toFixed(3)),
           tags: item.tags,
           content: item.content,
-          kind: item.kind ?? "raw"
+          kind: item.kind ?? "raw",
+          // Confidence signals: fidelity ("specific" = precise, trust details),
+          // strength (decays unless reinforced), locked (a user correction).
+          fidelity: item.fidelity ?? "normal",
+          strength: Number((item.strength ?? 0).toFixed(2)),
+          locked: Boolean(item.locked)
         }))
+      };
+    }
+  });
+
+  registry.register({
+    name: "correct_memory",
+    description: "Replace a stored memory that turned out to be WRONG. Hides the stale version from all future recall and locks in the corrected fact so the mistake never repeats. Use when the user corrects something previously stored or stated (a time, name, decision, preference) — do NOT just call remember with a second conflicting fact.",
+    parameters: {
+      type: "object",
+      properties: {
+        correction: { type: "string", description: "The corrected fact, stated fully and standalone (e.g. 'The Acme review meeting is at 4pm, not 3pm')." },
+        query: { type: "string", description: "What the stale memory was about — used to find it (e.g. 'Acme review meeting time')." },
+        id: { type: "string", description: "Exact memory id to supersede, when known (from a recall result). Takes precedence over query." },
+        tags: { type: "array", items: { type: "string" }, description: "Optional extra tags for the correction." }
+      },
+      required: ["correction"],
+      additionalProperties: false
+    },
+    handler: async (args, context) => {
+      if (!runtime.memory?.correct) return { error: "memory system does not support corrections" };
+      const scope = context?.agentId && context.agentId !== "main" ? `specialist:${context.agentId}` : "main";
+      const result = runtime.memory.correct({
+        id: args.id ?? null,
+        query: args.query ?? null,
+        content: String(args.correction ?? "").trim(),
+        tags: args.tags ?? [],
+        scope,
+        source: "correct-memory-tool",
+        metadata: { agentId: context.agentId, sessionId: context.sessionId }
+      });
+      return {
+        id: result.item.id,
+        tier: result.item.tier,
+        content: result.item.content,
+        supersededCount: result.superseded.length,
+        superseded: result.superseded.map((item) => ({ id: item.id, content: item.content.slice(0, 120) }))
       };
     }
   });

--- a/test/memory-corrections.test.js
+++ b/test/memory-corrections.test.js
@@ -1,0 +1,160 @@
+// Corrections lock in, never repeat: correct() supersedes the stale memory
+// (hidden from recall forever) and stores a locked correction that neither
+// decays, expires, nor gets evicted — and promotes toward long-term instead.
+// Plus: fidelity finally feeds retrieval ranking.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { MemorySystem } from "../src/memory-system.js";
+import { FileBackedMemorySystem } from "../src/file-backed-memory-system.js";
+import { ToolRegistry, registerCoreTools } from "../src/index.js";
+
+function seedStaleFact(memory) {
+  return memory.remember(
+    { source: "test", content: "The Acme review meeting is at 3pm on Thursday", tags: ["meeting", "acme"], specificity: 0.7 },
+    { strength: 0.8 }
+  );
+}
+
+test("correct() supersedes the stale memory and recall returns only the correction", () => {
+  const memory = new MemorySystem();
+  const stale = seedStaleFact(memory);
+
+  const { item, superseded } = memory.correct({
+    query: "Acme review meeting time",
+    content: "The Acme review meeting is at 4pm on Thursday, not 3pm"
+  });
+
+  assert.equal(superseded.length, 1);
+  assert.equal(superseded[0].id, stale.id);
+  assert.equal(stale.metadata.supersededBy, item.id);
+  assert.equal(item.locked, true);
+  assert.equal(item.kind, "correction");
+  assert.equal(item.strength, 1);
+  assert.ok(item.tags.includes("correction"));
+  assert.ok(item.tags.includes("acme"), "correction inherits the stale item's tags");
+
+  const hits = memory.retrieve("Acme review meeting time");
+  assert.ok(hits.length > 0);
+  assert.equal(hits[0].item.id, item.id, "the correction ranks first");
+  assert.ok(!hits.some((h) => h.item.id === stale.id), "the stale fact never resurfaces");
+});
+
+test("correct() by explicit id supersedes exactly that item", () => {
+  const memory = new MemorySystem();
+  const stale = seedStaleFact(memory);
+  const other = memory.remember({ source: "test", content: "Standup is 9am Mondays", tags: ["meeting"] });
+
+  const { superseded } = memory.correct({ id: stale.id, content: "Acme review moved to Friday" });
+  assert.deepEqual(superseded.map((s) => s.id), [stale.id]);
+  assert.equal(other.metadata.supersededBy, undefined, "unrelated memories untouched");
+});
+
+test("a vague query with no confident match supersedes nothing but still locks in the fact", () => {
+  const memory = new MemorySystem();
+  seedStaleFact(memory);
+  const { item, superseded } = memory.correct({ query: "zzz qqq unrelated nonsense", content: "Spencer prefers tea over coffee" });
+  assert.equal(superseded.length, 0);
+  assert.equal(item.locked, true);
+});
+
+test("locked corrections don't decay, don't evict, and promote toward long-term", () => {
+  const memory = new MemorySystem({ limits: { short: 100, medium: 2, long: 100 } });
+  const { item } = memory.correct({ content: "Production deploys are Tuesdays ONLY" });
+  assert.equal(item.tier, "medium");
+
+  // Strength does not fade with decay ticks.
+  memory.decay(new Date());
+  assert.equal(memory.items.get(item.id).strength, 1);
+
+  // Cap eviction skips locked items even when the tier is over its limit.
+  memory.remember({ source: "t", content: "filler one" }, { tier: "medium", strength: 0.05 });
+  memory.remember({ source: "t", content: "filler two" }, { tier: "medium", strength: 0.05 });
+  memory.remember({ source: "t", content: "filler three" }, { tier: "medium", strength: 0.05 });
+  assert.ok(memory.items.get(item.id), "correction survives cap eviction");
+
+  // Past the medium TTL (45d), a locked item promotes to long instead of deleting.
+  const future = new Date(Date.now() + 50 * 24 * 60 * 60 * 1000);
+  const { promoted, removed } = memory.decay(future);
+  const promotedCorrection = promoted.find((p) => p.kind === "correction");
+  assert.ok(promotedCorrection, "locked correction promotes at TTL");
+  assert.equal(promotedCorrection.tier, "long");
+  assert.ok(!removed.some((r) => r.kind === "correction"));
+});
+
+test("superseded items never promote into long-term memory", () => {
+  const memory = new MemorySystem();
+  // A high-repetition fact that would normally promote medium → long.
+  const stale = memory.remember(
+    { source: "t", content: "Weekly report goes to alice@example.com", repetition: 0.9, tags: ["report"] },
+    { tier: "medium", strength: 0.8 }
+  );
+  memory.correct({ id: stale.id, content: "Weekly report goes to bob@example.com now" });
+
+  const future = new Date(Date.now() + 50 * 24 * 60 * 60 * 1000);
+  const { promoted, removed } = memory.decay(future);
+  assert.ok(!promoted.some((p) => p.id === stale.id), "stale fact must not ride promotion to Lava");
+  assert.ok(removed.some((r) => r.id === stale.id), "stale fact expires at TTL instead");
+});
+
+test("fidelity feeds ranking: specific items edge out generic ones on equal matches", () => {
+  const memory = new MemorySystem();
+  // Same tier + strength + comparable text match, so the only differentiator
+  // is fidelity ("specific" from high specificity vs "normal").
+  const generic = memory.remember(
+    { source: "t", content: "spiders are dangerous to people sometimes", tags: ["spiders"], specificity: 0.3 },
+    { strength: 0.7, tier: "medium" }
+  );
+  const specific = memory.remember(
+    { source: "t", content: "hourglass-marked spiders are dangerous black widows", tags: ["spiders"], specificity: 0.9 },
+    { strength: 0.7, tier: "medium" }
+  );
+  assert.equal(generic.fidelity, "normal");
+  assert.equal(specific.fidelity, "specific");
+  const hits = memory.retrieve("are spiders dangerous");
+  const specificRank = hits.findIndex((h) => h.item.id === specific.id);
+  const genericRank = hits.findIndex((h) => h.item.id === generic.id);
+  assert.ok(specificRank !== -1 && genericRank !== -1);
+  assert.ok(specificRank < genericRank, "specific-fidelity item ranks above the generic one");
+});
+
+test("corrections persist and restore through the file-backed store", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-mem-correct-"));
+  const memory = new FileBackedMemorySystem({ dir });
+  const stale = memory.remember({ source: "t", content: "API key rotation is quarterly", tags: ["ops"] });
+  const { item } = memory.correct({ id: stale.id, content: "API key rotation is MONTHLY as of June" });
+
+  const reloaded = new FileBackedMemorySystem({ dir });
+  const restoredCorrection = reloaded.items.get(item.id);
+  assert.ok(restoredCorrection);
+  assert.equal(restoredCorrection.locked, true);
+  const restoredStale = reloaded.items.get(stale.id);
+  assert.equal(restoredStale.metadata.supersededBy, item.id, "supersede mutation survives restart");
+  const hits = reloaded.retrieve("API key rotation");
+  assert.equal(hits[0].item.id, item.id);
+  assert.ok(!hits.some((h) => h.item.id === stale.id));
+
+  fs.rmSync(dir, { recursive: true });
+});
+
+test("correct_memory tool wires through with scope + recall exposes confidence fields", async () => {
+  const memory = new MemorySystem();
+  const runtime = { memory };
+  const tools = new ToolRegistry();
+  registerCoreTools(tools, runtime);
+
+  memory.remember({ source: "t", content: "Standup is at 9am", tags: ["standup"] });
+  const { ok, result } = await tools.invoke("correct_memory", { correction: "Standup moved to 9:30am", query: "standup time" }, { agentId: "main", sessionId: "s1" });
+  assert.ok(ok);
+  assert.equal(result.supersededCount, 1);
+
+  const recall = await tools.invoke("recall", { query: "standup time" }, { agentId: "main" });
+  assert.ok(recall.ok);
+  const top = recall.result.items[0];
+  assert.equal(top.id, result.id);
+  assert.equal(top.locked, true);
+  assert.equal(typeof top.strength, "number");
+  assert.ok(["specific", "normal", "compressed"].includes(top.fidelity));
+});


### PR DESCRIPTION
Scope 3 from the feature audit: the two headline memory claims that were unimplemented.

## What was missing
- **"Corrections lock in, never repeat"** (README comparison table): no mechanism existed — correcting a fact just left two conflicting memories recalling with equal weight.
- **Fidelity-aware recall** (the whitepaper's hourglass-spider test): `fidelity` was computed and stored on every item but never consulted in retrieval ranking.

## Changes
- `MemorySystem.correct({id|query, content})` — supersedes the stale item (hidden from all future retrieval, barred from tier promotion) and locks in the corrected fact: strength 1.0, never decays/expires/evicts, promotes upward at TTL so corrections become long-term intuition. Fuzzy-query safety: only the top hit and near-ties get superseded.
- `retrieve()` skips superseded items; corrections get +0.3, specific-fidelity items +0.05 (both gated on a real text match).
- New `correct_memory` tool (specialist-scope-aware); `recall` now returns `fidelity`/`strength`/`locked`; agent instructions route corrections through it.
- File-backed persistence round-trips the supersede mutations.

## Tests
8 new cases in `test/memory-corrections.test.js`; full suite 202/202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)