### PR TITLE
fix: build-mac-app.sh auto-falls back to Xcode when CommandLineTools is broken

### DIFF
--- a/scripts/build-mac-app.sh
+++ b/scripts/build-mac-app.sh
@@ -52,6 +52,25 @@ echo "▶ OpenAGI.app build · version ${VERSION} · ${NODE_ARCH}"
 
 mkdir -p "${BUILD_DIR}/cache"
 
+# Toolchain sanity: a bare CommandLineTools install can't provide the macOS
+# platform SDK swift-build needs ("unable to lookup item 'PlatformPath'").
+# When the active toolchain is broken and a full Xcode exists, use it via
+# DEVELOPER_DIR instead of failing — no sudo/xcode-select required.
+if [[ -z "${DEVELOPER_DIR:-}" ]] && ! xcrun --sdk macosx --show-sdk-platform-path >/dev/null 2>&1; then
+  for XC in /Applications/Xcode.app /Applications/Xcode-beta.app; do
+    if [[ -d "${XC}/Contents/Developer" ]]; then
+      export DEVELOPER_DIR="${XC}/Contents/Developer"
+      echo "▶ Active toolchain can't build for macOS — using ${XC} (DEVELOPER_DIR)"
+      break
+    fi
+  done
+  if [[ -z "${DEVELOPER_DIR:-}" ]]; then
+    echo "ERROR: the active developer toolchain ($(xcode-select -p)) can't provide the macOS SDK and no Xcode.app was found." >&2
+    echo "Fix with: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer (after installing Xcode)" >&2
+    exit 1
+  fi
+fi
+
 # 1. Compile the Swift menubar binary
 echo "▶ Compiling Swift binary"
 (cd "${MAC_DIR}" && swift build -c release --product OpenAGI)


### PR DESCRIPTION
Running `./build-mac-app.sh` with `xcode-select` pointed at a bare CommandLineTools install fails with:

```
xcrun: error: unable to lookup item 'PlatformPath' from command line tools installation
```

The script now probes `xcrun --sdk macosx --show-sdk-platform-path` before compiling; when the active toolchain can't provide the macOS platform and an Xcode.app / Xcode-beta.app exists, it exports `DEVELOPER_DIR` to it automatically (no sudo needed). If no Xcode exists either, it errors with the exact `xcode-select` fix command instead of the cryptic xcrun message.

Verified on a machine exhibiting the failure: script now self-heals and builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)