### PR TITLE
feat: specialists are actually bounded — enforced tool allowlists + quality-aware routing

### DIFF
--- a/src/agent-host.js
+++ b/src/agent-host.js
@@ -3,6 +3,14 @@ import { createModelProvider } from "./model-provider.js";
 import { createId, nowIso } from "./utils.js";
 import { detectTaskInChat } from "./task-store.js";
 
+// Internal tools every specialist gets regardless of scope: its own memory
+// and the task queue it drains. Everything else comes from the specialist's
+// scoped allowlist (selected at propagation from the bounded scope).
+const SPECIALIST_CORE_TOOLS = [
+  "recall", "remember",
+  "list_tasks", "agent_pick_next", "complete_task", "move_task", "save_draft"
+];
+
 export class AgentHost {
   constructor(options = {}) {
     this.runtime = options.runtime;
@@ -80,9 +88,20 @@ export class AgentHost {
     const verdict = output.scrutiny.action;
     const toolPolicy = verdict === "watch" ? "read-only" : verdict === "ask" ? "confirm" : verdict === "ignore" ? "none" : "full";
     const toolRegistry = this.runtime.tools;
-    const tools = toolPolicy === "none"
+    let tools = toolPolicy === "none"
       ? []
       : (toolRegistry?.toOpenAITools?.({ readOnly: toolPolicy === "read-only" }) ?? []);
+
+    // Specialist bounds: a bounded specialist sees (and may invoke) only its
+    // scoped allowlist + the core set every specialist needs. Without this,
+    // "bounded" was advisory prompt text and any specialist could call any
+    // tool in the system.
+    let allowedToolNames = null;
+    if (isSpecialist) {
+      const scoped = agent.metadata?.specialist?.allowedTools ?? [];
+      allowedToolNames = [...new Set([...SPECIALIST_CORE_TOOLS, ...scoped])];
+      tools = tools.filter((tool) => allowedToolNames.includes(tool.name));
+    }
 
     // Lava intuition (C2): top principles from the vector store inserted into
     // the prompt as soft hints — distinct from explicit memoryHits.
@@ -130,7 +149,8 @@ export class AgentHost {
         // Enforced in ToolRegistry.invoke — the filtered tool list above is
         // advisory to the model; this gate is not.
         __scrutinyPolicy: toolPolicy === "read-only" ? "read-only" : toolPolicy === "confirm" ? "confirm" : null,
-        __reason: toolPolicy === "confirm" ? `scrutiny verdict 'ask' (score ${output.scrutiny.score.toFixed(2)})` : null
+        __reason: toolPolicy === "confirm" ? `scrutiny verdict 'ask' (score ${output.scrutiny.score.toFixed(2)})` : null,
+        __allowedTools: allowedToolNames
       }
     });
 
@@ -297,7 +317,8 @@ Answer the user plainly. If a specialist was created, mention its name and scope
   }
 
   ensureSpecialistAgent(specialist, parentId) {
-    const allowedToolList = (specialist.allowedTools ?? []).join(", ") || "all available tools";
+    // Matches the enforced allowlist in handleMessage: core set + scoped tools.
+    const allowedToolList = [...new Set([...SPECIALIST_CORE_TOOLS, ...(specialist.allowedTools ?? [])])].join(", ");
     return this.store.ensureAgent({
       id: specialist.id,
       name: specialist.name,

--- a/src/propagation-controller.js
+++ b/src/propagation-controller.js
@@ -1,4 +1,24 @@
-import { clamp, createId, nowIso, stableHash, summarizeText } from "./utils.js";
+import { clamp, createId, nowIso, stableHash, summarizeText, tokenOverlapScore } from "./utils.js";
+
+// A specialist's allowedTools used to be "every tool that existed at spawn
+// time" — a bound that bounds nothing. Division that inherits the whole
+// generalist toolset is just multiplication with a themed name. Instead:
+// keep only the tools whose name/description overlaps the bounded scope,
+// capped, ranked by overlap. (Core internal tools — recall/remember/task
+// ops — are granted at the enforcement layer in agent-host, not here.)
+const MAX_SCOPE_TOOLS = 10;
+export function selectScopedTools(tools, scopeText) {
+  const scored = [];
+  for (const tool of tools ?? []) {
+    const name = typeof tool === "string" ? tool : tool?.name;
+    if (!name) continue;
+    const description = typeof tool === "object" ? (tool.description ?? "") : "";
+    const score = tokenOverlapScore(scopeText, `${name.replace(/[_-]/g, " ")} ${description}`);
+    if (score > 0.05) scored.push({ name, score });
+  }
+  scored.sort((a, b) => b.score - a.score);
+  return [...new Set(scored.slice(0, MAX_SCOPE_TOOLS).map((entry) => entry.name))];
+}
 
 export class PropagationController {
   constructor(options = {}) {
@@ -72,7 +92,10 @@ export class PropagationController {
       parentGoal: workflow?.goal ?? signal.goal ?? "Improve outcome from signal evidence.",
       boundedScope: summarizeText(signal.specialistScope ?? signal.summary ?? signal.content ?? "Investigate and act on this signal class.", 240),
       successMetric: signal.successMetric ?? workflow?.successMetric ?? "Produces cited, actionable recommendations with lower repeated parent effort.",
-      allowedTools: tools.map((tool) => (typeof tool === "string" ? tool : tool.name)).filter(Boolean),
+      allowedTools: selectScopedTools(
+        tools,
+        `${signal.specialistScope ?? ""} ${signal.summary ?? ""} ${signal.content ?? ""} ${workflow?.goal ?? ""}`
+      ),
       status: "available",
       createdAt: nowIso(),
       lastActivatedAt: nowIso(),

--- a/src/specialist-router.js
+++ b/src/specialist-router.js
@@ -102,10 +102,19 @@ function scoreMatch(text, tags, specialist) {
   const ageDays = lastActivated > 0 ? (Date.now() - lastActivated) / (1000 * 60 * 60 * 24) : 9999;
   const recencyPenalty = ageDays > 60 ? 0.1 : ageDays > 30 ? 0.05 : 0;
 
+  // Outcome-quality feedback ("the individual then scrutinizes the
+  // creation"): once a specialist has enough resolved outcomes, its mean
+  // quality moves routing — proven specialists attract more work, struggling
+  // ones repel it before the retirement sweep catches them. ±0.15 swing.
+  let qualityAdjust = 0;
+  if ((specialist.outcomeSamples ?? 0) >= 3 && typeof specialist.meanOutcomeQuality === "number") {
+    qualityAdjust = (specialist.meanOutcomeQuality - 0.5) * 0.3;
+  }
+
   // Both signals weight equally; bonus when both fire (corroboration is itself a match signal).
   const baseScore = textScore * 0.5 + tagScore * 0.5;
   const corroborationBonus = textScore > 0.1 && tagScore > 0.1 ? 0.1 : 0;
-  const combined = baseScore + corroborationBonus + activationBoost - recencyPenalty;
+  const combined = baseScore + corroborationBonus + activationBoost + qualityAdjust - recencyPenalty;
 
   return {
     score: Math.max(0, Math.min(1, combined)),
@@ -113,6 +122,7 @@ function scoreMatch(text, tags, specialist) {
     tagScore,
     corroborationBonus,
     activationBoost,
+    qualityAdjust,
     recencyPenalty
   };
 }

--- a/src/tool-registry.js
+++ b/src/tool-registry.js
@@ -78,6 +78,15 @@ export class ToolRegistry {
     if (!tool) {
       return { ok: false, error: `Unknown tool: ${name}` };
     }
+    // Specialist bounds: a propagated specialist may only call tools inside
+    // its allowlist (its scoped MCP tools + the core set agent-host grants).
+    // Same advisory-list / enforced-gate split as the scrutiny policies.
+    if (Array.isArray(context?.__allowedTools) && !context.__allowedTools.includes(name)) {
+      return {
+        ok: false,
+        error: `Tool ${name} is outside this specialist's bounded scope. Recommend the user take this to the main agent.`
+      };
+    }
     // Scrutiny 'watch' policy: read-only turns hard-block side-effecting
     // tools (defense in depth — the filtered tool list is advisory to the
     // model, this gate is not).

--- a/test/specialist-bounds.test.js
+++ b/test/specialist-bounds.test.js
@@ -1,0 +1,166 @@
+// Bounded means bounded: specialists get a scope-matched tool allowlist at
+// spawn (not the whole generalist toolset), the allowlist is enforced at
+// invoke time, and routing learns from outcome quality.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PropagationController, ToolRegistry } from "../src/index.js";
+import { selectScopedTools } from "../src/propagation-controller.js";
+import { SpecialistRouter } from "../src/specialist-router.js";
+import { AgentHost } from "../src/agent-host.js";
+
+const MCP_TOOLS = [
+  { name: "calendar_list_events", description: "List events on the user's calendar" },
+  { name: "calendar_create_event", description: "Create a calendar event" },
+  { name: "stripe_refund_charge", description: "Refund a Stripe payment charge" },
+  { name: "github_merge_pr", description: "Merge a GitHub pull request" }
+];
+
+test("selectScopedTools keeps scope-matched tools and drops unrelated ones", () => {
+  const names = selectScopedTools(MCP_TOOLS, "handle calendar scheduling conflicts and recurring meeting events");
+  assert.ok(names.includes("calendar_list_events"));
+  assert.ok(names.includes("calendar_create_event"));
+  assert.ok(!names.includes("stripe_refund_charge"), "payment tool has no place in a calendar scope");
+  assert.ok(!names.includes("github_merge_pr"));
+});
+
+test("propagate() assigns a scoped allowlist, not every tool that existed at spawn", () => {
+  const controller = new PropagationController();
+  const { specialist } = controller.propagate({
+    signal: {
+      summary: "schedule and reschedule calendar meetings",
+      content: "the user keeps manually resolving calendar event conflicts",
+      repetition: 0.9,
+      domain: "general",
+      taskType: "specialization-candidate"
+    },
+    workflow: { id: "w", goal: "calendar conflict handling" },
+    scrutiny: { reasons: [] },
+    tools: MCP_TOOLS
+  });
+  assert.ok(specialist.allowedTools.includes("calendar_create_event"));
+  assert.ok(!specialist.allowedTools.includes("stripe_refund_charge"));
+  assert.ok(specialist.allowedTools.length < MCP_TOOLS.length);
+});
+
+test("invoke() enforces the specialist allowlist", async () => {
+  const registry = new ToolRegistry();
+  const ran = [];
+  for (const name of ["recall", "calendar_create_event", "stripe_refund_charge"]) {
+    registry.register({ name, handler: async () => { ran.push(name); return { ok: 1 }; } });
+  }
+  const ctx = { __allowedTools: ["recall", "calendar_create_event"] };
+
+  assert.equal((await registry.invoke("recall", {}, ctx)).ok, true);
+  assert.equal((await registry.invoke("calendar_create_event", {}, ctx)).ok, true);
+
+  const blocked = await registry.invoke("stripe_refund_charge", {}, ctx);
+  assert.equal(blocked.ok, false);
+  assert.match(blocked.error, /outside this specialist's bounded scope/);
+  assert.ok(!ran.includes("stripe_refund_charge"), "handler must not run");
+});
+
+test("a specialist turn sees only core + scoped tools, with the allowlist enforced in context", async () => {
+  const registry = new ToolRegistry();
+  for (const name of ["recall", "remember", "list_tasks", "agent_pick_next", "complete_task", "move_task", "save_draft", "calendar_create_event", "stripe_refund_charge", "send_message"]) {
+    registry.register({ name, handler: async () => ({}) });
+  }
+  const captured = {};
+  const runtime = {
+    tools: registry,
+    memory: { remember: () => ({ id: "m1" }) },
+    outcomes: null,
+    processSignal: () => ({
+      id: "out_1",
+      scrutiny: { action: "act", score: 0.6, reasons: [], dimensions: { novelty: 0.4, risk: 0.3, repetition: 0.3 } },
+      customContext: [],
+      propagation: { created: false }
+    })
+  };
+  const host = new AgentHost({
+    runtime,
+    modelProvider: {
+      isConfigured: () => true,
+      model: "stub",
+      generate: async (args) => {
+        captured.tools = args.tools;
+        captured.context = args.context;
+        return { text: "ok", provider: "stub", model: "stub", id: "r1", toolCalls: [] };
+      }
+    }
+  });
+
+  const specialist = {
+    id: "agent_cal",
+    name: "calendar-conflicts",
+    boundedScope: "handle calendar scheduling conflicts",
+    parentGoal: "calendar",
+    successMetric: "fewer conflicts",
+    allowedTools: ["calendar_create_event"]
+  };
+  host.ensureSpecialistAgent(specialist, "main");
+
+  await host.handleMessage({ text: "resolve the 3pm overlap", channel: "local", from: "u", agentId: "agent_cal", routeTo: false });
+
+  const names = captured.tools.map((t) => t.name);
+  assert.ok(names.includes("calendar_create_event"), "scoped tool present");
+  assert.ok(names.includes("recall"), "core tool present");
+  assert.ok(!names.includes("stripe_refund_charge"), "unscoped tool hidden");
+  assert.ok(!names.includes("send_message"), "non-core internal tool hidden");
+  assert.ok(Array.isArray(captured.context.__allowedTools), "enforcement allowlist passed to invoke context");
+  assert.ok(captured.context.__allowedTools.includes("calendar_create_event"));
+  assert.ok(!captured.context.__allowedTools.includes("stripe_refund_charge"));
+});
+
+test("the main agent's tools are not filtered", async () => {
+  const registry = new ToolRegistry();
+  for (const name of ["recall", "send_message"]) registry.register({ name, handler: async () => ({}) });
+  const captured = {};
+  const runtime = {
+    tools: registry,
+    memory: { remember: () => ({ id: "m1" }) },
+    outcomes: null,
+    processSignal: () => ({
+      id: "out_1",
+      scrutiny: { action: "act", score: 0.6, reasons: [], dimensions: { novelty: 0.4, risk: 0.3, repetition: 0.3 } },
+      customContext: [],
+      propagation: { created: false }
+    })
+  };
+  const host = new AgentHost({
+    runtime,
+    modelProvider: {
+      isConfigured: () => true,
+      model: "stub",
+      generate: async (args) => { captured.tools = args.tools; captured.context = args.context; return { text: "ok", provider: "stub", model: "stub", id: "r1", toolCalls: [] }; }
+    }
+  });
+  await host.handleMessage({ text: "hi", channel: "local", from: "u" });
+  assert.equal(captured.tools.length, 2);
+  assert.equal(captured.context.__allowedTools, null);
+});
+
+test("routing learns from outcome quality: struggling specialists repel work", async () => {
+  // Partial text match + no tag match, so scores sit below the 1.0 clamp and
+  // the quality term can actually separate the candidates.
+  const base = {
+    boundedScope: "triage calendar scheduling conflicts for meetings",
+    name: "calendar-conflicts",
+    parentGoal: "calendar",
+    status: "available",
+    activationCount: 5,
+    lastActivatedAt: new Date().toISOString(),
+    metadata: {}
+  };
+  const good = { ...base, id: "sp_good", meanOutcomeQuality: 0.9, outcomeSamples: 10 };
+  const bad = { ...base, id: "sp_bad", meanOutcomeQuality: 0.15, outcomeSamples: 10 };
+  const fresh = { ...base, id: "sp_fresh", meanOutcomeQuality: 0.1, outcomeSamples: 1 };
+
+  const router = new SpecialistRouter({ threshold: 0.99, mode: "live" });
+  const results = await router.search("can you help me sort out my overlapping calendar events this week", [], [good, bad, fresh]);
+  const score = (id) => results.find((r) => r.specialist.id === id).score;
+
+  assert.ok(score("sp_good") > score("sp_bad"), "quality separates otherwise-identical specialists");
+  assert.equal(results.find((r) => r.specialist.id === "sp_fresh").breakdown.qualityAdjust, 0, "no penalty before 3 samples");
+  assert.ok(results.find((r) => r.specialist.id === "sp_good").breakdown.qualityAdjust > 0);
+  assert.ok(results.find((r) => r.specialist.id === "sp_bad").breakdown.qualityAdjust < 0);
+});


### PR DESCRIPTION
Scope 4 from the feature audit. Stacked on #8 (reuses its ToolRegistry tool-policy primitive) — merge #8 first; GitHub will retarget this to main.

## Changes
- **Spawn-time scoping** — `allowedTools` was *every tool that existed at spawn* (a bound that bounds nothing; division inheriting the whole generalist toolset is just multiplication with a themed name). Now: scope-matched tools only (token overlap vs the bounded scope), ranked, capped at 10.
- **Enforcement** — specialist turns get only scoped + core tools (recall/remember/task ops/save_draft) in both the model-visible list AND an invoke-time `__allowedTools` gate. A calendar specialist can no longer call `stripe_refund_charge`. Main agent unaffected.
- **Routing learns** — `scoreMatch` gains a `qualityAdjust` term: after ≥3 resolved outcomes, a specialist's mean outcome quality swings its routing score ±0.15. Proven specialists attract work; struggling ones repel it before the retirement sweep fires.

## Tests
6 new cases in `test/specialist-bounds.test.js`; full suite 206/206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)