### PR TITLE
fix: OAuth browser-open crashes the daemon on headless Linux

### DIFF
--- a/src/mcp-oauth.js
+++ b/src/mcp-oauth.js
@@ -343,7 +343,7 @@ export function openInBrowser(url, { platform = process.platform, env = process.
   }
 }
 
-function startCallbackServer() {
+export function startCallbackServer() {
   return new Promise((resolve, reject) => {
     let resolveCb, rejectCb;
     const callback = new Promise((res, rej) => { resolveCb = res; rejectCb = rej; });
@@ -377,7 +377,16 @@ function startCallbackServer() {
       }
     });
     server.on("error", reject);
-    server.listen(0, "127.0.0.1", () => {
+    // Default: an OS-assigned random loopback port (fine when the browser and
+    // daemon are on the same machine). On a HEADLESS main reached from another
+    // device's browser, set OPENAGI_OAUTH_CALLBACK_PORT to a FIXED port and
+    // SSH-tunnel it from the browser machine:
+    //   ssh -L 8765:127.0.0.1:8765 distiller    # on the laptop
+    //   OPENAGI_OAUTH_CALLBACK_PORT=8765         # on the main
+    // Then the loopback redirect the browser hits tunnels back to the daemon.
+    const fixed = Number.parseInt(process.env.OPENAGI_OAUTH_CALLBACK_PORT ?? "", 10);
+    const listenPort = Number.isInteger(fixed) && fixed > 0 ? fixed : 0;
+    server.listen(listenPort, "127.0.0.1", () => {
       const port = server.address().port;
       resolve({ server, port, callback });
     });

--- a/src/mcp-oauth.js
+++ b/src/mcp-oauth.js
@@ -316,16 +316,30 @@ function defaultPrintAuthUrl({ name, url }) {
   process.stderr.write(banner);
 }
 
-function openInBrowser(url) {
-  // Best-effort, never throws.
+export function openInBrowser(url, { platform = process.platform, env = process.env, spawnFn = spawn } = {}) {
+  // Best-effort. On a HEADLESS box (no display) there's no browser to open —
+  // and on Linux a missing `xdg-open` previously CRASHED the daemon, because
+  // spawn() reports a missing binary via an async 'error' event, not a sync
+  // throw, so the try/catch never caught it. Now: skip the spawn when there's
+  // no display, and always attach an 'error' handler so a missing/again-failing
+  // opener degrades to the printed URL instead of taking down the process.
+  // (The auth URL is also surfaced to the dashboard via onAuthUrl → pendingAuthUrl.)
+  if (platform === "linux" && !env.DISPLAY && !env.WAYLAND_DISPLAY) {
+    return { opened: false, reason: "headless" }; // rely on the printed URL + dashboard
+  }
   try {
-    const cmd = process.platform === "darwin" ? "open"
-      : process.platform === "win32" ? "cmd"
+    const cmd = platform === "darwin" ? "open"
+      : platform === "win32" ? "cmd"
       : "xdg-open";
-    const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
-    spawn(cmd, args, { detached: true, stdio: "ignore" }).unref();
+    const args = platform === "win32" ? ["/c", "start", "", url] : [url];
+    const child = spawnFn(cmd, args, { detached: true, stdio: "ignore" });
+    // CRITICAL: handle the async 'error' event (missing binary etc) so it
+    // never bubbles up as an unhandled 'error' and kills the daemon.
+    child.on?.("error", () => { /* opener missing/failed — printed URL is the fallback */ });
+    child.unref?.();
+    return { opened: true };
   } catch {
-    /* fall back to printed URL */
+    return { opened: false, reason: "spawn-threw" };
   }
 }
 

--- a/test/mcp-oauth-open-browser.test.js
+++ b/test/mcp-oauth-open-browser.test.js
@@ -43,3 +43,24 @@ test("macOS opens via `open`", () => {
   assert.equal(calls[0].cmd, "open");
   assert.deepEqual(calls[0].args, ["https://x"]);
 });
+
+// Headless OAuth completion: the callback port must be pinnable so it can be
+// SSH-tunneled from the browser machine to a headless main.
+test("OPENAGI_OAUTH_CALLBACK_PORT pins the callback port (else random)", async () => {
+  const { startCallbackServer } = await import("../src/mcp-oauth.js");
+  const saved = process.env.OPENAGI_OAUTH_CALLBACK_PORT;
+  try {
+    process.env.OPENAGI_OAUTH_CALLBACK_PORT = "8765";
+    const fixed = await startCallbackServer();
+    assert.equal(fixed.port, 8765, "fixed port honored");
+    fixed.server.close();
+
+    delete process.env.OPENAGI_OAUTH_CALLBACK_PORT;
+    const rand = await startCallbackServer();
+    assert.ok(rand.port > 0 && rand.port !== 8765, "random port when unset");
+    rand.server.close();
+  } finally {
+    if (saved === undefined) delete process.env.OPENAGI_OAUTH_CALLBACK_PORT;
+    else process.env.OPENAGI_OAUTH_CALLBACK_PORT = saved;
+  }
+});

--- a/test/mcp-oauth-open-browser.test.js
+++ b/test/mcp-oauth-open-browser.test.js
@@ -1,0 +1,45 @@
+// Regression: opening the OAuth URL must never crash the daemon. On a headless
+// Linux box (a Distiller/Pi main) `xdg-open` is missing, and spawn() reports
+// that via an ASYNC 'error' event — which used to be unhandled and took the
+// whole process down on every OAuth MCP connect.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { EventEmitter } from "node:events";
+import { openInBrowser } from "../src/mcp-oauth.js";
+
+test("headless Linux (no display) skips the browser spawn entirely", () => {
+  let spawned = false;
+  const spawnFn = () => { spawned = true; return new EventEmitter(); };
+  const r = openInBrowser("https://x/authorize", { platform: "linux", env: {}, spawnFn });
+  assert.equal(r.opened, false);
+  assert.equal(r.reason, "headless");
+  assert.equal(spawned, false, "must not even try to spawn a browser on a headless box");
+});
+
+test("Linux WITH a display attempts the spawn and attaches an error handler", () => {
+  const child = new EventEmitter();
+  child.unref = () => {};
+  const r = openInBrowser("https://x/authorize", { platform: "linux", env: { DISPLAY: ":0" }, spawnFn: () => child });
+  assert.equal(r.opened, true);
+  // The async 'error' event (missing binary) must be handled — emitting it
+  // with a listener present does NOT throw; without the listener EventEmitter
+  // would rethrow and crash the process.
+  assert.ok(child.listenerCount("error") >= 1, "error handler must be attached");
+  assert.doesNotThrow(() => child.emit("error", Object.assign(new Error("spawn xdg-open ENOENT"), { code: "ENOENT" })));
+});
+
+test("a spawn that throws synchronously degrades gracefully", () => {
+  const r = openInBrowser("https://x", { platform: "linux", env: { DISPLAY: ":0" }, spawnFn: () => { throw new Error("nope"); } });
+  assert.equal(r.opened, false);
+  assert.equal(r.reason, "spawn-threw");
+});
+
+test("macOS opens via `open`", () => {
+  const calls = [];
+  const child = new EventEmitter(); child.unref = () => {};
+  const spawnFn = (cmd, args) => { calls.push({ cmd, args }); return child; };
+  const r = openInBrowser("https://x", { platform: "darwin", env: {}, spawnFn });
+  assert.equal(r.opened, true);
+  assert.equal(calls[0].cmd, "open");
+  assert.deepEqual(calls[0].args, ["https://x"]);
+});


### PR DESCRIPTION
Connecting any OAuth MCP server on a headless Linux **main** (a Pi / Pamir Distiller) crashed the entire daemon.

`openInBrowser()` spawned `xdg-open` inside a `try/catch`, but a missing binary is reported by `spawn()` via an **async `'error'` event** — which the `try/catch` can't catch — so it bubbled up as an unhandled `'error'` and killed the process. With `Restart=always`, every "Connect" click crash-looped the daemon, showing as "⏳ waiting for handshake" that never resolves.

### Fix
- Skip the browser-open on headless Linux (no `DISPLAY`/`WAYLAND_DISPLAY`) — the auth URL is already printed to the log and surfaced to the dashboard via `pendingAuthUrl`.
- Always attach a child `'error'` handler so a missing/failing opener degrades to the printed URL instead of crashing.
- `openInBrowser` is now exported + injectable (`platform`/`env`/`spawnFn`), returns `{opened, reason}`.

Found while installing OpenAGI as a main on a Raspberry Pi CM5 (Distiller). Tests: 4 cases; full suite 249/249.

> Note: this fixes the **crash**. Completing OAuth against a headless main viewed from a *remote* browser is a separate limitation — the OAuth callback redirects to `127.0.0.1:<random>` on the device, unreachable from the remote browser. For headless mains, prefer API-key/bearer auth (e.g. `BUILDBETTER_API_KEY`) over OAuth MCP. A reachable-callback flow is future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)