### PR TITLE
feat: POST /memory/remember (direct memory import)

### DIFF
--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -227,6 +227,29 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
       // they can take the user to the wizard instead of sitting silent.
       if (method === "GET" && pathname === "/health") return sendJson(res, 200, { ok: true, firstRun: isFirstRun(), status: runtime.status() });
       if (method === "GET" && pathname === "/memory") return sendJson(res, 200, runtime.memory.snapshot());
+      if (method === "POST" && pathname === "/memory/remember") {
+        // Direct memory import (auth-gated) — for migrations from another
+        // agent, bulk seeding, or integrations. Body: { content, tags?,
+        // importance?, scope?, source? }. Mirrors the `remember` tool.
+        const body = await readJson(req);
+        const content = String(body?.content ?? "").trim();
+        if (!content) return sendJson(res, 400, { error: "content required" });
+        const importance = body.importance ?? "normal";
+        const item = runtime.memory.remember(
+          {
+            source: body.source ?? "import",
+            scope: body.scope ?? "main",
+            content,
+            tags: ["import", ...(Array.isArray(body.tags) ? body.tags : [])],
+            risk: importance === "high" ? 0.8 : importance === "low" ? 0.2 : 0.45,
+            specificity: 0.7,
+            repetition: 0.4,
+            novelty: 0.5
+          },
+          { source: "memory-import", strength: importance === "high" ? 0.85 : 0.6 }
+        );
+        return sendJson(res, 200, { id: item.id, tier: item.tier });
+      }
       if (method === "GET" && pathname === "/agents") return sendJson(res, 200, runtime.agentHost?.store.listAgents() ?? runtime.propagation.list());
       if (method === "GET" && pathname === "/specialists") {
         const includeRetired = url.searchParams.get("retired") === "1";

--- a/test/memory-import.test.js
+++ b/test/memory-import.test.js
@@ -1,0 +1,39 @@
+// POST /memory/remember — direct memory import (for migrations / seeding).
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createDefaultRuntime, createHostedInterface } from "../src/index.js";
+
+test("POST /memory/remember imports a memory item", async () => {
+  const runtime = createDefaultRuntime();
+  const app = createHostedInterface(runtime, { port: 0 });
+  const address = await app.listen();
+  try {
+    const res = await fetch(`${address.url}/memory/remember`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ content: "Spencer's cruise: Australia → New Zealand, Mar 15-30", tags: ["cruise"], importance: "high" })
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.id);
+    // It's recallable.
+    const hits = runtime.memory.retrieve("cruise itinerary");
+    assert.ok(hits.some((h) => /Australia/.test(h.item.content)));
+    assert.ok(hits.some((h) => h.item.tags.includes("import") && h.item.tags.includes("cruise")));
+  } finally {
+    await app.close();
+  }
+});
+
+test("POST /memory/remember rejects empty content", async () => {
+  const app = createHostedInterface(createDefaultRuntime(), { port: 0 });
+  const address = await app.listen();
+  try {
+    const res = await fetch(`${address.url}/memory/remember`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ content: "  " })
+    });
+    assert.equal(res.status, 400);
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
Auth-gated endpoint to add a memory item directly — for migrating memory from another agent (e.g. an OpenClaw install), bulk seeding, or integrations. Mirrors the `remember` tool. Tests included; full suite green.