### PR TITLE
fix(mac): Quick Ask overlay stays on screen + smooth animations

### DIFF
--- a/mac/Sources/OpenAGI/Overlay/OverlayController.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayController.swift
@@ -9,6 +9,11 @@ final class OverlayController {
   private static let enabledKey = "openagi.overlay.enabled"
   private static let frameKey = "openagi.overlay.originX"
 
+  // Panel geometry. The expanded width matches OverlayView's fixed frame.
+  private static let expandedWidth: CGFloat = 320
+  private static let pillSize: CGFloat = 44
+  private static let screenMargin: CGFloat = 12
+
   static var isEnabled: Bool {
     UserDefaults.standard.object(forKey: enabledKey) == nil ? true : UserDefaults.standard.bool(forKey: enabledKey)
   }
@@ -32,19 +37,30 @@ final class OverlayController {
   func toggle() {
     guard Self.isEnabled else { return }
     if panel?.isVisible == true {
-      OverlayState.shared.expanded.toggle()
+      withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) {
+        OverlayState.shared.expanded.toggle()
+      }
       sizeToContent()
       if OverlayState.shared.expanded { panel?.makeKey() }
     } else {
       OverlayState.shared.expanded = true
-      show(); sizeToContent()
+      show(); sizeToContent(animate: false)
       panel?.makeKey()
     }
   }
 
+  /// Esc from anywhere in the panel collapses back to the pill.
+  func collapse() {
+    guard OverlayState.shared.expanded else { return }
+    withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) {
+      OverlayState.shared.expanded = false
+    }
+    sizeToContent()
+  }
+
   private func makePanel() -> NSPanel {
     let p = KeyableOverlayPanel(
-      contentRect: NSRect(x: 0, y: 0, width: 320, height: 60),
+      contentRect: NSRect(x: 0, y: 0, width: Self.expandedWidth, height: 60),
       styleMask: [.nonactivatingPanel, .borderless, .fullSizeContentView],
       backing: .buffered, defer: false)
     p.isFloatingPanel = true
@@ -56,36 +72,80 @@ final class OverlayController {
     p.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
     let host = NSHostingView(rootView: OverlayView(
       onCollapse: { [weak self] in self?.sizeToContent() },
-      onExpand: { [weak self] in DispatchQueue.main.async { self?.sizeToContent() } }
+      onExpand: { [weak self] in DispatchQueue.main.async { self?.sizeToContent() } },
+      // Content grows after the fact (answer arrives, nudges land, errors
+      // show). Without this hook the panel kept its stale frame and the
+      // reply rendered clipped / spilling past the panel edge.
+      onContentChange: { [weak self] in DispatchQueue.main.async { self?.sizeToContent() } }
     ))
     host.translatesAutoresizingMaskIntoConstraints = true
     p.contentView = host
     return p
   }
 
-  private func sizeToContent() {
+  /// Resize the panel to fit its SwiftUI content, animated, WITHOUT ever
+  /// leaving the screen: the top edge stays put while height grows downward,
+  /// the horizontal anchor is whichever edge is nearer a screen edge (so a
+  /// pill parked on the right expands leftward instead of off-screen), and
+  /// the final frame is clamped inside the screen's visible frame.
+  private func sizeToContent(animate: Bool = true) {
     guard let p = panel, let host = p.contentView else { return }
+    let screen = p.screen ?? NSScreen.main
+    guard let vf = screen?.visibleFrame else { return }
+    let m = Self.screenMargin
+    let expanded = OverlayState.shared.expanded
+
     let fitting = host.fittingSize
-    var frame = p.frame
-    let newH = max(44, fitting.height)
-    frame.origin.y += (frame.height - newH)
-    frame.size.height = newH
-    frame.size.width = OverlayState.shared.expanded ? 320 : 44
-    p.setFrame(frame, display: true, animate: false)
+    let newW = expanded ? Self.expandedWidth : Self.pillSize
+    let maxH = vf.height - m * 2
+    let newH = min(max(Self.pillSize, fitting.height), maxH)
+
+    let old = p.frame
+    let anchorRight = old.midX > vf.midX
+    var newX = anchorRight ? old.maxX - newW : old.minX
+    var newY = old.maxY - newH // keep the top edge fixed; grow downward
+
+    newX = min(max(vf.minX + m, newX), vf.maxX - m - newW)
+    newY = min(max(vf.minY + m, newY), vf.maxY - m - newH)
+    let target = NSRect(x: newX, y: newY, width: newW, height: newH)
+    guard target != old else { return }
+
+    if animate {
+      NSAnimationContext.runAnimationGroup { ctx in
+        ctx.duration = 0.22
+        ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
+        ctx.allowsImplicitAnimation = true
+        p.animator().setFrame(target, display: true)
+      }
+    } else {
+      p.setFrame(target, display: true)
+    }
   }
 
   private func positionPanel() {
     guard let p = panel, let screen = NSScreen.main else { return }
     let d = UserDefaults.standard
+    var placed = false
     if d.object(forKey: Self.frameKey) != nil {
-      let x = d.double(forKey: Self.frameKey)
-      let y = d.double(forKey: "openagi.overlay.originY")
-      p.setFrameOrigin(NSPoint(x: x, y: y))
-    } else {
-      let vf = screen.visibleFrame
-      p.setFrameOrigin(NSPoint(x: vf.maxX - 360, y: vf.minY + 80))
+      let saved = NSPoint(x: d.double(forKey: Self.frameKey), y: d.double(forKey: "openagi.overlay.originY"))
+      // A saved origin is only trustworthy while the screen layout that
+      // produced it still exists — after unplugging a monitor or changing
+      // resolution it can be entirely off-screen.
+      let onSomeScreen = NSScreen.screens.contains { $0.visibleFrame.insetBy(dx: -8, dy: -8).contains(saved) }
+      if onSomeScreen {
+        p.setFrameOrigin(saved)
+        placed = true
+      }
     }
-    sizeToContent()
+    if !placed {
+      let vf = screen.visibleFrame
+      // Default: upper-right, where downward growth has the most room.
+      p.setFrameOrigin(NSPoint(
+        x: vf.maxX - Self.expandedWidth - 40,
+        y: vf.maxY - 200
+      ))
+    }
+    sizeToContent(animate: false)
   }
 
   func persistPosition() {
@@ -100,4 +160,9 @@ final class OverlayController {
 // app from activating, so summoning never steals focus from the user's app.
 final class KeyableOverlayPanel: NSPanel {
   override var canBecomeKey: Bool { true }
+
+  // Esc anywhere in the panel collapses back to the pill instead of beeping.
+  override func cancelOperation(_ sender: Any?) {
+    Task { @MainActor in OverlayController.shared.collapse() }
+  }
 }

--- a/mac/Sources/OpenAGI/Overlay/OverlayState.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayState.swift
@@ -12,6 +12,14 @@ final class OverlayState: ObservableObject {
   @Published var error: String? = nil
   @Published var contextNote: String? = nil
 
+  /// Reset the answer area so the panel shrinks back to just the ask field.
+  func clearAnswer() {
+    answer = ""
+    error = nil
+    contextNote = nil
+    question = ""
+  }
+
   func ask() async {
     let q = question.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !q.isEmpty else { return }

--- a/mac/Sources/OpenAGI/Overlay/OverlayView.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayView.swift
@@ -4,30 +4,57 @@ struct OverlayView: View {
   @ObservedObject var state = OverlayState.shared
   @ObservedObject var app = AppState.shared
   @FocusState private var fieldFocused: Bool
+  @State private var pillHovered = false
   var onCollapse: () -> Void = {}
   var onExpand: () -> Void = {}
+  var onContentChange: () -> Void = {}
 
   var body: some View {
-    if state.expanded {
-      expandedPanel
-    } else {
-      pill
+    Group {
+      if state.expanded {
+        expandedPanel
+          .transition(.asymmetric(
+            insertion: .scale(scale: 0.96, anchor: .top).combined(with: .opacity),
+            removal: .opacity
+          ))
+      } else {
+        pill
+          .transition(.scale(scale: 0.8).combined(with: .opacity))
+      }
     }
+    .animation(.spring(response: 0.28, dampingFraction: 0.85), value: state.expanded)
+    // The panel resizes around this content — tell the controller whenever
+    // something that changes our height lands (answer, error, nudges, …).
+    .onChange(of: state.answer) { _, _ in onContentChange() }
+    .onChange(of: state.isLoading) { _, _ in onContentChange() }
+    .onChange(of: state.error) { _, _ in onContentChange() }
+    .onChange(of: state.contextNote) { _, _ in onContentChange() }
+    .onChange(of: app.nudges.count) { _, _ in onContentChange() }
+    .onChange(of: app.status) { _, _ in onContentChange() }
   }
 
   private var pill: some View {
-    Button(action: { state.expanded = true; onExpand() }) {
+    Button(action: {
+      withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) { state.expanded = true }
+      onExpand()
+    }) {
       ZStack {
-        Circle().fill(Color.accentColor).frame(width: 16, height: 16)
+        Circle().fill(Color.accentColor).frame(width: 18, height: 18)
         if !app.nudges.isEmpty {
           Text("\(app.nudges.count)")
             .font(.system(size: 9, weight: .bold)).foregroundColor(.white)
         }
       }
-      .padding(8)
+      .padding(9)
+      .contentShape(Circle())
     }
     .buttonStyle(.plain)
     .background(.ultraThinMaterial, in: Circle())
+    .overlay(Circle().strokeBorder(.white.opacity(pillHovered ? 0.25 : 0.1), lineWidth: 1))
+    .scaleEffect(pillHovered ? 1.08 : 1.0)
+    .animation(.easeOut(duration: 0.12), value: pillHovered)
+    .onHover { pillHovered = $0 }
+    .help("Quick Ask (⌥Space)")
   }
 
   private var expandedPanel: some View {
@@ -35,9 +62,14 @@ struct OverlayView: View {
       HStack {
         Text("Ask OpenAGI").font(.caption).foregroundStyle(.secondary)
         Spacer()
-        Button(action: { state.expanded = false; onCollapse() }) {
+        Button(action: {
+          withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) { state.expanded = false }
+          onCollapse()
+        }) {
           Image(systemName: "xmark.circle.fill").foregroundStyle(.tertiary)
-        }.buttonStyle(.plain)
+        }
+        .buttonStyle(.plain)
+        .help("Collapse (Esc)")
       }
       if app.status == .down {
         Text("OpenAGI is offline").font(.caption).foregroundStyle(.red)
@@ -51,14 +83,32 @@ struct OverlayView: View {
         Text(note).font(.system(size: 10)).foregroundStyle(.tertiary)
       }
       if state.isLoading {
-        ProgressView().controlSize(.small)
+        HStack(spacing: 6) {
+          ProgressView().controlSize(.small)
+          Text("Thinking…").font(.system(size: 11)).foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 2)
       } else if let err = state.error {
-        Text(err).font(.caption).foregroundStyle(.red)
+        Text(err).font(.caption).foregroundStyle(.red).lineLimit(4)
       } else if !state.answer.isEmpty {
-        ScrollView { Text(state.answer).font(.callout).textSelection(.enabled).frame(maxWidth: .infinity, alignment: .leading) }
-          .frame(maxHeight: 220)
-        Button("Continue in chat") { app.openDashboard(path: "/?tab=chat") }
-          .font(.caption).buttonStyle(.plain).foregroundStyle(.blue)
+        ScrollView {
+          Text(state.answer)
+            .font(.callout)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxHeight: 220)
+        HStack {
+          Button("Continue in chat") { app.openDashboard(path: "/?tab=chat") }
+            .font(.caption).buttonStyle(.plain).foregroundStyle(.blue)
+          Spacer()
+          Button(action: { state.clearAnswer() }) {
+            Text("Clear").font(.caption).foregroundStyle(.secondary)
+          }
+          .buttonStyle(.plain)
+          .help("Clear the answer")
+        }
       }
       if !app.nudges.isEmpty {
         Divider()
@@ -66,14 +116,16 @@ struct OverlayView: View {
         ForEach(app.nudges.prefix(4)) { n in
           HStack(alignment: .top, spacing: 6) {
             VStack(alignment: .leading, spacing: 1) {
-              Text(n.title).font(.system(size: 11, weight: .medium))
+              Text(n.title).font(.system(size: 11, weight: .medium)).lineLimit(2)
               if !n.body.isEmpty { Text(n.body).font(.system(size: 10)).foregroundStyle(.secondary).lineLimit(2) }
             }
             Spacer()
             Button(action: { app.openDashboard(path: "/?tab=chat&suggestion=\(n.id)") }) {
               Image(systemName: "arrow.up.right.square")
             }.buttonStyle(.plain).help("Review in chat")
-            Button(action: { app.nudges.removeAll { $0.id == n.id } }) {
+            Button(action: {
+              withAnimation(.easeOut(duration: 0.15)) { app.nudges.removeAll { $0.id == n.id } }
+            }) {
               Image(systemName: "xmark")
             }.buttonStyle(.plain).help("Dismiss")
           }
@@ -82,7 +134,8 @@ struct OverlayView: View {
     }
     .padding(12)
     .frame(width: 320)
-    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14))
+    .overlay(RoundedRectangle(cornerRadius: 14).strokeBorder(.white.opacity(0.1), lineWidth: 1))
     .onAppear { fieldFocused = true }
     .onChange(of: state.expanded) { _, expanded in if expanded { fieldFocused = true } }
   }


### PR DESCRIPTION
The floating widget could go off the page and felt abrupt. Root causes and fixes:

## Off-screen
- **No clamping**: `sizeToContent` grew the panel downward unbounded, and the default position was near the *bottom* of the screen — tall answers + nudges extended off the bottom edge. Frames now clamp inside `visibleFrame` with a 12px margin and height caps to the screen.
- **Wrong-direction expansion**: 44→320px always expanded rightward from the left edge; a pill near the right edge went off-screen. The horizontal anchor is now whichever edge is nearer a screen edge.
- **Stale saved positions** restored blind after monitor/resolution changes → validated against current screens, else reset to a new upper-right default (room to grow downward).

## Not resizing / clipping
The panel only re-fit on toggle — when the answer arrived, content grew inside the stale frame and clipped. The view now reports content changes (answer/loading/error/context/nudges/status) and the controller re-fits.

## Feel
- Animated frame changes (0.22s easeOut) + spring transition between pill ↔ panel.
- **Esc collapses** from anywhere in the panel.
- Pill hover scale + ring, ⌥Space tooltip, 'Thinking…' state, Clear button to shrink the panel back, subtle border stroke.

Swift build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)