### PR TITLE
feat: onboarding cleanup — auto-open wizard, safe re-runs, quick save, loud unconfigured state

### DIFF
--- a/mac/Sources/OpenAGI/AppState.swift
+++ b/mac/Sources/OpenAGI/AppState.swift
@@ -125,6 +125,12 @@ final class AppState: ObservableObject {
     pollTimer = nil
   }
 
+  // Latched per launch: a fresh install gets walked to the setup wizard
+  // exactly once instead of sitting silent behind a menubar icon. (The
+  // single biggest onboarding failure was the app launching, starting an
+  // unconfigured daemon, and never showing the user ANYTHING.)
+  private var offeredSetupThisLaunch = false
+
   private func pollOnce() async {
     // Always probe /health on its own so we can distinguish "daemon is dead"
     // from "daemon is up but /audit is throwing".
@@ -138,6 +144,11 @@ final class AppState: ObservableObject {
       memoryLong = h.status?.memory?.long ?? 0
       lastError = nil
       consecutiveFailures = 0
+      if h.firstRun == true && !offeredSetupThisLaunch {
+        offeredSetupThisLaunch = true
+        notify(title: "Welcome to OpenAGI", body: "Two minutes of setup and your agent is live.", path: "/setup")
+        openDashboard(path: "/setup")
+      }
     } catch {
       status = .down
       lastError = "/health: \(error.localizedDescription)"
@@ -409,6 +420,7 @@ final class AppState: ObservableObject {
 
 struct HealthResponse: Decodable {
   let ok: Bool?
+  let firstRun: Bool?
   let status: HealthInner?
   struct HealthInner: Decodable {
     let agentHost: AgentHost?

--- a/mac/Sources/OpenAGI/TrayController.swift
+++ b/mac/Sources/OpenAGI/TrayController.swift
@@ -105,7 +105,7 @@ struct TrayMenu: View {
       if state.providerConfigured {
         Text("Model: \(state.providerName)").disabled(true)
       } else {
-        Button("Open setup wizard…") { state.openDashboard(path: "/setup") }
+        Button("⚠ Finish setup — agent has no model key") { state.openDashboard(path: "/setup") }
       }
       Text("Today: $\(formatUsd(state.spentToday)) / $\(formatUsd(state.spentLimit))")
         .disabled(true)
@@ -125,6 +125,9 @@ struct TrayMenu: View {
   }
 
   private var statusLine: String {
+    // An unconfigured agent isn't "online" in any sense the user cares
+    // about — say so before anything else.
+    if state.status == .healthy && !state.providerConfigured { return "● setup needed" }
     switch state.status {
     case .healthy: return "● online"
     case .degraded: return "● needs attention"

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -183,7 +183,11 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
       // Setup wizard handlers — work both during first-run (auth-bypassed)
       // and after-auth (so users can re-edit env from the dashboard's Settings).
       if (method === "GET" && pathname === "/setup") {
-        return sendHtml(res, 200, renderWizard(), extraCookies);
+        // Re-runs prefill from the live env: the existing auth token is
+        // KEPT (a re-run used to silently rotate it on save), provider/
+        // model/budget show their current values, and already-set secrets
+        // get a "saved" marker instead of looking unconfigured.
+        return sendHtml(res, 200, renderWizard({ existingEnv: process.env }), extraCookies);
       }
       if (method === "POST" && pathname === "/setup/save") {
         const body = await readJson(req);
@@ -216,7 +220,9 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
       }
 
       if (method === "GET" && pathname === "/") return sendHtml(res, 200, renderApp(), extraCookies);
-      if (method === "GET" && pathname === "/health") return sendJson(res, 200, { ok: true, status: runtime.status() });
+      // firstRun lets clients (Mac app) know setup has never completed, so
+      // they can take the user to the wizard instead of sitting silent.
+      if (method === "GET" && pathname === "/health") return sendJson(res, 200, { ok: true, firstRun: isFirstRun(), status: runtime.status() });
       if (method === "GET" && pathname === "/memory") return sendJson(res, 200, runtime.memory.snapshot());
       if (method === "GET" && pathname === "/agents") return sendJson(res, 200, runtime.agentHost?.store.listAgents() ?? runtime.propagation.list());
       if (method === "GET" && pathname === "/specialists") {

--- a/src/setup-wizard.js
+++ b/src/setup-wizard.js
@@ -110,8 +110,18 @@ function parseEnvText(text) {
   return out;
 }
 
-export function renderWizard({ proposedToken } = {}) {
-  const token = proposedToken ?? generateToken(32);
+export function renderWizard({ proposedToken, existingEnv = {} } = {}) {
+  // Re-running /setup must NOT rotate the auth token: every save used to
+  // overwrite OPENAGI_AUTH_TOKEN with a fresh value because the hidden field
+  // always submitted. Keep the existing token when there is one.
+  const token = proposedToken ?? existingEnv.OPENAGI_AUTH_TOKEN ?? generateToken(32);
+  const hasExistingToken = Boolean(existingEnv.OPENAGI_AUTH_TOKEN);
+  const val = (key, fallback = "") => escapeHtml(existingEnv[key] ?? fallback);
+  // "✓ saved" marker for secret fields that already have a value — blank
+  // means "keep what's saved", so the user can see what's configured
+  // without us echoing the secret back into the page.
+  const saved = (key) => (existingEnv[key] ? ' <span class="pill">✓ saved — blank keeps it</span>' : "");
+  const providerChecked = (p) => ((existingEnv.OPENAGI_PROVIDER ?? "auto") === p ? "checked" : "");
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -198,35 +208,41 @@ export function renderWizard({ proposedToken } = {}) {
       <h3>Pick a primary provider</h3>
       <p>You can supply both — but pick which one drives chat and tool calls. Switch later from the dashboard.</p>
       <div class="grid">
-        <label class="opt"><input type="radio" name="OPENAGI_PROVIDER" value="auto" checked> Auto · use whichever has a key (Anthropic preferred)</label>
-        <label class="opt"><input type="radio" name="OPENAGI_PROVIDER" value="anthropic"> Anthropic · Claude Sonnet 4.6</label>
-        <label class="opt"><input type="radio" name="OPENAGI_PROVIDER" value="openai"> OpenAI · ChatGPT (GPT-5)</label>
+        <label class="opt"><input type="radio" name="OPENAGI_PROVIDER" value="auto" ${providerChecked("auto")}> Auto · use whichever has a key (Anthropic preferred)</label>
+        <label class="opt"><input type="radio" name="OPENAGI_PROVIDER" value="anthropic" ${providerChecked("anthropic")}> Anthropic · Claude Sonnet 4.6</label>
+        <label class="opt"><input type="radio" name="OPENAGI_PROVIDER" value="openai" ${providerChecked("openai")}> OpenAI · ChatGPT (GPT-5)</label>
       </div>
 
       <h3 style="margin-top:14px;">Anthropic key</h3>
       <p>Get one at <a href="https://console.anthropic.com/" target="_blank" rel="noopener">console.anthropic.com</a>.</p>
-      <label>ANTHROPIC_API_KEY</label>
+      <label>ANTHROPIC_API_KEY${saved("ANTHROPIC_API_KEY")}</label>
       <input type="password" name="ANTHROPIC_API_KEY" placeholder="sk-ant-…" autocomplete="off">
       <label style="margin-top:8px;">Model</label>
-      <input type="text" name="ANTHROPIC_MODEL" value="claude-sonnet-4-6">
+      <input type="text" name="ANTHROPIC_MODEL" value="${val("ANTHROPIC_MODEL", "claude-sonnet-4-6")}">
 
       <h3 style="margin-top:14px;">OpenAI / ChatGPT key</h3>
       <p>Get one at <a href="https://platform.openai.com/api-keys" target="_blank" rel="noopener">platform.openai.com</a>. Works with Zero Data Retention orgs.</p>
-      <label>OPENAI_API_KEY</label>
+      <label>OPENAI_API_KEY${saved("OPENAI_API_KEY")}</label>
       <input type="password" name="OPENAI_API_KEY" placeholder="sk-proj-…" autocomplete="off">
       <label style="margin-top:8px;">Model</label>
-      <input type="text" name="OPENAI_MODEL" value="gpt-5">
+      <input type="text" name="OPENAI_MODEL" value="${val("OPENAI_MODEL", "gpt-5")}">
     </div>
 
     <div class="step">
       <h2>3 / 8 · auth</h2>
       <h3>Bearer token</h3>
-      <p>This is the password for your dashboard. Save it now — you'll need it to log in. We auto-generated a strong one for you, or paste your own.</p>
+      <p>${hasExistingToken
+        ? "This is your <strong>existing</strong> dashboard token — saving keeps it unchanged. Regenerate only if you want to rotate it (other signed-in browsers will need the new one)."
+        : "This is the password for your dashboard. Save it now — you'll need it to log in. We auto-generated a strong one for you, or paste your own."}</p>
       <div class="token" id="tokenView">${escapeHtml(token)}</div>
       <input type="hidden" name="OPENAGI_AUTH_TOKEN" id="tokenInput" value="${escapeHtml(token)}">
       <div class="actions">
         <button type="button" class="secondary" id="copyToken">Copy</button>
         <button type="button" class="secondary" id="regenToken">Regenerate</button>
+      </div>
+      <div style="margin-top:14px; padding-top:12px; border-top:1px solid #2a352f;">
+        <p class="sub" style="margin-bottom:8px;">That's the minimum viable setup — a model key + this token. Everything below (channels, sources, MCPs, tunnel, budget) can wait.</p>
+        <button type="submit" class="secondary">Save now — set up the rest later</button>
       </div>
     </div>
 
@@ -238,16 +254,16 @@ export function renderWizard({ proposedToken } = {}) {
       <details>
         <summary>Twilio SMS — text the agent and get texts back</summary>
         <div style="padding-top:10px;" class="grid">
-          <div><label>TWILIO_ACCOUNT_SID</label><input type="text" name="TWILIO_ACCOUNT_SID" placeholder="AC..."></div>
-          <div><label>TWILIO_AUTH_TOKEN</label><input type="password" name="TWILIO_AUTH_TOKEN" autocomplete="off"></div>
-          <div><label>TWILIO_FROM_NUMBER</label><input type="text" name="TWILIO_FROM_NUMBER" placeholder="+15551234567"></div>
+          <div><label>TWILIO_ACCOUNT_SID${saved("TWILIO_ACCOUNT_SID")}</label><input type="text" name="TWILIO_ACCOUNT_SID" placeholder="AC..."></div>
+          <div><label>TWILIO_AUTH_TOKEN${saved("TWILIO_AUTH_TOKEN")}</label><input type="password" name="TWILIO_AUTH_TOKEN" autocomplete="off"></div>
+          <div><label>TWILIO_FROM_NUMBER${saved("TWILIO_FROM_NUMBER")}</label><input type="text" name="TWILIO_FROM_NUMBER" placeholder="+15551234567"></div>
         </div>
       </details>
 
       <details style="margin-top:8px;">
         <summary>Telegram — bot from @BotFather</summary>
         <div style="padding-top:10px;" class="grid">
-          <div><label>TELEGRAM_BOT_TOKEN</label><input type="password" name="TELEGRAM_BOT_TOKEN" autocomplete="off"></div>
+          <div><label>TELEGRAM_BOT_TOKEN${saved("TELEGRAM_BOT_TOKEN")}</label><input type="password" name="TELEGRAM_BOT_TOKEN" autocomplete="off"></div>
           <div><label>TELEGRAM_WEBHOOK_SECRET (any random string)</label><input type="text" name="TELEGRAM_WEBHOOK_SECRET"></div>
           <div class="opt"><input type="checkbox" id="tgPoll" name="TELEGRAM_POLLING" value="1"><label for="tgPoll" style="margin:0;">Long-poll instead of webhook (works without a tunnel)</label></div>
         </div>
@@ -263,7 +279,7 @@ export function renderWizard({ proposedToken } = {}) {
         <summary>Linear — assigned issues become tasks</summary>
         <div style="padding-top:10px;">
           <p class="sub">Get a personal API key at <a href="https://linear.app/settings/api" target="_blank" rel="noopener">linear.app/settings/api</a>. Polls every 5 min.</p>
-          <label>LINEAR_API_KEY</label>
+          <label>LINEAR_API_KEY${saved("LINEAR_API_KEY")}</label>
           <input type="password" name="LINEAR_API_KEY" placeholder="lin_api_…" autocomplete="off">
         </div>
       </details>
@@ -273,10 +289,10 @@ export function renderWizard({ proposedToken } = {}) {
         <div style="padding-top:10px;" class="grid">
           <p class="sub">Pulls action_item / commitment / follow_up extractions from your recent calls. Polls every 15 min, and (optionally) syncs instantly via webhook.</p>
           <p class="sub">Already connected BuildBetter on the <code>MCP</code> tab? You can leave everything below blank — OpenAGI reuses that login.</p>
-          <div><label>BUILDBETTER_API_KEY <span class="sub">(optional if connected via MCP)</span></label><input type="password" name="BUILDBETTER_API_KEY" autocomplete="off"></div>
-          <div><label>BUILDBETTER_USER_EMAIL <span class="sub">(optional — auto-detected from your login)</span></label><input type="email" name="BUILDBETTER_USER_EMAIL" placeholder="you@example.com"></div>
-          <div><label>BUILDBETTER_USER_NAME <span class="sub">(optional — only needed if auto-detect can't pinpoint you)</span></label><input type="text" name="BUILDBETTER_USER_NAME" placeholder="Your Name"></div>
-          <div><label>BUILDBETTER_WEBHOOK_SECRET <span class="sub">(optional — enables instant push)</span></label><input type="password" name="BUILDBETTER_WEBHOOK_SECRET" autocomplete="off" placeholder="a long random string"><p class="sub">Set this, then point a BuildBetter webhook at <code>&lt;your public URL&gt;/webhooks/buildbetter?secret=…</code> (shown on the Channels tab once a public URL is set) to sync the moment a call is processed instead of waiting for the poll.</p></div>
+          <div><label>BUILDBETTER_API_KEY <span class="sub">(optional if connected via MCP)</span>${saved("BUILDBETTER_API_KEY")}</label><input type="password" name="BUILDBETTER_API_KEY" autocomplete="off"></div>
+          <div><label>BUILDBETTER_USER_EMAIL <span class="sub">(optional — auto-detected from your login)</span></label><input type="email" name="BUILDBETTER_USER_EMAIL" placeholder="you@example.com" value="${val("BUILDBETTER_USER_EMAIL")}"></div>
+          <div><label>BUILDBETTER_USER_NAME <span class="sub">(optional — only needed if auto-detect can't pinpoint you)</span></label><input type="text" name="BUILDBETTER_USER_NAME" placeholder="Your Name" value="${val("BUILDBETTER_USER_NAME")}"></div>
+          <div><label>BUILDBETTER_WEBHOOK_SECRET <span class="sub">(optional — enables instant push)</span>${saved("BUILDBETTER_WEBHOOK_SECRET")}</label><input type="password" name="BUILDBETTER_WEBHOOK_SECRET" autocomplete="off" placeholder="a long random string"><p class="sub">Set this, then point a BuildBetter webhook at <code>&lt;your public URL&gt;/webhooks/buildbetter?secret=…</code> (shown on the Channels tab once a public URL is set) to sync the moment a call is processed instead of waiting for the poll.</p></div>
         </div>
       </details>
 
@@ -284,7 +300,7 @@ export function renderWizard({ proposedToken } = {}) {
         <summary>Rize.io — what you worked on today</summary>
         <div style="padding-top:10px;">
           <p class="sub">Activity tracking surfaces "what did I work on today?" via the <code>rize_*</code> agent tools. Get a key at <a href="https://my.rize.io/settings/api" target="_blank" rel="noopener">my.rize.io/settings/api</a>.</p>
-          <label>RIZE_API_KEY</label>
+          <label>RIZE_API_KEY${saved("RIZE_API_KEY")}</label>
           <input type="password" name="RIZE_API_KEY" autocomplete="off">
         </div>
       </details>
@@ -293,7 +309,7 @@ export function renderWizard({ proposedToken } = {}) {
         <summary>Calendar — did the meeting happen?</summary>
         <div style="padding-top:10px;">
           <p class="sub">Paste your calendar's <strong>secret iCal/ICS URL</strong> (Google: Settings → your calendar → "Secret address in iCal format"; Outlook/Apple have an equivalent). Used to reconcile whether scheduled meetings occurred and to plan your day. Comma-separate multiple calendars. No OAuth required.</p>
-          <label>CALENDAR_ICS_URL</label>
+          <label>CALENDAR_ICS_URL${saved("CALENDAR_ICS_URL")}</label>
           <input type="password" name="CALENDAR_ICS_URL" autocomplete="off" placeholder="https://calendar.google.com/calendar/ical/.../basic.ics">
         </div>
       </details>
@@ -337,7 +353,7 @@ export function renderWizard({ proposedToken } = {}) {
       <p>If you want Twilio or Telegram webhooks to reach this machine, expose it via a tunnel. <code>cloudflared</code> on macOS: <code>brew install cloudflared</code>; on Linux: <a href="https://pkg.cloudflare.com/index.html" target="_blank" rel="noopener">pkg.cloudflare.com</a>.</p>
       <p>Then run <code>npm run tunnel</code> in another terminal and paste the URL it prints below.</p>
       <label>OPENAGI_PUBLIC_URL <span class="sub">leave blank to skip</span></label>
-      <input type="text" name="OPENAGI_PUBLIC_URL" placeholder="https://abcd.trycloudflare.com">
+      <input type="text" name="OPENAGI_PUBLIC_URL" placeholder="https://abcd.trycloudflare.com" value="${val("OPENAGI_PUBLIC_URL")}">
     </div>
 
     <div class="step">
@@ -345,7 +361,7 @@ export function renderWizard({ proposedToken } = {}) {
       <h3>Daily budget</h3>
       <p>Hard ceiling on LLM spend per day. Provider calls throw <code>BUDGET_EXCEEDED</code> past this. Default $10/day.</p>
       <label>OPENAGI_DAILY_USD_LIMIT</label>
-      <input type="number" name="OPENAGI_DAILY_USD_LIMIT" value="10" min="0.5" step="0.5">
+      <input type="number" name="OPENAGI_DAILY_USD_LIMIT" value="${val("OPENAGI_DAILY_USD_LIMIT", "10")}" min="0.5" step="0.5">
     </div>
 
     <div class="step">
@@ -435,6 +451,7 @@ export function renderWizard({ proposedToken } = {}) {
     const out = document.getElementById("output");
     out.style.display = "block";
     out.textContent = "Saving…";
+    out.scrollIntoView({ behavior: "smooth", block: "center" });
     const btn = document.getElementById("saveBtn");
     btn.disabled = true;
 

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -1,0 +1,68 @@
+// Onboarding polish: re-running /setup must not rotate the auth token or
+// reset configured values, saved secrets are visibly marked, and /health
+// exposes firstRun so the Mac app can walk a fresh install to the wizard.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderWizard, isFirstRun } from "../src/setup-wizard.js";
+import { createDefaultRuntime, createHostedInterface } from "../src/index.js";
+
+test("fresh wizard generates a token and uses defaults", () => {
+  const html = renderWizard({ existingEnv: {} });
+  assert.match(html, /auto-generated a strong one/);
+  assert.match(html, /value="claude-sonnet-4-6"/);
+  assert.match(html, /value="gpt-5"/);
+  assert.ok(!html.includes("✓ saved"), "no saved markers on a fresh install");
+});
+
+test("re-run wizard keeps the existing auth token instead of rotating it", () => {
+  const html = renderWizard({
+    existingEnv: {
+      OPENAGI_AUTH_TOKEN: "tok_existing_abc123",
+      OPENAGI_PROVIDER: "anthropic",
+      ANTHROPIC_API_KEY: "sk-ant-secret",
+      ANTHROPIC_MODEL: "claude-opus-4-8",
+      OPENAGI_DAILY_USD_LIMIT: "25",
+      LINEAR_API_KEY: "lin_secret"
+    }
+  });
+  assert.match(html, /tok_existing_abc123/, "existing token shown + submitted unchanged");
+  assert.match(html, /existing<\/strong> dashboard token/, "copy explains it's the current token");
+  // Prefill: provider radio, model, budget.
+  assert.match(html, /value="anthropic" checked/);
+  assert.match(html, /value="claude-opus-4-8"/);
+  assert.match(html, /value="25" min="0.5"/);
+  // Secrets never echo back, but their presence is visible.
+  assert.ok(!html.includes("sk-ant-secret"), "secret values must not be echoed into the page");
+  assert.ok(!html.includes("lin_secret"));
+  const savedMarkers = html.match(/✓ saved/g) ?? [];
+  assert.ok(savedMarkers.length >= 2, "ANTHROPIC_API_KEY and LINEAR_API_KEY show saved markers");
+});
+
+test("quick-save path exists after the auth step", () => {
+  const html = renderWizard({ existingEnv: {} });
+  assert.match(html, /Save now — set up the rest later/);
+  assert.match(html, /minimum viable setup/);
+});
+
+test("/health exposes firstRun for the Mac app", async () => {
+  const savedEnv = { a: process.env.ANTHROPIC_API_KEY, o: process.env.OPENAI_API_KEY, t: process.env.OPENAGI_AUTH_TOKEN };
+  delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.OPENAGI_AUTH_TOKEN;
+  const app = createHostedInterface(createDefaultRuntime(), { port: 0 });
+  const address = await app.listen();
+  try {
+    assert.equal(isFirstRun(), true);
+    let body = await (await fetch(`${address.url}/health`)).json();
+    assert.equal(body.firstRun, true);
+
+    process.env.OPENAGI_AUTH_TOKEN = "tok_x";
+    body = await (await fetch(`${address.url}/health?token=tok_x`)).json();
+    assert.equal(body.firstRun, false, "configured installs report firstRun:false");
+  } finally {
+    await app.close();
+    if (savedEnv.a) process.env.ANTHROPIC_API_KEY = savedEnv.a;
+    if (savedEnv.o) process.env.OPENAI_API_KEY = savedEnv.o;
+    if (savedEnv.t) process.env.OPENAGI_AUTH_TOKEN = savedEnv.t; else delete process.env.OPENAGI_AUTH_TOKEN;
+  }
+});


### PR DESCRIPTION
Walks through the first-run flow end to end and fixes what let an install sit dead for months.

## The walk-through findings
1. **Nothing happens on first launch** — the Mac app starts a keyless daemon and shows only a menubar icon. The wizard exists; nobody is taken to it.
2. **Re-running /setup is a footgun** — the token field always regenerates AND always submits, so re-saving to add one key silently rotates `OPENAGI_AUTH_TOKEN` and resets provider/model/budget to defaults.
3. **No prefill** — a re-run shows everything blank/default; you can't tell what's already configured.
4. **No quick path** — 8 steps, one save button at the very bottom, when key+token is the actual minimum.
5. **Tray reads "online"** while the agent can't think.

## Fixes
- `/health` exposes `firstRun`; the Mac app opens `/setup` once per launch on a fresh install (+ welcome notification).
- Wizard prefills from live env: token preserved on re-runs, provider/models/budget/public URL/BB identity prefilled, secrets show "✓ saved — blank keeps it" pills (never echoed back).
- "Save now — set up the rest later" button after the auth step; save output scrolls into view.
- Tray: "● setup needed" + "⚠ Finish setup" action.

## Tests
4 new cases in `test/onboarding.test.js` (incl. no-secret-echo and an HTTP-level firstRun check); full suite green; Swift builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)