### PR TITLE
fix: onboarding rough edges — traceless setup test, clearer BuildBetter path, partial-setup nudge

### DIFF
--- a/mac/Sources/OpenAGI/AppState.swift
+++ b/mac/Sources/OpenAGI/AppState.swift
@@ -148,6 +148,13 @@ final class AppState: ObservableObject {
         offeredSetupThisLaunch = true
         notify(title: "Welcome to OpenAGI", body: "Two minutes of setup and your agent is live.", path: "/setup")
         openDashboard(path: "/setup")
+      } else if h.firstRun != true && !providerConfigured && !offeredSetupThisLaunch {
+        // Partially-configured install (auth token saved, model key missing —
+        // isFirstRun() is false but the agent can't think). Nudge once per
+        // launch with a notification only; don't grab a window from someone
+        // who may be running deterministic-only on purpose.
+        offeredSetupThisLaunch = true
+        notify(title: "OpenAGI needs a model key", body: "The agent is running without an LLM. Tap to finish setup.", path: "/setup")
       }
     } catch {
       status = .down

--- a/src/abi-runtime.js
+++ b/src/abi-runtime.js
@@ -423,7 +423,9 @@ export class AbiRuntime {
       this.agentHost.ensureSpecialistAgent(propagated.specialist, "main");
     }
 
-    const memoryItem = this.memory.remember(
+    // Ephemeral signals (setup-wizard connectivity test) are not committed
+    // to memory — they're a round-trip check, not lived experience.
+    const memoryItem = options.ephemeral ? null : this.memory.remember(
       {
         source: signal.source,
         content: `${signal.summary}\nDecision: ${scrutiny.action}\nReasons: ${scrutiny.reasons.join(" ")}`,
@@ -468,7 +470,9 @@ export class AbiRuntime {
       outputId: output.id,
       createdAt: nowIso(),
       loop: "outputs-to-integrations",
-      summary: `Output ${output.id} fed back into memory tier ${memoryItem.tier}.`
+      summary: memoryItem
+        ? `Output ${output.id} fed back into memory tier ${memoryItem.tier}.`
+        : `Output ${output.id} was ephemeral — not committed to memory.`
     });
 
     return output;

--- a/src/agent-host.js
+++ b/src/agent-host.js
@@ -17,6 +17,10 @@ export class AgentHost {
     let agentId = input.agentId ?? "main";
     const text = String(input.text ?? input.message ?? "").trim();
     if (!text) throw new Error("Message text is required.");
+    // Ephemeral turns (setup-wizard "say hi" test) must leave no trace:
+    // no session in the dashboard list, no auto-task, no memory write,
+    // no outcome — they're a connectivity check, not a conversation.
+    const ephemeral = input.ephemeral === true;
 
     // Specialist routing: see if any active specialist's bounded scope matches.
     // The caller can opt out by passing input.routeTo === false (used by sub-agents to avoid loops).
@@ -37,7 +41,7 @@ export class AgentHost {
     // Auto-task detection — if the user said "remind me to X" / "todo: X" /
     // "I need to X", create a task in the user queue without requiring them
     // to invoke add_task. Best-effort; failures don't block the chat reply.
-    if (this.runtime?.tasks?.add && agentId === "main" && channel !== "autopilot") {
+    if (!ephemeral && this.runtime?.tasks?.add && agentId === "main" && channel !== "autopilot") {
       const detected = detectTaskInChat(text);
       if (detected) {
         try {
@@ -49,20 +53,23 @@ export class AgentHost {
       }
     }
 
-    const sessionBefore = this.store.appendMessage(sessionId, {
-      role: "user",
-      content: text,
-      agentId,
-      channel,
-      from,
-      metadata: input.metadata ?? {}
-    });
+    const sessionBefore = ephemeral
+      ? { id: sessionId, messages: [{ role: "user", content: text }] }
+      : this.store.appendMessage(sessionId, {
+          role: "user",
+          content: text,
+          agentId,
+          channel,
+          from,
+          metadata: input.metadata ?? {}
+        });
 
     const signal = this.messageToSignal({ text, channel, from, agent, sessionId, metadata: input.metadata ?? {} });
     const isSpecialist = agent.role === "specialist";
     const output = this.runtime.processSignal(signal, {
       scope: isSpecialist ? `specialist:${agent.id}` : "main",
-      parentSpecialistId: isSpecialist ? agent.id : null
+      parentSpecialistId: isSpecialist ? agent.id : null,
+      ephemeral
     });
 
     if (output.propagation?.specialist) {
@@ -118,7 +125,7 @@ export class AgentHost {
       }
     });
 
-    const outcomeRecord = this.runtime.outcomes?.record({
+    const outcomeRecord = ephemeral ? null : this.runtime.outcomes?.record({
       kind: input.origin === "autopilot" ? "autopilot-fire" : input.origin === "cron" ? "cron-fire" : "agent-reply",
       refId: null, // patched after we know assistant message id
       signalId: signal.id,
@@ -141,49 +148,53 @@ export class AgentHost {
       }
     }) ?? null;
 
-    const sessionAfter = this.store.appendMessage(sessionId, {
-      role: "assistant",
-      content: modelResult.text,
-      agentId,
-      channel,
-      from: "openagi",
-      metadata: {
-        provider: modelResult.provider,
-        model: modelResult.model,
-        responseId: modelResult.id,
-        outputId: output.id,
-        outcomeId: outcomeRecord?.id ?? null,
-        toolCalls: (modelResult.toolCalls ?? []).map((call) => ({
-          name: call.name,
-          arguments: call.arguments,
-          ok: call.result?.ok ?? false
-        }))
-      }
-    });
+    const sessionAfter = ephemeral
+      ? { id: sessionId, messages: [{ role: "user", content: text }, { role: "assistant", content: modelResult.text }] }
+      : this.store.appendMessage(sessionId, {
+          role: "assistant",
+          content: modelResult.text,
+          agentId,
+          channel,
+          from: "openagi",
+          metadata: {
+            provider: modelResult.provider,
+            model: modelResult.model,
+            responseId: modelResult.id,
+            outputId: output.id,
+            outcomeId: outcomeRecord?.id ?? null,
+            toolCalls: (modelResult.toolCalls ?? []).map((call) => ({
+              name: call.name,
+              arguments: call.arguments,
+              ok: call.result?.ok ?? false
+            }))
+          }
+        });
 
     if (outcomeRecord) outcomeRecord.refId = sessionAfter.messages.at(-1)?.id ?? null;
 
-    this.runtime.memory.remember(
-      {
-        source: "agent-host",
-        scope: agent.role === "specialist" ? `specialist:${agent.id}` : "main",
-        content: `Session ${sessionId} user asked: ${text}\nAgent replied: ${modelResult.text}`,
-        tags: ["agent-turn", channel, agentId],
-        novelty: output.scrutiny.dimensions.novelty,
-        risk: output.scrutiny.dimensions.risk,
-        repetition: output.scrutiny.dimensions.repetition,
-        specificity: 0.6,
-        metadata: {
-          sessionId,
-          agentId,
-          outputId: output.id
+    if (!ephemeral) {
+      this.runtime.memory.remember(
+        {
+          source: "agent-host",
+          scope: agent.role === "specialist" ? `specialist:${agent.id}` : "main",
+          content: `Session ${sessionId} user asked: ${text}\nAgent replied: ${modelResult.text}`,
+          tags: ["agent-turn", channel, agentId],
+          novelty: output.scrutiny.dimensions.novelty,
+          risk: output.scrutiny.dimensions.risk,
+          repetition: output.scrutiny.dimensions.repetition,
+          specificity: 0.6,
+          metadata: {
+            sessionId,
+            agentId,
+            outputId: output.id
+          }
+        },
+        {
+          source: "agent-host",
+          strength: output.scrutiny.score
         }
-      },
-      {
-        source: "agent-host",
-        strength: output.scrutiny.score
-      }
-    );
+      );
+    }
 
     return {
       id: createId("turn"),

--- a/src/channels.js
+++ b/src/channels.js
@@ -32,7 +32,10 @@ export class ChannelManager {
       agentId: body.agentId ?? "main",
       sessionId: body.sessionId,
       text: body.text ?? body.message,
-      metadata: body.metadata ?? {}
+      metadata: body.metadata ?? {},
+      // Ephemeral turns (setup-wizard test message) leave no trace: no
+      // session, no memory write, no outcome — just a model round-trip.
+      ephemeral: body.ephemeral === true
     });
   }
 

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -205,7 +205,9 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
         const body = await readJson(req);
         if (!channels) return sendJson(res, 503, { error: "agent-host-disabled" });
         try {
-          const turn = await channels.handleLocalMessage({ text: body.text ?? "Say hi in one short sentence.", from: "setup" });
+          // ephemeral: the connectivity test must not seed a session, task,
+          // memory item, or outcome — it's plumbing, not conversation.
+          const turn = await channels.handleLocalMessage({ text: body.text ?? "Say hi in one short sentence.", from: "setup", ephemeral: true });
           return sendJson(res, 200, { reply: turn.reply, model: turn.model });
         } catch (error) {
           return sendJson(res, 500, { error: error.message });

--- a/src/setup-wizard.js
+++ b/src/setup-wizard.js
@@ -288,7 +288,7 @@ export function renderWizard({ proposedToken, existingEnv = {} } = {}) {
         <summary>BuildBetter — call action items become tasks</summary>
         <div style="padding-top:10px;" class="grid">
           <p class="sub">Pulls action_item / commitment / follow_up extractions from your recent calls. Polls every 15 min, and (optionally) syncs instantly via webhook.</p>
-          <p class="sub">Already connected BuildBetter on the <code>MCP</code> tab? You can leave everything below blank — OpenAGI reuses that login.</p>
+          <p class="sub"><strong>Easiest path:</strong> check <strong>BuildBetter</strong> in step 6 below (one-click OAuth) and leave this card blank — task sync reuses that login automatically, identity included. The fields here are only for API-key setups or webhook push.</p>
           <div><label>BUILDBETTER_API_KEY <span class="sub">(optional if connected via MCP)</span>${saved("BUILDBETTER_API_KEY")}</label><input type="password" name="BUILDBETTER_API_KEY" autocomplete="off"></div>
           <div><label>BUILDBETTER_USER_EMAIL <span class="sub">(optional — auto-detected from your login)</span></label><input type="email" name="BUILDBETTER_USER_EMAIL" placeholder="you@example.com" value="${val("BUILDBETTER_USER_EMAIL")}"></div>
           <div><label>BUILDBETTER_USER_NAME <span class="sub">(optional — only needed if auto-detect can't pinpoint you)</span></label><input type="text" name="BUILDBETTER_USER_NAME" placeholder="Your Name" value="${val("BUILDBETTER_USER_NAME")}"></div>

--- a/test/ephemeral-turn.test.js
+++ b/test/ephemeral-turn.test.js
@@ -1,0 +1,40 @@
+// The setup wizard's connectivity test must leave no trace: no session in
+// the dashboard, no auto-detected task, no memory items, no outcome record.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createDefaultRuntime } from "../src/index.js";
+import { ChannelManager } from "../src/channels.js";
+
+test("ephemeral turns leave no session, task, memory, or outcome", async () => {
+  const runtime = createDefaultRuntime();
+  const memBefore = runtime.memory.items.size;
+  const outcomesBefore = runtime.outcomes.recent(100).length;
+
+  const turn = await runtime.agentHost.handleMessage({
+    from: "setup",
+    text: "remind me to check this works", // would normally auto-create a task
+    ephemeral: true
+  });
+
+  assert.ok(turn.reply.length > 0, "still produces a reply");
+  assert.equal(runtime.agentHost.store.listSessions().length, 0, "no session persisted");
+  assert.equal(runtime.tasks.list({ limit: 50 }).length, 0, "no auto-task created");
+  assert.equal(runtime.memory.items.size, memBefore, "no memory written (signal or turn)");
+  assert.equal(runtime.outcomes.recent(100).length, outcomesBefore, "no outcome recorded");
+});
+
+test("normal turns still persist everything", async () => {
+  const runtime = createDefaultRuntime();
+  await runtime.agentHost.handleMessage({ from: "user", text: "hello there agent" });
+  assert.equal(runtime.agentHost.store.listSessions().length, 1);
+  assert.ok(runtime.memory.items.size > 0);
+});
+
+test("ChannelManager forwards the ephemeral flag", async () => {
+  const seen = [];
+  const channels = new ChannelManager({ agentHost: { runtime: {}, handleMessage: async (input) => { seen.push(input); return { reply: "ok" }; } } });
+  await channels.handleLocalMessage({ text: "hi", ephemeral: true });
+  await channels.handleLocalMessage({ text: "hi" });
+  assert.equal(seen[0].ephemeral, true);
+  assert.equal(seen[1].ephemeral, false);
+});


### PR DESCRIPTION
Stacked on #12 (merge that first; GitHub retargets this to main).

- **Traceless setup test**: the wizard's "say hi" connectivity test was seeding a session, potentially an auto-task, memory items, and an outcome record. New `ephemeral` turn support skips all persistence while keeping the model round-trip.
- **BuildBetter path clarity**: step 5's card now steers to the one-click step-6 OAuth checkbox, with the manual fields framed as API-key/webhook-only.
- **Partial-setup nudge**: installs with a token but no model key (`firstRun` false, agent brainless) get a once-per-launch notification → /setup. Notification only — no window grab.

Tests: 3 new; full suite 201/201; Swift builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)