### PR TITLE
fix: systemd unit makes the install dir writable (self-update was blocked)

### DIFF
--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -52,7 +52,10 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=full
 ProtectHome=read-only
-ReadWritePaths=${2}
+# Writable: the data dir, AND the install dir itself — self-update
+# (openagi update / OPENAGI_AUTO_UPDATE) git-pulls the checkout, which
+# ProtectHome=read-only would otherwise block ("Read-only file system").
+ReadWritePaths=${2} ${PROJECT_DIR}
 
 [Install]
 WantedBy=${1:-multi-user.target}


### PR DESCRIPTION
`ProtectHome=read-only` with `ReadWritePaths=<dataDir>` left the git checkout read-only to the daemon, so self-update (`openagi update` / `OPENAGI_AUTO_UPDATE`) failed with `cannot open '.git/FETCH_HEAD': Read-only file system`. Adds the install dir to `ReadWritePaths`.

Found and verified running self-update on a Raspberry Pi CM5 (Distiller) main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)