### PR TITLE
feat: iMessage bridge (Mac node relays iMessages to the main)

### DIFF
--- a/bin/openagi.js
+++ b/bin/openagi.js
@@ -33,6 +33,8 @@ function parseArgs(argv) {
     else if (a === "--token") flags.token = argv[++i];
     else if (a === "--host") flags.host = argv[++i];
     else if (a === "--port") flags.port = argv[++i];
+    else if (a === "--allow") flags.allow = argv[++i];
+    else if (a === "--check") flags.check = true;
     else if (a === "-h" || a === "--help") flags.help = true;
     else positional.push(a);
   }
@@ -152,6 +154,32 @@ function cmdUnpair() {
   return 0;
 }
 
+async function cmdImessageBridge(flags) {
+  const { client, target } = makeClient(flags);
+  if (!target.remote && !flags.remote) {
+    console.log(c(DIM, "Bridging to the LOCAL daemon. For the main+nodes setup, `openagi pair <main>` first or pass --remote."));
+  }
+  // Verify the main is reachable before we start polling chat.db.
+  const health = await client.health();
+  if (!health.ok) { console.error(c(RED, `✗ main unreachable at ${target.url} — ${health.error ?? "HTTP " + health.status}`)); return 1; }
+
+  const { IMessageBridge } = await import("../src/integrations/imessage-bridge.js");
+  const allowFrom = flags.allow ? String(flags.allow).split(",").map((s) => s.trim()).filter(Boolean) : [];
+  const bridge = new IMessageBridge({
+    client,
+    allowFrom,
+    onEvent: (e) => {
+      if (e.kind === "relayed") console.log(c(GREEN, `↔ ${e.handle}: `) + c(DIM, `"${e.in}" → "${e.out}"`));
+      else if (e.kind && e.error) console.error(c(YELLOW, `! ${e.kind} ${e.handle ?? ""}: ${e.error}`));
+    }
+  });
+  console.log(c(GREEN, `iMessage bridge → main at ${target.url}`));
+  console.log(c(DIM, `Incoming iMessages${allowFrom.length ? ` from ${allowFrom.join(", ")}` : ""} are answered by the main. Ctrl-C to stop.`));
+  console.log(c(DIM, "Requires: Full Disk Access (read chat.db) + Automation→Messages (send) for this process."));
+  bridge.start({ intervalMs: 2000 });
+  await new Promise(() => {}); // run until killed
+}
+
 async function cmdUpdate(positional, flags) {
   const { client, target } = makeClient(flags);
   const checkOnly = positional.includes("--check") || flags.check;
@@ -200,6 +228,8 @@ ${c(BOLD, "Use it (local, or a remote main):")}
 ${c(BOLD, "Turn this device into a node of a remote main:")}
   openagi pair <main-url> [--token T]    save the main as this device's target
   openagi unpair                         forget it
+  openagi imessage-bridge [--allow h,…]  (macOS) relay incoming iMessages to the
+                                         main and text its replies back
 
 ${c(BOLD, "Global flags:")} --remote <url>  --token <token>  --json
 
@@ -220,6 +250,7 @@ async function main() {
       case "pair": return cmdPair(positional, flags);
       case "unpair": return cmdUnpair();
       case "update": return await cmdUpdate(positional, flags);
+      case "imessage-bridge": return await cmdImessageBridge(flags);
       case "tick": return await cmdTick(flags);
       default:
         console.error(c(RED, `unknown command: ${cmd}`));

--- a/src/cli-client.js
+++ b/src/cli-client.js
@@ -30,6 +30,7 @@ export function readNodeConfig(dataDir = resolveDataDir()) {
 
 export function writeNodeConfig({ remote, token }, dataDir = resolveDataDir()) {
   const file = nodeConfigPath(dataDir);
+  fs.mkdirSync(dataDir, { recursive: true }); // a fresh node has no ~/.openagi yet
   fs.writeFileSync(file, JSON.stringify({ remote, token: token ?? null }, null, 2) + "\n", { mode: 0o600 });
   return file;
 }

--- a/src/integrations/imessage-bridge.js
+++ b/src/integrations/imessage-bridge.js
@@ -1,0 +1,164 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+// iMessage bridge (node-side). Turns a Mac into a conversational gateway for a
+// remote OpenAGI "main": new INCOMING iMessages are forwarded to the main's
+// /message endpoint, and the main's reply is sent back via Messages.app.
+//
+//   incoming iMessage --> POST <main>/message --> reply --> osascript send back
+//
+// The Mac holds none of the brain — memory/context/integrations live on the
+// main. This node only needs Full Disk Access (read chat.db) and Automation
+// permission for Messages (send replies).
+//
+// Deps are injected (db reader, the CliClient, the send fn) so the relay loop
+// is unit-testable without a real chat.db or Messages.app.
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_DB = path.join(os.homedir(), "Library", "Messages", "chat.db");
+
+export class IMessageBridge {
+  constructor(options = {}) {
+    this.client = options.client; // CliClient pointed at the main
+    this.dbPath = options.dbPath ?? DEFAULT_DB;
+    this.statePath = options.statePath ?? path.join(options.dataDir ?? path.join(os.homedir(), ".openagi"), "imessage-bridge.json");
+    this.readMessages = options.readMessages ?? ((sinceRowid) => readNewMessages(this.dbPath, sinceRowid));
+    this.sendMessage = options.sendMessage ?? sendViaIMessage;
+    // Optional allowlist of sender handles (phone/email). Empty = anyone.
+    this.allowFrom = new Set((options.allowFrom ?? []).map((h) => String(h).toLowerCase()));
+    this.onEvent = options.onEvent ?? (() => {});
+  }
+
+  _loadState() {
+    try { return JSON.parse(fs.readFileSync(this.statePath, "utf8")); } catch { return { lastRowid: null }; }
+  }
+  _saveState(state) {
+    fs.mkdirSync(path.dirname(this.statePath), { recursive: true });
+    fs.writeFileSync(this.statePath, JSON.stringify(state, null, 2) + "\n", { mode: 0o600 });
+  }
+
+  allowed(handle) {
+    return this.allowFrom.size === 0 || this.allowFrom.has(String(handle).toLowerCase());
+  }
+
+  // One pass: forward each new allowed incoming message, reply with the main's
+  // answer. Returns a summary { processed, replied, skipped, errors }.
+  async poll() {
+    let state = this._loadState();
+    // First run: don't replay history — start from the current high-water mark.
+    if (state.lastRowid == null) {
+      state = { lastRowid: await this.readMaxRowid(), initialized: true };
+      this._saveState(state);
+      return { processed: 0, replied: 0, skipped: 0, errors: 0, bootstrapped: true };
+    }
+
+    const rows = await this.readMessages(state.lastRowid);
+    let processed = 0, replied = 0, skipped = 0, errors = 0, highest = state.lastRowid;
+    for (const row of rows) {
+      if (row.rowid > highest) highest = row.rowid;
+      processed++;
+      const text = (row.text ?? "").trim();
+      if (!text || !row.handle) { skipped++; continue; }
+      if (!this.allowed(row.handle)) { skipped++; continue; }
+      try {
+        const res = await this.client.chat(text, { from: `imessage:${row.handle}` });
+        const reply = res?.json?.reply;
+        if (res?.ok && reply) {
+          await this.sendMessage(row.handle, reply);
+          replied++;
+          this.onEvent({ kind: "relayed", handle: row.handle, in: text.slice(0, 80), out: reply.slice(0, 80) });
+        } else {
+          errors++;
+          this.onEvent({ kind: "main-error", handle: row.handle, error: res?.error ?? `HTTP ${res?.status}` });
+        }
+      } catch (error) {
+        errors++;
+        this.onEvent({ kind: "send-error", handle: row.handle, error: error.message });
+      }
+    }
+    this._saveState({ ...state, lastRowid: highest });
+    return { processed, replied, skipped, errors };
+  }
+
+  async readMaxRowid() {
+    const rows = await this.readMessages(0);
+    return rows.reduce((mx, r) => Math.max(mx, r.rowid), 0);
+  }
+
+  // Run the poll loop until stop() is called.
+  start({ intervalMs = 2000 } = {}) {
+    this._stopped = false;
+    const tick = async () => {
+      if (this._stopped) return;
+      try { await this.poll(); } catch (error) { this.onEvent({ kind: "poll-error", error: error.message }); }
+      if (!this._stopped) this._timer = setTimeout(tick, intervalMs);
+    };
+    tick();
+  }
+  stop() { this._stopped = true; if (this._timer) clearTimeout(this._timer); }
+}
+
+// Read new INCOMING messages (is_from_me = 0) newer than sinceRowid, across all
+// conversations. Returns [{ rowid, handle, text, appleDate }]. Pulls text from
+// the `text` column, falling back to a best-effort decode of attributedBody
+// (modern macOS often stores the body there, leaving `text` NULL).
+export async function readNewMessages(dbPath, sinceRowid) {
+  const { DatabaseSync } = await import("node:sqlite");
+  const db = new DatabaseSync(dbPath);
+  try {
+    const rows = db.prepare(`
+      SELECT m.ROWID AS rowid, m.text AS text, m.attributedBody AS body,
+             m.date AS appleDate, h.id AS handle
+      FROM message m
+      LEFT JOIN handle h ON h.ROWID = m.handle_id
+      WHERE m.ROWID > ? AND m.is_from_me = 0 AND h.id IS NOT NULL
+      ORDER BY m.ROWID ASC
+      LIMIT 200
+    `).all(sinceRowid);
+    return rows.map((r) => ({
+      rowid: r.rowid,
+      handle: r.handle,
+      appleDate: r.appleDate,
+      text: r.text && r.text.trim() ? r.text : extractAttributedText(r.body)
+    }));
+  } finally {
+    db.close();
+  }
+}
+
+// Best-effort text out of the NSAttributedString typedstream blob Messages
+// stores in `attributedBody`. Byte-walk (no fragile control-char regex): find
+// the "NSString" class marker, skip the short length-prefix of control bytes
+// (and a leading '+'), then collect UTF-8 until the 0x86/0x84 end marker.
+// Not a full typedstream parser — pragmatic, handles the common case.
+export function extractAttributedText(body) {
+  if (!body) return "";
+  const buf = Buffer.isBuffer(body) ? body : Buffer.from(body);
+  const marker = buf.indexOf(Buffer.from("NSString", "ascii"));
+  if (marker === -1) return "";
+  let i = marker + "NSString".length;
+  while (i < buf.length && (buf[i] < 0x20 || buf[i] === 0x2b)) i++; // skip ctrl bytes + leading '+'
+  const start = i;
+  while (i < buf.length && buf[i] !== 0x86 && buf[i] !== 0x84) i++;
+  // Trim any trailing control bytes that slipped in.
+  let end = i;
+  while (end > start && buf[end - 1] < 0x20) end--;
+  return buf.slice(start, end).toString("utf8").trim();
+}
+
+// Send a message back over iMessage via AppleScript. Requires Automation
+// permission for Messages granted to the controlling process.
+export async function sendViaIMessage(handle, text, { run = execFileAsync } = {}) {
+  const script = `
+    on run {targetHandle, msgText}
+      tell application "Messages"
+        set svc to 1st account whose service type = iMessage
+        set theBuddy to participant targetHandle of svc
+        send msgText to theBuddy
+      end tell
+    end run`;
+  await run("osascript", ["-e", script, handle, text], { timeout: 15000 });
+}

--- a/test/imessage-bridge.test.js
+++ b/test/imessage-bridge.test.js
@@ -1,0 +1,99 @@
+// iMessage bridge relay: forward incoming → main → reply back, with rowid
+// high-water tracking, allowlist, and bootstrap-skips-history. Injects the db
+// reader, the main client, and the send fn so no chat.db / Messages.app needed.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { IMessageBridge, extractAttributedText } from "../src/integrations/imessage-bridge.js";
+
+function makeBridge({ messages = [], replies = {}, allowFrom = [] } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-imsg-"));
+  const sent = [];
+  const forwarded = [];
+  const client = {
+    health: async () => ({ ok: true, json: { ok: true } }),
+    chat: async (text, opts) => {
+      forwarded.push({ text, from: opts.from });
+      const reply = replies[text];
+      return reply ? { ok: true, json: { reply } } : { ok: false, status: 500, error: "no reply" };
+    }
+  };
+  const bridge = new IMessageBridge({
+    client, allowFrom,
+    dataDir: dir,
+    readMessages: async (since) => messages.filter((m) => m.rowid > since),
+    sendMessage: async (handle, text) => { sent.push({ handle, text }); }
+  });
+  return { bridge, sent, forwarded, dir };
+}
+
+test("first poll bootstraps to the high-water mark without replaying history", async () => {
+  const { bridge, sent, forwarded } = makeBridge({
+    messages: [{ rowid: 10, handle: "+15551112222", text: "old" }, { rowid: 11, handle: "+15551112222", text: "older" }]
+  });
+  const r = await bridge.poll();
+  assert.equal(r.bootstrapped, true);
+  assert.equal(sent.length, 0, "no history replayed");
+  assert.equal(forwarded.length, 0);
+});
+
+test("relays a new incoming message to the main and texts the reply back", async () => {
+  const { bridge, sent, forwarded } = makeBridge({
+    messages: [{ rowid: 5, handle: "+15551112222", text: "what's on my calendar?" }],
+    replies: { "what's on my calendar?": "You have a 3pm with Acme." }
+  });
+  await bridge.poll(); // bootstrap (maxRowid=5)
+  // a NEW message arrives after the bootstrap mark
+  bridge.readMessages = async (since) => [{ rowid: 6, handle: "+15551112222", text: "remind me to call Sam" }].filter((m) => m.rowid > since);
+  bridge.client.chat = async (text, opts) => { forwarded.push({ text, from: opts.from }); return { ok: true, json: { reply: "Got it — I'll remind you." } }; };
+  const r = await bridge.poll();
+  assert.equal(r.replied, 1);
+  assert.equal(forwarded[0].from, "imessage:+15551112222", "sender becomes the main session id");
+  assert.deepEqual(sent[0], { handle: "+15551112222", text: "Got it — I'll remind you." });
+});
+
+test("allowlist drops messages from non-allowed senders", async () => {
+  const { bridge, sent } = makeBridge({
+    messages: [{ rowid: 1, handle: "+1999", text: "hi" }],
+    allowFrom: ["+15551112222"]
+  });
+  // force past bootstrap with lastRowid already set
+  bridge._saveState({ lastRowid: 0, initialized: true });
+  bridge.readMessages = async () => [{ rowid: 2, handle: "+1999", text: "spam" }, { rowid: 3, handle: "+15551112222", text: "real" }];
+  bridge.client.chat = async () => ({ ok: true, json: { reply: "ok" } });
+  const r = await bridge.poll();
+  assert.equal(r.skipped, 1, "non-allowed sender skipped");
+  assert.equal(r.replied, 1, "allowed sender answered");
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].handle, "+15551112222");
+});
+
+test("advances the rowid high-water mark even when a send errors", async () => {
+  const { bridge, dir } = makeBridge({});
+  bridge._saveState({ lastRowid: 100, initialized: true });
+  bridge.readMessages = async (since) => [{ rowid: 101, handle: "+1", text: "x" }].filter((m) => m.rowid > since);
+  bridge.client.chat = async () => ({ ok: false, status: 500, error: "boom" });
+  const r = await bridge.poll();
+  assert.equal(r.errors, 1);
+  const state = JSON.parse(fs.readFileSync(path.join(dir, "imessage-bridge.json"), "utf8"));
+  assert.equal(state.lastRowid, 101, "won't reprocess the same failed message forever");
+});
+
+test("extractAttributedText pulls text from an attributedBody blob", () => {
+  // Minimal synthetic typedstream: ...NSString <ctrl> + <text> 0x86...
+  const text = "hello from imessage";
+  const blob = Buffer.concat([
+    Buffer.from("streamtyped...NSString", "binary"),
+    Buffer.from([0x01, 0x2b]),
+    Buffer.from(text, "utf8"),
+    Buffer.from([0x86, 0x84])
+  ]);
+  assert.equal(extractAttributedText(blob), text);
+});
+
+test("extractAttributedText returns empty for a body with no NSString marker", () => {
+  assert.equal(extractAttributedText(Buffer.from("garbage")), "");
+  assert.equal(extractAttributedText(null), "");
+});


### PR DESCRIPTION
A Mac paired to a remote main becomes a conversational iMessage gateway — the headless Distiller brain can read & respond to texts.

```
incoming iMessage ──▶ POST <main>/message ──▶ reply ──▶ Messages.app send-back
```

The Mac holds no brain; memory/context/integrations stay on the main. It just bridges.

## What
- **`src/integrations/imessage-bridge.js`** — `IMessageBridge` polls `chat.db` for new INCOMING messages (ROWID high-water mark, first run skips history), forwards each to the main as `from=imessage:<handle>`, sends the reply back via `osascript`. `--allow` allowlists senders. Text from the `text` column or a byte-walk decode of `attributedBody` (modern macOS leaves `text` NULL). Deps injected → unit-testable without chat.db/Messages.
- **`openagi imessage-bridge`** CLI — resolves the main (pair/`--remote`), verifies reachability, runs the loop.
- **fix:** `openagi pair` now mkdir's `~/.openagi` (pairing a fresh node failed with ENOENT).

## Requires (macOS, user-granted)
Full Disk Access (read chat.db) + Automation→Messages (send). 

## Tests
6 bridge cases (bootstrap, relay+reply, allowlist, rowid-advances-on-error, attributedBody extraction); full suite 264/264.

> Live end-to-end validation is pending an iMessage account being signed into Messages.app on the node Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)