### PR TITLE
fix(mac): zero Swift build warnings

### DIFF
--- a/mac/Sources/OpenAGI/AppDelegate.swift
+++ b/mac/Sources/OpenAGI/AppDelegate.swift
@@ -12,7 +12,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
       NSApp.setActivationPolicy(.accessory) // No Dock icon, only menubar.
 
       UNUserNotificationCenter.current().delegate = self
-      UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
+      _ = try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound])
 
       LoginItem.registerOnFirstLaunchIfNeeded()
 

--- a/mac/Sources/OpenAGI/Capture/ActivityTracker.swift
+++ b/mac/Sources/OpenAGI/Capture/ActivityTracker.swift
@@ -20,10 +20,10 @@ final class ActivityTracker {
     observer = center.addObserver(forName: NSWorkspace.didActivateApplicationNotification, object: nil, queue: .main) { [weak self] note in
       guard let self else { return }
       let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
-      self.handleAppFocus(bundleId: app?.bundleIdentifier, name: app?.localizedName)
+      Task { @MainActor in self.handleAppFocus(bundleId: app?.bundleIdentifier, name: app?.localizedName) }
     }
     pollTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
-      self?.pollFrontmostWindow()
+      Task { @MainActor in self?.pollFrontmostWindow() }
     }
     pollFrontmostWindow()
   }

--- a/mac/Sources/OpenAGI/Capture/CaptureBridge.swift
+++ b/mac/Sources/OpenAGI/Capture/CaptureBridge.swift
@@ -35,7 +35,7 @@ final class CaptureBridge {
     // (e.g. a home Mac mini). Plumbing to a remote URL + bearer token
     // is the same as localhost; just a settings field + UserDefaults.
     // See docs/ROADMAP.md for the full design.
-    var url = URL(string: "http://127.0.0.1:43210/observations")!
+    let url = URL(string: "http://127.0.0.1:43210/observations")!
     var req = URLRequest(url: url)
     req.httpMethod = "POST"
     req.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/mac/Sources/OpenAGI/Capture/CaptureController.swift
+++ b/mac/Sources/OpenAGI/Capture/CaptureController.swift
@@ -15,7 +15,7 @@ final class CaptureController {
   func start() {
     apply()
     retentionTimer = Timer.scheduledTimer(withTimeInterval: 6 * 3600, repeats: true) { [weak self] _ in
-      self?.runRetention()
+      Task { @MainActor in self?.runRetention() }
     }
     runRetention()
   }

--- a/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
+++ b/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
@@ -179,7 +179,9 @@ final class ScreenCapturer {
     }
   }
 
-  private static func runOcr(image: CGImage, completion: @escaping (String, Double) -> Void) {
+  // nonisolated: OCR deliberately runs on ocrQueue, off the main actor —
+  // it touches no actor state (Vision request + completion callback only).
+  nonisolated private static func runOcr(image: CGImage, completion: @escaping (String, Double) -> Void) {
     let req = VNRecognizeTextRequest { request, error in
       let observations = request.results as? [VNRecognizedTextObservation] ?? []
       var pieces: [String] = []

--- a/mac/Sources/OpenAGI/PrivacyPanel.swift
+++ b/mac/Sources/OpenAGI/PrivacyPanel.swift
@@ -45,7 +45,7 @@ struct PrivacyPanel: View {
         section(title: "Status") {
           HStack {
             Toggle("Capture enabled", isOn: $settings.enabled)
-              .onChange(of: settings.enabled) { _ in CaptureController.shared.apply() }
+              .onChange(of: settings.enabled) { _, _ in CaptureController.shared.apply() }
             Spacer()
             if let until = settings.pausedUntil, Date() < until {
               Text("Paused until \(until.formatted(date: .omitted, time: .shortened))")


### PR DESCRIPTION
Resolves all nine warnings in the Mac target — mostly real concurrency smells, not noise:

- Timer/notification closures in `ActivityTracker` and `CaptureController` were calling main-actor methods from nonisolated contexts; now hop explicitly via `Task { @MainActor }`.
- `ScreenCapturer.runOcr` was implicitly main-actor-isolated but is deliberately invoked on `ocrQueue` — marked `nonisolated` (it touches no actor state), fixing the isolation at the declaration rather than papering over call sites.
- `requestAuthorization` → async variant; `var url` → `let`; deprecated `onChange(of:perform:)` → two-param form.

`swift build`: zero warnings, zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)