### PR TITLE
feat: persona.md — give the main agent a name + soul

### DIFF
--- a/src/abi-runtime.js
+++ b/src/abi-runtime.js
@@ -46,6 +46,7 @@ import { PropagationController } from "./propagation-controller.js";
 import { SkillRegistry } from "./skills.js";
 import { registerCoreTools, ToolRegistry } from "./tool-registry.js";
 import { registerDefaultWorkflows, WorkflowRegistry } from "./workflow-registry.js";
+import { applyPersona } from "./persona.js";
 import { createId, nowIso } from "./utils.js";
 
 const AUTOPILOT_DEFAULT_PROMPT = `Autopilot pulse. Look at what's recent — sessions, memory, scheduled jobs, MCP tools you have access to.
@@ -982,6 +983,9 @@ export function createDurableRuntime(options = {}) {
   });
   const mcpConfigPath = options.mcpConfigPath ?? path.join(dataDir, "mcp.json");
   runtime.mcp.loadConfigFile(mcpConfigPath);
+  // Apply persona.md (if present) to the main agent — name + system prompt.
+  // Re-applied every boot so editing the file + restarting updates the agent.
+  applyPersona(runtime, dataDir);
   // Reconnect previously-authorized MCP servers on boot, silently — servers
   // with a cached OAuth token / bearer key / stdio command come back "live"
   // instead of showing "idle" until someone clicks Connect. Never opens a

--- a/src/agent-store.js
+++ b/src/agent-store.js
@@ -19,6 +19,14 @@ export class InMemoryAgentStore {
     return created;
   }
 
+  // Overwrite fields on an agent (unlike ensureAgent, which no-ops if it
+  // exists). Used to apply persona.md to the main agent on every boot.
+  setAgent(id, fields) {
+    const merged = normalizeAgent({ ...(this.agents.get(id) ?? { id }), ...fields, id });
+    this.agents.set(id, merged);
+    return merged;
+  }
+
   createAgent(agent = {}) {
     const id = agent.id ?? createId("agent");
     return this.ensureAgent({ ...agent, id });
@@ -108,6 +116,18 @@ export class FileBackedAgentStore extends InMemoryAgentStore {
     this.agents.set(created.id, created);
     this.saveAgents();
     return created;
+  }
+
+  // Overwrite fields on an agent (unlike ensureAgent). Used to apply
+  // persona.md to the main agent on every boot. Skips the disk write when
+  // nothing actually changed (avoids needless churn on every restart).
+  setAgent(id, fields) {
+    const before = this.agents.get(id);
+    const merged = normalizeAgent({ ...(before ?? { id }), ...fields, id });
+    if (before && before.name === merged.name && before.systemPrompt === merged.systemPrompt) return before;
+    this.agents.set(id, merged);
+    this.saveAgents();
+    return merged;
   }
 
   createAgent(agent = {}) {

--- a/src/persona.js
+++ b/src/persona.js
@@ -1,0 +1,41 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveDataDir } from "./data-dir.js";
+
+// Persona / identity for the main agent — the SOUL.md pattern. Drop a
+// `<dataDir>/persona.md` and its content becomes the main agent's system
+// prompt (prepended before the always-on ABI-loop instructions), giving the
+// agent a name + voice + values that persist across sessions. Edit the file
+// and restart to change it. Absent → the default "Main Agent".
+//
+// The agent NAME is taken from (first match): OPENAGI_AGENT_NAME env, a
+// "Name:" line in the file, the first markdown heading, else "Main Agent".
+
+export function personaPath(dataDir = resolveDataDir()) {
+  return path.join(dataDir, "persona.md");
+}
+
+export function parsePersona(text) {
+  if (!text || !text.trim()) return null;
+  const nameLine = text.match(/^[\s>*-]*\**\s*Name\**\s*:?\**\s*[:|-]?\s*([^\n*]+)/im);
+  const heading = text.match(/^#+\s*([^\n]+)/m);
+  const fromEnv = (process.env.OPENAGI_AGENT_NAME ?? "").trim();
+  const name = (fromEnv || nameLine?.[1]?.trim() || heading?.[1]?.trim() || "").replace(/\s*[-–—].*$/, "").trim() || "Main Agent";
+  return { name, systemPrompt: text.trim() };
+}
+
+export function loadPersona(dataDir = resolveDataDir()) {
+  let text;
+  try { text = fs.readFileSync(personaPath(dataDir), "utf8"); } catch { return null; }
+  return parsePersona(text);
+}
+
+// Apply persona.md to the runtime's main agent. Safe no-op when there's no
+// file or no agent store. Returns the applied persona or null.
+export function applyPersona(runtime, dataDir = resolveDataDir()) {
+  const persona = loadPersona(dataDir);
+  const store = runtime?.agentHost?.store;
+  if (!persona || !store?.setAgent) return null;
+  store.setAgent("main", { name: persona.name, systemPrompt: persona.systemPrompt, role: "root" });
+  return persona;
+}

--- a/test/persona.test.js
+++ b/test/persona.test.js
@@ -1,0 +1,63 @@
+// Persona: persona.md sets the main agent's name + system prompt, re-applied
+// every boot, and flows into the agent's instructions.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { parsePersona, loadPersona, applyPersona } from "../src/persona.js";
+import { createDurableRuntime } from "../src/index.js";
+
+test("parsePersona pulls the name from a 'Name:' line", () => {
+  const p = parsePersona("# IDENTITY\n\n- **Name:** Peri\n- Vibe: sharp\n\nBe helpful.");
+  assert.equal(p.name, "Peri");
+  assert.match(p.systemPrompt, /Be helpful/);
+});
+
+test("parsePersona falls back to the first heading, then default", () => {
+  assert.equal(parsePersona("# Atlas\n\nsome soul").name, "Atlas");
+  assert.equal(parsePersona("just text no heading").name, "Main Agent");
+  assert.equal(parsePersona("   "), null);
+});
+
+test("OPENAGI_AGENT_NAME overrides the parsed name", (t) => {
+  const saved = process.env.OPENAGI_AGENT_NAME;
+  process.env.OPENAGI_AGENT_NAME = "Override";
+  t.after(() => { if (saved === undefined) delete process.env.OPENAGI_AGENT_NAME; else process.env.OPENAGI_AGENT_NAME = saved; });
+  assert.equal(parsePersona("- Name: Peri\nsoul").name, "Override");
+});
+
+test("loadPersona returns null without a file", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-persona-"));
+  assert.equal(loadPersona(dir), null);
+  fs.rmSync(dir, { recursive: true });
+});
+
+test("applyPersona sets the main agent and it reaches the system prompt", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-persona-rt-"));
+  fs.writeFileSync(path.join(dir, "persona.md"), "# IDENTITY\n- **Name:** Peri\n\nYou are direct, no fluff.");
+  const runtime = createDurableRuntime({ dataDir: dir, autoConnectMcp: false });
+
+  const main = runtime.agentHost.store.getAgent("main");
+  assert.equal(main.name, "Peri");
+  assert.match(main.systemPrompt, /direct, no fluff/);
+
+  // The persona flows into the prompt the model receives.
+  const prompt = runtime.agentHost.instructionsForAgent(main, {
+    scrutiny: { action: "act", score: 0.6, reasons: [], dimensions: {} }
+  });
+  assert.match(prompt, /You are direct, no fluff/);
+  assert.match(prompt, /You are Peri/);
+  // (temp dir left for the OS to reap — the durable runtime keeps SQLite
+  // handles open in the background and deleting under it races.)
+});
+
+test("editing persona.md + reboot updates the persisted main agent", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-persona-edit-"));
+  fs.writeFileSync(path.join(dir, "persona.md"), "- Name: Peri\nv1 soul");
+  createDurableRuntime({ dataDir: dir, autoConnectMcp: false });
+  // edit + reboot
+  fs.writeFileSync(path.join(dir, "persona.md"), "- Name: Peri\nv2 soul updated");
+  const reboot = createDurableRuntime({ dataDir: dir, autoConnectMcp: false });
+  assert.match(reboot.agentHost.store.getAgent("main").systemPrompt, /v2 soul updated/);
+});


### PR DESCRIPTION
Drop a `<dataDir>/persona.md` and its content becomes the main agent's system prompt (the SOUL.md pattern), with the name parsed from a `Name:` line / first heading / `OPENAGI_AGENT_NAME`. Re-applied every boot. Lets a migrated identity (OpenClaw/Hermes persona) carry into OpenAGI so it stays itself across the move.

- `src/persona.js`: parse/load/apply.
- agent-store `setAgent()` to overwrite the main agent (ensureAgent no-ops on existing).
- wired into `createDurableRuntime` boot.

Tests: 6 cases; full suite 270/270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)