### PR TITLE
fix: silent failures that hide why tasks never appear

### DIFF
--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -264,8 +264,16 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
       if (method === "POST" && pathname === "/message") {
         if (!channels) return sendJson(res, 503, { error: "agent-host-disabled" });
         const body = await readJson(req);
-        const result = await channels.handleLocalMessage(body);
-        return sendJson(res, 200, result);
+        // Chat must return a structured error, not a generic 500: the
+        // dashboard needs to distinguish "budget cap hit" / "provider auth
+        // failed" / "network blip" to show something actionable.
+        try {
+          const result = await channels.handleLocalMessage(body);
+          return sendJson(res, 200, result);
+        } catch (error) {
+          const code = error?.code === "BUDGET_EXCEEDED" || /budget/i.test(error?.message ?? "") ? "budget" : "agent-error";
+          return sendJson(res, 500, { error: error.message ?? String(error), code });
+        }
       }
 
       if (method === "POST" && pathname === "/channels/telegram/webhook") {
@@ -722,6 +730,7 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
                 configured: Boolean(runtime.linearTaskSource?.isConfigured?.()),
                 envKeys: ["LINEAR_API_KEY"],
                 lastSyncedAt: runtime.linearTaskSource?.lastSyncedAt ?? null,
+                lastSync: runtime.linearTaskSource?.lastSyncResult ?? null,
                 feeds: "tasks",
                 detail: "Polls every 5 min. Assigned issues become tasks. Lin priority maps to bucket+priority."
               },
@@ -744,6 +753,7 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
                 configured: Boolean(runtime.buildBetterTaskSource?.isConfigured?.()),
                 envKeys: ["BUILDBETTER_API_KEY", "BUILDBETTER_USER_EMAIL", "BUILDBETTER_USER_NAME"],
                 lastSyncedAt: runtime.buildBetterTaskSource?.lastSyncedAt ?? null,
+                lastSync: runtime.buildBetterTaskSource?.lastSyncResult ?? null,
                 feeds: "tasks",
                 detail: "Polls every 15 min. action_item / commitment / follow_up extractions become tasks."
               },
@@ -3932,9 +3942,34 @@ async function renderTasks() {
   const userTotal = stats.user?.total ?? 0;
   const agentTotal = stats.agent?.total ?? 0;
 
+  // Zero tasks EVER is almost always "no source is connected", not "inbox
+  // zero". Diagnose it loudly instead of showing two empty sections: which
+  // task sources are configured, and the last sync's skip reason when not.
+  let gettingStarted = "";
+  if (userTotal === 0 && agentTotal === 0) {
+    const integ = await fetchJson("/integrations/status").catch(() => null);
+    const taskSources = (integ?.integrations ?? []).filter((s) => ["linear", "buildbetter"].includes(s.id));
+    const rows = taskSources.map((s) => {
+      const api = (s.paths ?? []).find((p) => p.kind === "api");
+      const ok = Boolean(api?.configured);
+      const reason = api?.lastSync?.skipped ? api.lastSync.reason : (api?.lastSync?.signals?.skipped ? api.lastSync.signals.reason : null);
+      const status = ok
+        ? (reason ? \`connected — last sync skipped: \${escapeHtml(reason)}\` : "connected")
+        : \`not connected (\${(api?.envKeys ?? []).slice(0, 1).map(escapeHtml).join("")} or MCP)\`;
+      return \`<li style="margin:2px 0;"><strong>\${escapeHtml(s.name)}</strong>: <span class="\${ok && !reason ? "" : "ui-muted"}">\${status}</span></li>\`;
+    }).join("");
+    gettingStarted = \`
+      <div class="card" style="margin-bottom: var(--space-4); border-left: 3px solid var(--warn, #d4a72c); padding: var(--space-3);">
+        <div style="font-weight:600; margin-bottom:4px;">No tasks yet — here's why</div>
+        <ul style="margin:4px 0 8px 16px; padding:0; font-size:13px;">\${rows || "<li>No task sources detected.</li>"}</ul>
+        <div class="ui-meta">Connect a source in <a href="/?tab=integrations">Integrations</a>, drop .md/.txt files in ~/.openagi/inbox, or just tell the agent below: "remind me to…"</div>
+      </div>\`;
+  }
+
   main.innerHTML = \`
     <div class="pane">
       <h2>Tasks</h2>
+      \${gettingStarted}
       <p class="ui-muted">Talk to the agent below to add, complete, or rearrange tasks. Or click checkboxes directly. <strong>My tasks</strong> are what you should do; <strong>Agent tasks</strong> are what OpenAGI is working on for you.</p>
 
       <div id="tasksPageChat"></div>

--- a/src/integrations/buildbetter-tasks.js
+++ b/src/integrations/buildbetter-tasks.js
@@ -30,13 +30,17 @@ const LOOKBACK_DAYS = 7;
 export class BuildBetterTaskSource {
   constructor(options = {}) {
     this.runtime = options.runtime;
-    this.apiKey = options.apiKey ?? process.env.BUILDBETTER_API_KEY ?? null;
-    this.userEmail = options.userEmail ?? process.env.BUILDBETTER_USER_EMAIL ?? null;
-    this.userName = options.userName ?? process.env.BUILDBETTER_USER_NAME ?? null;
+    this._apiKey = options.apiKey ?? null;
+    this._userEmail = options.userEmail ?? null;
+    this._userName = options.userName ?? null;
     // Identity auto-derivation (option 1): once we've successfully asked `me`,
     // don't ask again this process — even if it returned no user.
     this._identityResolved = false;
     this.lastSyncedAt = null;
+    // The most recent sync outcome (including skip reasons), surfaced via
+    // /integrations/status so "why are there zero tasks" is answerable from
+    // the dashboard instead of invisible inside cron tick results.
+    this.lastSyncResult = null;
     // Coalescing state for webhook-triggered syncs: if a sync is already
     // running when a ping arrives, we don't start a second — we just flag
     // that one more run is owed, and run it once when the current finishes.
@@ -45,6 +49,16 @@ export class BuildBetterTaskSource {
     const mode = (options.ingestMode ?? process.env.BUILDBETTER_INGEST_MODE ?? "signals").toLowerCase();
     this.ingestMode = ["signals", "transcripts", "both"].includes(mode) ? mode : "signals";
   }
+
+  // Credentials/identity read the env LIVE (not a constructor snapshot) so
+  // values added after boot — setup-wizard save, manual .env edit — take
+  // effect on the next sync tick without a daemon restart. ensureIdentity()
+  // still assigns through the setters when it derives identity from `me`.
+  get apiKey() { return this._apiKey ?? process.env.BUILDBETTER_API_KEY ?? null; }
+  get userEmail() { return this._userEmail ?? process.env.BUILDBETTER_USER_EMAIL ?? null; }
+  set userEmail(value) { this._userEmail = value; }
+  get userName() { return this._userName ?? process.env.BUILDBETTER_USER_NAME ?? null; }
+  set userName(value) { this._userName = value; }
 
   isConfigured() {
     // Identity is auto-derived now, so auth alone is enough: an API key, or a
@@ -312,6 +326,7 @@ export class BuildBetterTaskSource {
     if (this.ingestMode === "transcripts" || this.ingestMode === "both") {
       out.transcripts = await this.syncTranscripts({ now });
     }
+    this.lastSyncResult = { at: new Date().toISOString(), ...out };
     return out;
   }
 

--- a/src/integrations/linear-tasks.js
+++ b/src/integrations/linear-tasks.js
@@ -36,9 +36,16 @@ const ASSIGNED_ISSUES_QUERY = `
 export class LinearTaskSource {
   constructor(options = {}) {
     this.runtime = options.runtime;
-    this.apiKey = options.apiKey ?? process.env.LINEAR_API_KEY ?? null;
+    this._apiKey = options.apiKey ?? null;
     this.includeCompleted = options.includeCompleted ?? false;
     this.lastSyncedAt = null;
+  }
+
+  // Read the env live (not a constructor snapshot) so a key added after boot
+  // — setup-wizard save, manual .env edit — starts syncing on the next cron
+  // tick without a daemon restart.
+  get apiKey() {
+    return this._apiKey ?? process.env.LINEAR_API_KEY ?? null;
   }
 
   isConfigured() {
@@ -64,7 +71,14 @@ export class LinearTaskSource {
    * Poll Linear and reconcile against the OpenAGI TaskStore.
    * Returns { created, updated, completed } counts.
    */
-  async sync({ now = new Date() } = {}) {
+  async sync(opts = {}) {
+    const result = await this._sync(opts);
+    // Surfaced via /integrations/status so skip reasons are visible.
+    this.lastSyncResult = { at: new Date().toISOString(), ...result };
+    return result;
+  }
+
+  async _sync({ now = new Date() } = {}) {
     if (!this.isConfigured()) return { skipped: true, reason: "LINEAR_API_KEY not set" };
     if (!this.runtime?.tasks?.add) return { skipped: true, reason: "task store not available" };
 
@@ -168,11 +182,11 @@ function pickBucket(dueDateIso, now = new Date()) {
 
 export function registerLinearTaskSource(runtime, options = {}) {
   const source = options.source ?? new LinearTaskSource({ runtime, ...options });
-  if (!source.isConfigured()) {
-    return { registered: false, reason: "LINEAR_API_KEY not set" };
-  }
-  // Add a cron job for periodic sync. Idempotent — addJob skips duplicates
-  // by id.
+  // Register the source + cron job even when LINEAR_API_KEY is missing at
+  // boot (same pattern as the BuildBetter source): sync() self-gates on
+  // isConfigured(), which reads the env live, so a key added later via the
+  // setup wizard is picked up on the next 5-min tick — previously the cron
+  // job was never installed and Linear stayed dead until a restart.
   if (runtime.cron?.addJob) {
     runtime.cron.addJob({
       id: "linear-task-sync",
@@ -183,5 +197,5 @@ export function registerLinearTaskSource(runtime, options = {}) {
     });
   }
   runtime.linearTaskSource = source;
-  return { registered: true };
+  return { registered: true, idle: !source.isConfigured() };
 }

--- a/test/silent-failures.test.js
+++ b/test/silent-failures.test.js
@@ -1,0 +1,90 @@
+// Silent-failure fixes from the feature audit: Linear registers even without
+// a key (and picks one up live), BuildBetter reads identity/credentials live
+// and surfaces sync skip reasons, and /message returns structured errors
+// instead of crashing the request.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createDefaultRuntime, createHostedInterface } from "../src/index.js";
+import { LinearTaskSource, registerLinearTaskSource } from "../src/integrations/linear-tasks.js";
+import { BuildBetterTaskSource } from "../src/integrations/buildbetter-tasks.js";
+
+test("Linear source + cron register even when LINEAR_API_KEY is unset at boot", async () => {
+  delete process.env.LINEAR_API_KEY;
+  const jobs = [];
+  const runtime = { cron: { addJob: (j) => jobs.push(j) }, tasks: { add: () => ({}) } };
+
+  const result = registerLinearTaskSource(runtime);
+  assert.equal(result.registered, true);
+  assert.equal(result.idle, true);
+  assert.ok(runtime.linearTaskSource, "source attached for later credential arrival");
+  assert.ok(jobs.some((j) => j.id === "linear-task-sync"), "cron job installed");
+
+  // Unconfigured tick self-gates with a reason — and records it for status.
+  const sync = await runtime.linearTaskSource.sync();
+  assert.equal(sync.skipped, true);
+  assert.match(sync.reason, /LINEAR_API_KEY/);
+  assert.equal(runtime.linearTaskSource.lastSyncResult.skipped, true);
+
+  // A key added mid-session (setup wizard, .env edit) is seen live.
+  process.env.LINEAR_API_KEY = "lin_test_123";
+  try {
+    assert.equal(runtime.linearTaskSource.isConfigured(), true, "env read live, no restart needed");
+  } finally {
+    delete process.env.LINEAR_API_KEY;
+  }
+});
+
+test("BuildBetter reads credentials/identity from env live and records sync results", async () => {
+  delete process.env.BUILDBETTER_API_KEY;
+  delete process.env.BUILDBETTER_USER_EMAIL;
+  const runtime = { tasks: { add: () => ({}) }, mcp: { hasOAuthToken: () => false, silentTokenFor: async () => null } };
+  const source = new BuildBetterTaskSource({ runtime });
+
+  assert.equal(source.isConfigured(), false);
+  const result = await source.sync();
+  assert.equal(result.signals.skipped, true);
+  assert.match(result.signals.reason, /no BuildBetter auth/);
+  assert.equal(source.lastSyncResult.signals.skipped, true, "skip reason captured for /integrations/status");
+
+  process.env.BUILDBETTER_API_KEY = "bb_test";
+  process.env.BUILDBETTER_USER_EMAIL = "spencer@example.com";
+  try {
+    assert.equal(source.isConfigured(), true, "API key read live");
+    assert.equal(source.userEmail, "spencer@example.com", "identity read live");
+    // ensureIdentity's derived values still win over later reads.
+    source.userEmail = "derived@example.com";
+    assert.equal(source.userEmail, "derived@example.com");
+  } finally {
+    delete process.env.BUILDBETTER_API_KEY;
+    delete process.env.BUILDBETTER_USER_EMAIL;
+  }
+});
+
+test("Linear source still registers normally when configured", () => {
+  const jobs = [];
+  const runtime = { cron: { addJob: (j) => jobs.push(j) }, tasks: { add: () => ({}) } };
+  const result = registerLinearTaskSource(runtime, { source: new LinearTaskSource({ runtime, apiKey: "lin_x" }) });
+  assert.equal(result.registered, true);
+  assert.equal(result.idle, false);
+});
+
+test("POST /message returns a structured error instead of a bare 500 crash", async () => {
+  const runtime = createDefaultRuntime();
+  const app = createHostedInterface(runtime, { port: 0 });
+  const address = await app.listen();
+  try {
+    // Force the agent path to throw.
+    runtime.agentHost.handleMessage = async () => { const e = new Error("Daily budget exceeded: $10 cap"); e.code = "BUDGET_EXCEEDED"; throw e; };
+    const res = await fetch(`${address.url}/message`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ from: "t", text: "hi" })
+    });
+    assert.equal(res.status, 500);
+    const body = await res.json();
+    assert.equal(body.code, "budget", "budget errors are distinguishable");
+    assert.match(body.error, /budget exceeded/i);
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
Follow-up round on the audit's task-pipeline P0/P1s — the root causes of "I rarely see tasks show up".

## Changes
- **Linear (P0)**: source + cron now register even without `LINEAR_API_KEY` at boot (the early return meant adding a key later did nothing until restart). Key is read live from env, so the setup wizard's save takes effect on the next 5-min tick.
- **BuildBetter (P1)**: `BUILDBETTER_API_KEY`/`USER_EMAIL`/`USER_NAME` were constructor snapshots → now live env getters. `ensureIdentity()`'s auto-derived identity still wins.
- **Sync visibility (P1)**: both sources record `lastSyncResult` (with skip reasons); `/integrations/status` exposes it — "auth broken" vs "no recent calls" vs "identity missing" are finally distinguishable.
- **`/message` (P0)**: structured `{ error, code }` on failure; budget-cap errors return `code: "budget"` instead of an indistinguishable bare 500.
- **Tasks tab empty state**: zero-tasks-ever now renders a "No tasks yet — here's why" card diagnosing each source's state + last skip reason, linking to Integrations / inbox folder / chat.

## Tests
4 new cases (`test/silent-failures.test.js`) incl. an HTTP-level /message error test; full suite 198/198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)