### PR TITLE
feat: scrutiny verdicts drive tool access — act/ask/watch/ignore have real consequences

### DIFF
--- a/src/abi-runtime.js
+++ b/src/abi-runtime.js
@@ -423,27 +423,41 @@ export class AbiRuntime {
       this.agentHost.ensureSpecialistAgent(propagated.specialist, "main");
     }
 
-    const memoryItem = this.memory.remember(
-      {
+    // An 'ignore' verdict has a consequence: the signal is NOT committed to
+    // memory (forgetting low-signal noise is the point), just audit-logged.
+    // Every other verdict remembers the signal + decision as before.
+    let memoryItem = null;
+    if (scrutiny.action === "ignore") {
+      this.events?.emit?.("signal-ignored", {
+        at: nowIso(),
+        signalId: signal.id,
         source: signal.source,
-        content: `${signal.summary}\nDecision: ${scrutiny.action}\nReasons: ${scrutiny.reasons.join(" ")}`,
-        tags: ["signal", signal.domain, signal.taskType, ...(signal.tags ?? [])],
-        novelty: signal.novelty,
-        risk: signal.risk,
-        repetition: signal.repetition,
-        specificity: signal.specificity,
-        metadata: {
-          signalId: signal.id,
-          workflowId: workflow?.id,
-          scrutiny: scrutiny.dimensions
+        summary: signal.summary,
+        score: scrutiny.score
+      });
+    } else {
+      memoryItem = this.memory.remember(
+        {
+          source: signal.source,
+          content: `${signal.summary}\nDecision: ${scrutiny.action}\nReasons: ${scrutiny.reasons.join(" ")}`,
+          tags: ["signal", signal.domain, signal.taskType, ...(signal.tags ?? [])],
+          novelty: signal.novelty,
+          risk: signal.risk,
+          repetition: signal.repetition,
+          specificity: signal.specificity,
+          metadata: {
+            signalId: signal.id,
+            workflowId: workflow?.id,
+            scrutiny: scrutiny.dimensions
+          }
+        },
+        {
+          source: "abi-runtime",
+          strength: scrutiny.score,
+          critical: signal.risk >= 0.85
         }
-      },
-      {
-        source: "abi-runtime",
-        strength: scrutiny.score,
-        critical: signal.risk >= 0.85
-      }
-    );
+      );
+    }
 
     const output = {
       id: createId("out"),
@@ -468,7 +482,9 @@ export class AbiRuntime {
       outputId: output.id,
       createdAt: nowIso(),
       loop: "outputs-to-integrations",
-      summary: `Output ${output.id} fed back into memory tier ${memoryItem.tier}.`
+      summary: memoryItem
+        ? `Output ${output.id} fed back into memory tier ${memoryItem.tier}.`
+        : `Output ${output.id} ignored — signal not committed to memory.`
     });
 
     return output;

--- a/src/agent-host.js
+++ b/src/agent-host.js
@@ -69,8 +69,20 @@ export class AgentHost {
       this.ensureSpecialistAgent(output.propagation.specialist, agentId);
     }
 
+    // The scrutiny verdict has consequences, not just prompt flavor:
+    //   act       → full tool access
+    //   ask       → side-effecting tool calls divert to the approval queue
+    //               this turn (the agent is told to clarify first)
+    //   watch     → read-only tools only (filtered list + invoke-time gate)
+    //   ignore    → no tools; the user still gets a (brief) reply — a direct
+    //               human message is never silently dropped
+    //   propagate → full access (the specialist spawn already happened above)
+    const verdict = output.scrutiny.action;
+    const toolPolicy = verdict === "watch" ? "read-only" : verdict === "ask" ? "confirm" : verdict === "ignore" ? "none" : "full";
     const toolRegistry = this.runtime.tools;
-    const tools = toolRegistry?.toOpenAITools?.() ?? [];
+    const tools = toolPolicy === "none"
+      ? []
+      : (toolRegistry?.toOpenAITools?.({ readOnly: toolPolicy === "read-only" }) ?? []);
 
     // Lava intuition (C2): top principles from the vector store inserted into
     // the prompt as soft hints — distinct from explicit memoryHits.
@@ -114,7 +126,11 @@ export class AgentHost {
         target: from,
         agentId,
         sessionId,
-        runtime: this.runtime
+        runtime: this.runtime,
+        // Enforced in ToolRegistry.invoke — the filtered tool list above is
+        // advisory to the model; this gate is not.
+        __scrutinyPolicy: toolPolicy === "read-only" ? "read-only" : toolPolicy === "confirm" ? "confirm" : null,
+        __reason: toolPolicy === "confirm" ? `scrutiny verdict 'ask' (score ${output.scrutiny.score.toFixed(2)})` : null
       }
     });
 
@@ -274,7 +290,7 @@ Your job is to help through the ABI loop:
 3. Propagate bounded specialists only when repeated or novel high-risk work justifies it.
 
 Current decision: ${output.scrutiny.action}
-Reasons:
+${verdictGuidance(output.scrutiny.action)}Reasons:
 ${output.scrutiny.reasons.map((reason) => `- ${reason}`).join("\n")}
 ${intuitionBlock}${ambientBlock}${screenBlock}
 Answer the user plainly. If a specialist was created, mention its name and scope.`;
@@ -309,6 +325,22 @@ Stay inside the bounded scope. If the user's request falls outside it, say so an
       sessions: this.store.listSessions()
     };
   }
+}
+
+// What each scrutiny verdict means for THIS turn — matches the enforcement
+// in agent-host.handleMessage / ToolRegistry.invoke, so the model's
+// expectations line up with what will actually happen to its tool calls.
+function verdictGuidance(action) {
+  if (action === "ask") {
+    return "This turn: clarify before acting. Ask ONE focused clarifying question. Any side-effecting tool you call now will be queued for the user's approval instead of executing immediately — prefer to ask first, act next turn.\n";
+  }
+  if (action === "watch") {
+    return "This turn: observation mode. Only read-only tools are available; side-effecting calls will be rejected. Answer from what you can read and note what you'd do once confidence is higher.\n";
+  }
+  if (action === "ignore") {
+    return "This turn: low-signal. No tools are available. Reply briefly and move on.\n";
+  }
+  return "";
 }
 
 // Format the fresh focused-window context the floating widget attaches to a

--- a/src/integrations/computer-use.js
+++ b/src/integrations/computer-use.js
@@ -122,6 +122,7 @@ export function registerComputerUseTools(registry, runtime) {
 
   registry.register({
     name: "computer_screenshot",
+    sideEffects: false,
     description: "Read the current screen state. Returns the most recent OCR text + active app from the observation store (real data). This build does not return raw image bytes — image transport ships with the Mac app in a later phase.",
     parameters: {
       type: "object",

--- a/src/integrations/web-search.js
+++ b/src/integrations/web-search.js
@@ -13,6 +13,7 @@ export function registerWebSearchTools(runtime, opts = {}) {
 
   runtime.tools.register({
     name: "web_search",
+    sideEffects: false,
     description: "Search the live web. Returns a list of results (title, url, snippet, and often page content). Picks a configured provider automatically; pass `provider` to force one.",
     parameters: {
       type: "object",
@@ -56,6 +57,7 @@ export function registerWebSearchTools(runtime, opts = {}) {
 
   runtime.tools.register({
     name: "fetch_url",
+    sideEffects: false,
     description: "Fetch the contents of a web page as markdown/text. Uses Firecrawl when configured, otherwise a plain fetch.",
     parameters: {
       type: "object",

--- a/src/tool-registry.js
+++ b/src/tool-registry.js
@@ -22,6 +22,13 @@ export class ToolRegistry {
       // Short human-readable summary used in the approval UI when the args
       // alone don't describe the action well. Optional fn(args) -> string.
       summarize: typeof tool.summarize === "function" ? tool.summarize : null,
+      // Whether invoking this tool changes state anywhere (memory, tasks,
+      // cron, outbound messages, external services). Defaults to TRUE — a
+      // tool must explicitly declare sideEffects: false to count as
+      // read-only. Scrutiny verdicts gate on this: 'watch' turns allow only
+      // read-only tools; 'ask' turns divert side-effecting calls to the
+      // approval queue.
+      sideEffects: tool.sideEffects !== false,
       metadata: tool.metadata ?? {}
     };
     this.tools.set(normalized.name, normalized);
@@ -44,12 +51,13 @@ export class ToolRegistry {
     return this.tools.get(name);
   }
 
-  list() {
-    return [...this.tools.values()].map(({ handler, ...rest }) => rest);
+  list({ readOnly = false } = {}) {
+    const all = [...this.tools.values()].map(({ handler, ...rest }) => rest);
+    return readOnly ? all.filter((tool) => !tool.sideEffects) : all;
   }
 
-  toOpenAITools() {
-    return this.list().map((tool) => ({
+  toOpenAITools(options = {}) {
+    return this.list(options).map((tool) => ({
       type: "function",
       name: tool.name,
       description: tool.description,
@@ -57,8 +65,8 @@ export class ToolRegistry {
     }));
   }
 
-  toAnthropicTools() {
-    return this.list().map((tool) => ({
+  toAnthropicTools(options = {}) {
+    return this.list(options).map((tool) => ({
       name: tool.name,
       description: tool.description,
       input_schema: tool.parameters
@@ -70,10 +78,21 @@ export class ToolRegistry {
     if (!tool) {
       return { ok: false, error: `Unknown tool: ${name}` };
     }
+    // Scrutiny 'watch' policy: read-only turns hard-block side-effecting
+    // tools (defense in depth — the filtered tool list is advisory to the
+    // model, this gate is not).
+    if (context?.__scrutinyPolicy === "read-only" && tool.sideEffects) {
+      return {
+        ok: false,
+        error: `Tool ${name} is blocked this turn: scrutiny verdict 'watch' permits read-only tools only.`
+      };
+    }
     // Confirmation gate. When set, divert the call into the pending-action
     // queue UNLESS context.__confirmed is true (which the approve endpoint
-    // sets after a human OKs the action).
-    if (tool.needsConfirmation && !context?.__confirmed && this.pendingActions) {
+    // sets after a human OKs the action). Scrutiny 'ask' turns extend this
+    // to EVERY side-effecting tool, not just the always-gated ones.
+    const scrutinyConfirm = context?.__scrutinyPolicy === "confirm" && tool.sideEffects;
+    if ((tool.needsConfirmation || scrutinyConfirm) && !context?.__confirmed && this.pendingActions) {
       const summary = tool.summarize ? safeSummarize(tool.summarize, args) : `Run ${name}`;
       const action = this.pendingActions.enqueue({
         toolName: name,
@@ -150,6 +169,7 @@ export function registerCoreTools(registry, runtime) {
 
   registry.register({
     name: "recall",
+    sideEffects: false,
     description: "Search memory for items related to a query. Returns the most relevant items across short, medium, and long-term memory.",
     parameters: {
       type: "object",
@@ -247,6 +267,7 @@ export function registerCoreTools(registry, runtime) {
 
   registry.register({
     name: "recall_activity",
+    sideEffects: false,
     description: "Search the user's ambient capture log (window titles + app focus events + OCR text from screen frames). Use this when the user asks about what they were doing at a specific time, or to ground 'where did I leave off' questions. Returns rows with timestamp, app, window, and matching snippet.",
     parameters: {
       type: "object",
@@ -274,6 +295,7 @@ export function registerCoreTools(registry, runtime) {
 
   registry.register({
     name: "recall_spend",
+    sideEffects: false,
     description: "Summarize LLM credit (USD) usage: how much has been spent, on what activity/model, and the costliest recent calls. Use to answer questions about cost/credits/budget — e.g. 'why did I spend $4 today?'.",
     parameters: {
       type: "object",
@@ -299,6 +321,7 @@ export function registerCoreTools(registry, runtime) {
 
   registry.register({
     name: "list_sessions",
+    sideEffects: false,
     description: "List recent conversations across channels.",
     parameters: {
       type: "object",
@@ -315,6 +338,7 @@ export function registerCoreTools(registry, runtime) {
 
   registry.register({
     name: "list_skills",
+    sideEffects: false,
     description: "List the skills (named prompts) available to this agent.",
     parameters: { type: "object", properties: {}, additionalProperties: false },
     handler: async () => {
@@ -362,6 +386,7 @@ export function registerCoreTools(registry, runtime) {
 
   registry.register({
     name: "list_mcp_tools",
+    sideEffects: false,
     description: "List tools exposed by connected MCP servers.",
     parameters: { type: "object", properties: {}, additionalProperties: false },
     handler: async () => {
@@ -474,6 +499,7 @@ export function registerCoreTools(registry, runtime) {
 
   registry.register({
     name: "list_cron_jobs",
+    sideEffects: false,
     description: "List all scheduled jobs (prompt schedules, autopilot pulses, system tasks).",
     parameters: { type: "object", properties: {}, additionalProperties: false },
     handler: async () => runtime.cron.listJobs()
@@ -493,6 +519,7 @@ export function registerCoreTools(registry, runtime) {
 
   registry.register({
     name: "get_audit",
+    sideEffects: false,
     description: "Get a structural health snapshot of the runtime: specialist counts, memory tier saturation, outcome quality (7d/30d), upcoming cron jobs, MCP servers, and any actionable findings (warn/err severity). Use this when the user asks 'how are you doing' or 'what's wrong'.",
     parameters: { type: "object", properties: {}, additionalProperties: false },
     handler: async () => runtime.introspector?.audit() ?? { error: "no introspector" }
@@ -500,6 +527,7 @@ export function registerCoreTools(registry, runtime) {
 
   registry.register({
     name: "get_budget",
+    sideEffects: false,
     description: "Get today's LLM spend, daily limit, calls, and token counts. Returns 14 days of history.",
     parameters: { type: "object", properties: {}, additionalProperties: false },
     handler: async () => runtime.budget?.status?.() ?? { error: "no budget" }
@@ -569,6 +597,7 @@ export function registerCoreTools(registry, runtime) {
 
   registry.register({
     name: "list_tasks",
+    sideEffects: false,
     description: "List tasks. Filter by queue (user/agent), bucket (today / this_week / this_month / this_quarter / this_year / someday / done), or status (pending/in_progress/blocked/completed/cancelled).",
     parameters: {
       type: "object",
@@ -649,6 +678,7 @@ export function registerCoreTools(registry, runtime) {
 
   registry.register({
     name: "list_goals",
+    sideEffects: false,
     description: "List goals with optional status filter. Use to see what longer-term threads exist before adding more tasks — a task linked to an existing goal is more useful than a free-floating one.",
     parameters: {
       type: "object",
@@ -694,6 +724,7 @@ export function registerCoreTools(registry, runtime) {
 
   registry.register({
     name: "daily_recap",
+    sideEffects: false,
     description: "Answer 'what did I get done today?' Returns a structured summary of completed tasks, skills run, agent actions approved, time tracked, and themes. Pass a date (YYYY-MM-DD) to recap a specific day; defaults to today in the user's local timezone. format='markdown' returns a human-readable chat reply; format='json' returns the raw structure for further processing.",
     parameters: {
       type: "object",
@@ -714,6 +745,7 @@ export function registerCoreTools(registry, runtime) {
 
   registry.register({
     name: "daily_plan",
+    sideEffects: false,
     description: "Answer 'what should I do today?' Returns a forward-looking plan synthesized from the user's calendar, pending + carried-over tasks, recent call commitments, and active goals: a focus list, what the agent can take off their plate, and time-sensitive items. Pass a date (YYYY-MM-DD) to plan a specific day; defaults to today. format='markdown' for a chat reply, 'json' for the raw structure.",
     parameters: {
       type: "object",
@@ -758,6 +790,7 @@ export function registerCoreTools(registry, runtime) {
 
   registry.register({
     name: "list_mcp_catalog",
+    sideEffects: false,
     description: "List the MCP servers in OpenAGI's curated catalog — names, descriptions, auth mode (api-key vs oauth), availability (available vs coming-soon), and required env-var name for bearer-auth entries. Use BEFORE connect_catalog_mcp to confirm an entry exists and learn what credentials it needs.",
     parameters: {
       type: "object",

--- a/test/verdict-consequences.test.js
+++ b/test/verdict-consequences.test.js
@@ -1,0 +1,158 @@
+// Scrutiny verdicts have consequences: act/ask/watch/ignore produce different
+// tool access, not just a prompt hint. The tool-policy primitive lives in
+// ToolRegistry (sideEffects flag + filtered listing + invoke-time gates).
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ToolRegistry, createDefaultRuntime } from "../src/index.js";
+import { AgentHost } from "../src/agent-host.js";
+
+function makeRegistry() {
+  const calls = [];
+  const registry = new ToolRegistry();
+  registry.register({
+    name: "lookup_thing",
+    sideEffects: false,
+    handler: async () => { calls.push("lookup_thing"); return { found: true }; }
+  });
+  registry.register({
+    name: "send_thing",
+    handler: async () => { calls.push("send_thing"); return { sent: true }; }
+  });
+  return { registry, calls };
+}
+
+test("sideEffects defaults to true; read-only listing filters", () => {
+  const { registry } = makeRegistry();
+  assert.equal(registry.get("send_thing").sideEffects, true);
+  assert.equal(registry.get("lookup_thing").sideEffects, false);
+
+  assert.deepEqual(registry.list({ readOnly: true }).map((t) => t.name), ["lookup_thing"]);
+  assert.deepEqual(registry.toOpenAITools({ readOnly: true }).map((t) => t.name), ["lookup_thing"]);
+  assert.equal(registry.toOpenAITools().length, 2, "unfiltered listing unchanged");
+});
+
+test("watch policy: invoke hard-blocks side-effecting tools, allows read-only", async () => {
+  const { registry, calls } = makeRegistry();
+  const ctx = { __scrutinyPolicy: "read-only" };
+
+  const blocked = await registry.invoke("send_thing", {}, ctx);
+  assert.equal(blocked.ok, false);
+  assert.match(blocked.error, /watch.*read-only/i);
+  assert.ok(!calls.includes("send_thing"), "handler must not run");
+
+  const allowed = await registry.invoke("lookup_thing", {}, ctx);
+  assert.equal(allowed.ok, true);
+  assert.deepEqual(allowed.result, { found: true });
+});
+
+test("ask policy: side-effecting calls divert to the approval queue; read-only runs; approval bypasses", async () => {
+  const { registry, calls } = makeRegistry();
+  const queued = [];
+  registry.bindPendingActions({ enqueue: (a) => { queued.push(a); return { id: "act_1", summary: a.summary }; } });
+  const ctx = { __scrutinyPolicy: "confirm", __reason: "scrutiny verdict 'ask' (score 0.42)" };
+
+  const diverted = await registry.invoke("send_thing", {}, ctx);
+  assert.equal(diverted.ok, true);
+  assert.equal(diverted.result.status, "awaiting_confirmation");
+  assert.equal(queued.length, 1);
+  assert.equal(queued[0].reason, "scrutiny verdict 'ask' (score 0.42)");
+  assert.ok(!calls.includes("send_thing"));
+
+  const readOnly = await registry.invoke("lookup_thing", {}, ctx);
+  assert.equal(readOnly.ok, true);
+  assert.deepEqual(readOnly.result, { found: true });
+
+  // The approve endpoint re-invokes with __confirmed — must execute directly.
+  const approved = await registry.invoke("send_thing", {}, { ...ctx, __confirmed: true });
+  assert.equal(approved.ok, true);
+  assert.deepEqual(approved.result, { sent: true });
+});
+
+test("core read-only tools are flagged; mutating tools are not", () => {
+  const runtime = createDefaultRuntime();
+  const reg = runtime.tools;
+  for (const name of ["recall", "list_tasks", "list_sessions", "get_budget", "daily_plan", "daily_recap"]) {
+    assert.equal(reg.get(name)?.sideEffects, false, `${name} should be read-only`);
+  }
+  for (const name of ["remember", "add_task", "schedule_message", "send_message", "run_mcp_tool"]) {
+    assert.equal(reg.get(name)?.sideEffects, true, `${name} should be side-effecting`);
+  }
+});
+
+// Minimal AgentHost harness with a stubbed processSignal so we can force each
+// verdict, and a capturing model provider so we can see what tools + context
+// the model actually receives.
+function makeHost(verdict) {
+  const captured = {};
+  const { registry } = makeRegistry();
+  const runtime = {
+    tools: registry,
+    memory: { remember: () => ({ id: "m1" }) },
+    outcomes: null,
+    processSignal: () => ({
+      id: "out_1",
+      scrutiny: { action: verdict, score: 0.42, reasons: ["stub"], dimensions: { novelty: 0.4, risk: 0.3, repetition: 0.3 } },
+      customContext: [],
+      propagation: { created: false }
+    })
+  };
+  const host = new AgentHost({
+    runtime,
+    modelProvider: {
+      isConfigured: () => true,
+      model: "stub",
+      generate: async (args) => {
+        captured.tools = args.tools;
+        captured.context = args.context;
+        captured.instructions = args.instructions;
+        return { text: "ok", provider: "stub", model: "stub", id: "r1", toolCalls: [] };
+      }
+    }
+  });
+  return { host, captured };
+}
+
+test("agent turn under each verdict gets the right tools + enforcement context", async () => {
+  const expectations = [
+    { verdict: "act", toolNames: ["lookup_thing", "send_thing"], policy: null },
+    { verdict: "ask", toolNames: ["lookup_thing", "send_thing"], policy: "confirm" },
+    { verdict: "watch", toolNames: ["lookup_thing"], policy: "read-only" },
+    { verdict: "ignore", toolNames: [], policy: null }
+  ];
+  for (const { verdict, toolNames, policy } of expectations) {
+    const { host, captured } = makeHost(verdict);
+    const result = await host.handleMessage({ text: "hello there", channel: "local", from: "u" });
+    assert.equal(result.reply, "ok", `${verdict}: user always gets a reply`);
+    assert.deepEqual((captured.tools ?? []).map((t) => t.name).sort(), toolNames.sort(), `${verdict}: tool list`);
+    assert.equal(captured.context.__scrutinyPolicy, policy, `${verdict}: enforcement policy`);
+    if (verdict !== "act" && verdict !== "propagate" && verdict !== "ignore") {
+      assert.match(captured.instructions, /This turn:/, `${verdict}: instructions explain the gate`);
+    }
+  }
+});
+
+test("processSignal: 'ignore' skips the memory write and emits an audit event", () => {
+  const runtime = createDefaultRuntime();
+  const emitted = [];
+  runtime.events = { emit: (name, payload) => emitted.push({ name, payload }) };
+  runtime.scrutiny = { evaluate: () => ({ action: "ignore", score: 0.1, reasons: ["noise"], dimensions: {} }) };
+
+  const before = runtime.memory.items.size;
+  const output = runtime.processSignal({
+    id: "sig_noise",
+    source: "test",
+    type: "event",
+    domain: "general",
+    taskType: "adaptation-review",
+    summary: "low-signal noise",
+    content: "nothing to see",
+    tags: [],
+    novelty: 0.1, repetition: 0.1, risk: 0.1, urgency: 0.1, impact: 0.1,
+    confidence: 0.5, specificity: 0.2, ambiguity: 0.5, conflict: 0,
+    goalAlignment: 0.5, strategicFit: 0.5, externalPressure: 0.3, internalPressure: 0.3
+  });
+
+  assert.equal(output.memory, null, "ignored signals are not committed to memory");
+  assert.equal(runtime.memory.items.size, before, "memory count unchanged");
+  assert.ok(emitted.some((e) => e.name === "signal-ignored" && e.payload.signalId === "sig_noise"));
+});


### PR DESCRIPTION
Scope 1 from the feature audit: make 'that decision drives everything downstream' true.

## Before
All verdicts produced the same agent reply with the same tools; only 'ignore' gated propagation. The verdict was a line in the prompt.

## Now
| Verdict | Direct chat | Ambient signal |
|---|---|---|
| act / propagate | full tools | normal processing |
| ask | side-effecting calls divert to the approval queue this turn; instructed to ask ONE clarifying question | (unchanged) |
| watch | read-only toolset; side-effecting calls hard-blocked at invoke | (unchanged) |
| ignore | no tools, still replies briefly | signal NOT committed to memory; 'signal-ignored' audit event |

Built on a new ToolRegistry tool-policy primitive: `sideEffects` flag (default true), `{readOnly}` filtered listings, and invoke-time enforcement via `context.__scrutinyPolicy` — the filtered list is advisory to the model, the gate is not. 17 read-only tools flagged. **Scope 4 (specialist allowedTools enforcement) will reuse this primitive.**

## Safety check
Probed verdict distribution for typical chat before wiring: overwhelmingly 'act' (6/8) with 'propagate' for automation asks — so chat UX is unaffected; the gates bite on ambient signals and as calibration shifts. Known limitation (pre-existing): `messageToSignal`'s regex-derived features are low-fidelity panel inputs.

## Tests
6 new cases in `test/verdict-consequences.test.js`; full suite 200/200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)