### PR TITLE
feat: self-update (openagi update + opt-in daily auto-update)

### DIFF
--- a/bin/openagi.js
+++ b/bin/openagi.js
@@ -152,6 +152,28 @@ function cmdUnpair() {
   return 0;
 }
 
+async function cmdUpdate(positional, flags) {
+  const { client, target } = makeClient(flags);
+  const checkOnly = positional.includes("--check") || flags.check;
+  // GET = dry check, POST = apply + restart. The daemon owns the git checkout.
+  const res = checkOnly ? await client.request("GET", "/control/update") : await client.request("POST", "/control/update");
+  if (flags.json) { console.log(JSON.stringify(res.json ?? { error: res.error ?? res.status }, null, 2)); return res.ok ? 0 : 1; }
+  if (!res.ok) { console.error(c(RED, `✗ ${res.error ?? "HTTP " + res.status}`)); return 1; }
+  const r = res.json ?? {};
+  if (checkOnly) {
+    if (r.updateAvailable) console.log(c(YELLOW, `↑ update available: ${r.current} → ${r.latest} (${r.behind} commit${r.behind === 1 ? "" : "s"} behind on ${r.branch})`));
+    else console.log(c(GREEN, `✓ up to date (${r.current} on ${r.branch ?? "?"})`) + (r.reason ? c(DIM, ` — ${r.reason}`) : ""));
+    return 0;
+  }
+  if (r.updated) {
+    console.log(c(GREEN, `✓ updated ${r.from} → ${r.to}`) + (r.depsChanged ? c(DIM, " (deps reinstalled)") : ""));
+    console.log(c(DIM, `${target.remote ? "main" : "daemon"} is restarting with the new code…`));
+  } else {
+    console.log(c(GREEN, `✓ ${r.reason ?? "nothing to do"}`));
+  }
+  return 0;
+}
+
 async function cmdTick(flags) {
   const { client } = makeClient(flags);
   const res = await client.tick();
@@ -171,6 +193,8 @@ ${c(BOLD, "Use it (local, or a remote main):")}
   openagi status              health, provider, memory, task counts
   openagi doctor              diagnose setup/connection and print fixes
   openagi setup               print the dashboard/setup URL + token
+  openagi update [--check]    fast-forward + restart (or just check); set
+                              OPENAGI_AUTO_UPDATE=1 for a daily auto-update
   openagi tick                fire a scheduler tick
 
 ${c(BOLD, "Turn this device into a node of a remote main:")}
@@ -195,6 +219,7 @@ async function main() {
       case "setup": return await cmdSetup(flags);
       case "pair": return cmdPair(positional, flags);
       case "unpair": return cmdUnpair();
+      case "update": return await cmdUpdate(positional, flags);
       case "tick": return await cmdTick(flags);
       default:
         console.error(c(RED, `unknown command: ${cmd}`));

--- a/docs/MAIN-AND-NODES.md
+++ b/docs/MAIN-AND-NODES.md
@@ -91,7 +91,17 @@ local daemon.
 | `openagi status` | health, provider, memory, task counts |
 | `openagi doctor` | diagnose setup/connection, print fixes |
 | `openagi setup` | print the dashboard/setup URL + token |
+| `openagi update [--check]` | fast-forward the checkout + restart (or just check) |
 | `openagi pair <url> [--token T]` / `unpair` | save / forget a remote main |
 | `openagi tick` | fire a scheduler tick |
 
 Global flags: `--remote <url>`, `--token <token>`, `--json`.
+
+## Keeping it current
+
+The daemon updates itself — no manual `git pull` on the device.
+
+- **Manual:** `openagi update` (locally or `--remote` against the main) fast-forwards the git checkout, reinstalls deps if `package.json` changed, and restarts with the new code. `openagi update --check` just reports whether a newer version is available. Fast-forward only — it never clobbers local commits.
+- **Automatic (opt-in):** set `OPENAGI_AUTO_UPDATE=1` (and optionally `OPENAGI_AUTO_UPDATE_AT=HH:MM`, default `04:30`) in the main's `.env`. A daily cron job checks for updates and applies + restarts when one ships. Off by default; visible/toggleable in the dashboard's Cron tab.
+
+Both rely on the supervisor (systemd `Restart=always`, launchd, or the Mac app) to respawn after the update — which the install scripts already configure.

--- a/src/abi-runtime.js
+++ b/src/abi-runtime.js
@@ -228,6 +228,17 @@ export class AbiRuntime {
         task: "retirement-sweep",
         dailyAt: "04:00"
       });
+      // Opt-in self-update: when OPENAGI_AUTO_UPDATE is truthy, the daemon
+      // checks its git checkout daily and fast-forwards + restarts if a newer
+      // version is available. Off by default — registered disabled so it's
+      // visible in the dashboard and can be toggled without an env change.
+      this.cron.addJob({
+        id: "self-update",
+        name: "Self-update (fast-forward + restart when a new version ships)",
+        enabled: /^(1|true|yes|on)$/i.test(process.env.OPENAGI_AUTO_UPDATE ?? ""),
+        task: "self-update",
+        dailyAt: process.env.OPENAGI_AUTO_UPDATE_AT ?? "04:30"
+      });
       this.cron.addJob({
         id: "weekly-scrutiny-fit",
         name: "Weekly scrutiny weight fit",
@@ -541,6 +552,18 @@ export class AbiRuntime {
       }
       if (job.task === "condense") {
         return this.condenser.condense({ now });
+      }
+      if (job.task === "self-update") {
+        const { applyUpdate } = await import("./self-update.js");
+        const result = await applyUpdate();
+        if (result.updated) {
+          this.events?.emit?.("self-update", { at: nowIso(), from: result.from, to: result.to });
+          // Respawn with the new code (systemd Restart=always / launchd
+          // KeepAlive / Mac DaemonController bring it back). Defer so the
+          // tick result can flush first.
+          setTimeout(() => process.exit(0), 500);
+        }
+        return result;
       }
       if (job.task === "retirement-sweep") {
         const retired = this.propagation.retirementSweep?.() ?? [];

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -722,6 +722,25 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
         setTimeout(() => process.exit(0), 200);
         return;
       }
+      if (method === "GET" && pathname === "/control/update") {
+        // Dry check — is a newer version available? (no changes applied)
+        const { checkForUpdate } = await import("./self-update.js");
+        return sendJson(res, 200, await checkForUpdate());
+      }
+      if (method === "POST" && pathname === "/control/update") {
+        // Self-update: fast-forward the checkout, reinstall deps if needed,
+        // then exit(0) so the supervisor (systemd Restart=always / launchd
+        // KeepAlive / Mac DaemonController) respawns with the new code. No-op
+        // with a reason when already current or not fast-forwardable.
+        const { applyUpdate } = await import("./self-update.js");
+        const result = await applyUpdate();
+        sendJson(res, result.updated ? 202 : 200, result);
+        if (result.updated) {
+          runtime.events?.emit?.("self-update", { at: new Date().toISOString(), from: result.from, to: result.to });
+          setTimeout(() => process.exit(0), 300); // respawn with new code
+        }
+        return;
+      }
       if (method === "GET" && pathname === "/integrations/status") {
         // Unified integrations view. Every source/channel/MCP catalog
         // entry shows up here, with whichever paths apply (API key vs.

--- a/src/self-update.js
+++ b/src/self-update.js
@@ -1,0 +1,76 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Self-update: the daemon can check for and apply updates to its own git
+// checkout, then exit(0) so the service manager (systemd Restart=always /
+// launchd KeepAlive) respawns it with the new code. Exposed three ways:
+//   - `openagi update` CLI → POST /control/update
+//   - POST /control/update endpoint (dashboard / CLI)
+//   - opt-in daemon cron job (OPENAGI_AUTO_UPDATE=1) that applies on a schedule
+//
+// Fast-forward only: never clobbers local changes. No-op (with a clear reason)
+// when there's no upstream, the checkout has diverged, or it's already current.
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+async function gitRun(args, cwd = REPO_ROOT) {
+  const { stdout } = await execFileAsync("git", args, { cwd, timeout: 120000 });
+  return stdout.trim();
+}
+
+async function defaultInstallDeps() {
+  await execFileAsync("npm", ["install", "--omit=dev", "--no-audit", "--no-fund"], { cwd: REPO_ROOT, timeout: 300000 });
+}
+
+// Inspect the checkout vs its upstream. Pure read (a `git fetch` + rev compares).
+export async function checkForUpdate({ run = gitRun } = {}) {
+  let branch, current;
+  try {
+    branch = await run(["rev-parse", "--abbrev-ref", "HEAD"]);
+    current = await run(["rev-parse", "--short", "HEAD"]);
+  } catch (error) {
+    return { ok: false, reason: `not a git checkout: ${error.message}`, updateAvailable: false };
+  }
+  let upstream = null;
+  try { upstream = await run(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]); }
+  catch { return { ok: true, branch, current, upstream: null, behind: 0, ahead: 0, updateAvailable: false, reason: "no upstream tracking branch" }; }
+
+  try { await run(["fetch", "--quiet"]); }
+  catch (error) { return { ok: false, branch, current, upstream, updateAvailable: false, reason: `fetch failed: ${error.message}` }; }
+
+  const behind = Number.parseInt(await run(["rev-list", "--count", `HEAD..${upstream}`]), 10) || 0;
+  const ahead = Number.parseInt(await run(["rev-list", "--count", `${upstream}..HEAD`]), 10) || 0;
+  const latest = await run(["rev-parse", "--short", upstream]);
+  return {
+    ok: true, branch, current, upstream, latest, behind, ahead,
+    updateAvailable: behind > 0,
+    canFastForward: behind > 0 && ahead === 0
+  };
+}
+
+// Apply an available update (fast-forward), reinstalling deps if package.json
+// changed. Returns { updated, ... }. Does NOT restart — the caller decides
+// (the endpoint/cron schedule a process exit so the supervisor respawns).
+export async function applyUpdate({ run = gitRun, installDeps = defaultInstallDeps } = {}) {
+  const status = await checkForUpdate({ run });
+  if (!status.ok) return { updated: false, ...status };
+  if (!status.updateAvailable) return { updated: false, reason: "already up to date", ...status };
+  if (!status.canFastForward) {
+    return { updated: false, reason: `local commits / divergence (ahead ${status.ahead}) — not fast-forwardable; resolve manually`, ...status };
+  }
+
+  // Which files change — decide whether deps need reinstalling.
+  const changedFiles = await run(["diff", "--name-only", "HEAD", status.upstream]).catch(() => "");
+  const depsChanged = /(^|\n)(package\.json|package-lock\.json)\b/.test(changedFiles);
+
+  await run(["merge", "--ff-only", status.upstream]);
+  if (depsChanged) {
+    try { await installDeps(); }
+    catch (error) { return { updated: true, from: status.current, to: status.latest, depsChanged: true, depsInstalled: false, depsError: error.message, branch: status.branch, behind: status.behind }; }
+  }
+  const to = await run(["rev-parse", "--short", "HEAD"]);
+  return { updated: true, from: status.current, to, behind: status.behind, depsChanged, depsInstalled: depsChanged ? true : undefined, branch: status.branch };
+}

--- a/test/mcp-oauth-open-browser.test.js
+++ b/test/mcp-oauth-open-browser.test.js
@@ -44,20 +44,33 @@ test("macOS opens via `open`", () => {
   assert.deepEqual(calls[0].args, ["https://x"]);
 });
 
+// Pick a port the OS says is currently free, so the test doesn't collide with
+// whatever else is running on the dev machine (a hardcoded port can — and did —
+// clash with a real app).
+async function freePort() {
+  const { createServer } = await import("node:net");
+  return new Promise((resolve, reject) => {
+    const s = createServer();
+    s.on("error", reject);
+    s.listen(0, "127.0.0.1", () => { const p = s.address().port; s.close(() => resolve(p)); });
+  });
+}
+
 // Headless OAuth completion: the callback port must be pinnable so it can be
 // SSH-tunneled from the browser machine to a headless main.
 test("OPENAGI_OAUTH_CALLBACK_PORT pins the callback port (else random)", async () => {
   const { startCallbackServer } = await import("../src/mcp-oauth.js");
   const saved = process.env.OPENAGI_OAUTH_CALLBACK_PORT;
+  const pinned = await freePort();
   try {
-    process.env.OPENAGI_OAUTH_CALLBACK_PORT = "8765";
+    process.env.OPENAGI_OAUTH_CALLBACK_PORT = String(pinned);
     const fixed = await startCallbackServer();
-    assert.equal(fixed.port, 8765, "fixed port honored");
+    assert.equal(fixed.port, pinned, "fixed port honored");
     fixed.server.close();
 
     delete process.env.OPENAGI_OAUTH_CALLBACK_PORT;
     const rand = await startCallbackServer();
-    assert.ok(rand.port > 0 && rand.port !== 8765, "random port when unset");
+    assert.ok(rand.port > 0 && rand.port !== pinned, "random port when unset");
     rand.server.close();
   } finally {
     if (saved === undefined) delete process.env.OPENAGI_OAUTH_CALLBACK_PORT;

--- a/test/self-update.test.js
+++ b/test/self-update.test.js
@@ -1,0 +1,136 @@
+// Self-update: check + apply against a fake git, covering up-to-date,
+// fast-forwardable, diverged, no-upstream, and deps-changed paths.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { checkForUpdate, applyUpdate } from "../src/self-update.js";
+
+// Build a fake `git` runner from a scripted command→output map. Records the
+// commands so we can assert what ran (e.g. that a merge happened or didn't).
+function fakeGit(responses) {
+  const calls = [];
+  const run = async (args) => {
+    calls.push(args.join(" "));
+    const key = args.join(" ");
+    for (const [pattern, val] of Object.entries(responses)) {
+      if (key.startsWith(pattern)) {
+        if (val instanceof Error) throw val;
+        return typeof val === "function" ? val() : val;
+      }
+    }
+    throw new Error(`unexpected git: ${key}`);
+  };
+  return { run, calls };
+}
+
+test("checkForUpdate reports behind/available when upstream is ahead", async () => {
+  const { run } = fakeGit({
+    "rev-parse --abbrev-ref HEAD": "main",
+    "rev-parse --short HEAD": "aaaaaaa",
+    "rev-parse --abbrev-ref --symbolic-full-name @{u}": "origin/main",
+    "fetch": "",
+    "rev-list --count HEAD..origin/main": "3",
+    "rev-list --count origin/main..HEAD": "0",
+    "rev-parse --short origin/main": "bbbbbbb"
+  });
+  const r = await checkForUpdate({ run });
+  assert.equal(r.updateAvailable, true);
+  assert.equal(r.behind, 3);
+  assert.equal(r.canFastForward, true);
+  assert.equal(r.latest, "bbbbbbb");
+});
+
+test("checkForUpdate: up to date", async () => {
+  const { run } = fakeGit({
+    "rev-parse --abbrev-ref HEAD": "main",
+    "rev-parse --short HEAD": "aaaaaaa",
+    "rev-parse --abbrev-ref --symbolic-full-name @{u}": "origin/main",
+    "fetch": "",
+    "rev-list --count HEAD..origin/main": "0",
+    "rev-list --count origin/main..HEAD": "0",
+    "rev-parse --short origin/main": "aaaaaaa"
+  });
+  const r = await checkForUpdate({ run });
+  assert.equal(r.updateAvailable, false);
+});
+
+test("checkForUpdate: no upstream → not available, clear reason", async () => {
+  const { run } = fakeGit({
+    "rev-parse --abbrev-ref HEAD": "main",
+    "rev-parse --short HEAD": "aaaaaaa",
+    "rev-parse --abbrev-ref --symbolic-full-name @{u}": new Error("no upstream")
+  });
+  const r = await checkForUpdate({ run });
+  assert.equal(r.updateAvailable, false);
+  assert.match(r.reason, /no upstream/);
+});
+
+test("applyUpdate fast-forwards and signals what changed (no deps)", async () => {
+  const { run, calls } = fakeGit({
+    "rev-parse --abbrev-ref HEAD": "main",
+    "rev-parse --short HEAD": () => calls.includes("merge --ff-only origin/main") ? "bbbbbbb" : "aaaaaaa",
+    "rev-parse --abbrev-ref --symbolic-full-name @{u}": "origin/main",
+    "fetch": "",
+    "rev-list --count HEAD..origin/main": "2",
+    "rev-list --count origin/main..HEAD": "0",
+    "rev-parse --short origin/main": "bbbbbbb",
+    "diff --name-only HEAD origin/main": "src/foo.js\nREADME.md",
+    "merge --ff-only origin/main": ""
+  });
+  let installed = false;
+  const r = await applyUpdate({ run, installDeps: async () => { installed = true; } });
+  assert.equal(r.updated, true);
+  assert.equal(r.to, "bbbbbbb");
+  assert.equal(r.depsChanged, false);
+  assert.equal(installed, false, "no npm install when package.json didn't change");
+  assert.ok(calls.includes("merge --ff-only origin/main"));
+});
+
+test("applyUpdate reinstalls deps when package.json changed", async () => {
+  const { run } = fakeGit({
+    "rev-parse --abbrev-ref HEAD": "main",
+    "rev-parse --short HEAD": "ccccccc",
+    "rev-parse --abbrev-ref --symbolic-full-name @{u}": "origin/main",
+    "fetch": "",
+    "rev-list --count HEAD..origin/main": "1",
+    "rev-list --count origin/main..HEAD": "0",
+    "rev-parse --short origin/main": "ddddddd",
+    "diff --name-only HEAD origin/main": "package.json\npackage-lock.json\nsrc/x.js",
+    "merge --ff-only origin/main": ""
+  });
+  let installed = false;
+  const r = await applyUpdate({ run, installDeps: async () => { installed = true; } });
+  assert.equal(r.updated, true);
+  assert.equal(r.depsChanged, true);
+  assert.equal(installed, true);
+});
+
+test("applyUpdate refuses to update a diverged checkout (won't clobber local commits)", async () => {
+  const { run, calls } = fakeGit({
+    "rev-parse --abbrev-ref HEAD": "main",
+    "rev-parse --short HEAD": "aaaaaaa",
+    "rev-parse --abbrev-ref --symbolic-full-name @{u}": "origin/main",
+    "fetch": "",
+    "rev-list --count HEAD..origin/main": "2",
+    "rev-list --count origin/main..HEAD": "1",   // local is ahead → diverged
+    "rev-parse --short origin/main": "bbbbbbb"
+  });
+  const r = await applyUpdate({ run, installDeps: async () => {} });
+  assert.equal(r.updated, false);
+  assert.match(r.reason, /diverg|fast-forward/i);
+  assert.ok(!calls.includes("merge --ff-only origin/main"), "must not merge a diverged checkout");
+});
+
+test("applyUpdate: already up to date is a clean no-op", async () => {
+  const { run } = fakeGit({
+    "rev-parse --abbrev-ref HEAD": "main",
+    "rev-parse --short HEAD": "aaaaaaa",
+    "rev-parse --abbrev-ref --symbolic-full-name @{u}": "origin/main",
+    "fetch": "",
+    "rev-list --count HEAD..origin/main": "0",
+    "rev-list --count origin/main..HEAD": "0",
+    "rev-parse --short origin/main": "aaaaaaa"
+  });
+  const r = await applyUpdate({ run, installDeps: async () => {} });
+  assert.equal(r.updated, false);
+  assert.match(r.reason, /up to date/i);
+});


### PR DESCRIPTION
Built-in updating, so a deployed main (Pi/Distiller) or any install stays current without a manual git pull — replacing the idea of hand-installing a systemd update timer per device.

## What
- **`src/self-update.js`** — `checkForUpdate()` (fetch + compare HEAD vs upstream) and `applyUpdate()` (fast-forward + npm install when package.json changed). **Fast-forward only** — refuses a diverged checkout, never clobbers local commits.
- **`POST /control/update`** applies + `exit(0)` so the supervisor respawns with new code; **`GET /control/update`** is a dry check. Emits a `self-update` event.
- **`openagi update [--check]`** CLI — targets local or a remote main like the other commands.
- **Opt-in daily cron** (`OPENAGI_AUTO_UPDATE=1`, `OPENAGI_AUTO_UPDATE_AT` default 04:30), registered disabled so it's visible/toggleable in the dashboard without an env change.
- Relies on the supervisor (systemd `Restart=always` / launchd / Mac app) to respawn — already configured by the install scripts.

## Tests
7 self-update cases (behind / up-to-date / no-upstream / fast-forward / deps-changed / diverged-refusal). Also fixed the OAuth callback-port test to grab a free port (it hardcoded 8765, which collided with a real app on the dev machine). Full suite 258/258; `openagi update --check` verified live against a running daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)