### PR TITLE
fix: systemd Restart=always (wizard save killed the daemon on Linux)

### DIFF
--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -38,7 +38,11 @@ ExecStart=${NODE_BIN} ${PROJECT_DIR}/examples/hosted-server.js
 WorkingDirectory=${PROJECT_DIR}
 EnvironmentFile=-${2}/.env
 Environment=OPENAGI_DATA_DIR=${2}
-Restart=on-failure
+# Restart=always (not on-failure): the setup wizard applies new settings by
+# asking the daemon to restart itself — a CLEAN exit(0) via /control/restart.
+# on-failure would NOT bring it back after that, leaving the daemon dead the
+# moment a user saves the wizard. always also covers OOM/clean shutdowns.
+Restart=always
 RestartSec=10s
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
On Linux/device installs, saving the setup wizard left the daemon dead.

The wizard applies settings by calling `/control/restart`, which does a clean `process.exit(0)` and relies on the service manager to respawn. The systemd unit shipped `Restart=on-failure`, which by definition does **not** restart after a clean exit — so the daemon stopped and never came back the moment a user completed setup.

`Restart=always` fixes it (still covers crashes/OOM). Found and verified while installing OpenAGI as a main on a Raspberry Pi CM5 (Distiller): with the fix, a `/control/restart` brings the daemon back within RestartSec and `/health` recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)