### PR TITLE
feat: openagi migrate — import OpenClaw / Hermes into OpenAGI

### DIFF
--- a/bin/openagi.js
+++ b/bin/openagi.js
@@ -35,6 +35,8 @@ function parseArgs(argv) {
     else if (a === "--port") flags.port = argv[++i];
     else if (a === "--allow") flags.allow = argv[++i];
     else if (a === "--check") flags.check = true;
+    else if (a === "--from") flags.from = argv[++i];
+    else if (a === "--dry-run") flags.dryRun = true;
     else if (a === "-h" || a === "--help") flags.help = true;
     else positional.push(a);
   }
@@ -154,6 +156,42 @@ function cmdUnpair() {
   return 0;
 }
 
+async function cmdMigrate(positional, flags) {
+  const { detectSource, defaultSourceDir, extract, applyMigration } = await import("../src/migrate.js");
+  const { resolveDataDir } = await import("../src/data-dir.js");
+  let source = positional[0];
+  if (!source) {
+    source = detectSource();
+    if (!source) { console.error(c(RED, "couldn't detect an OpenClaw or Hermes install — pass `openagi migrate <openclaw|hermes> --from <dir>`")); return 1; }
+    console.log(c(DIM, `detected: ${source}`));
+  }
+  const dir = flags.from ?? defaultSourceDir(source);
+  let extracted;
+  try { extracted = extract(source, dir); }
+  catch (error) { console.error(c(RED, `✗ ${error.message}`)); return 1; }
+
+  console.log(`${c(BOLD, `Migrate ${source}`)} from ${c(DIM, dir)}`);
+  console.log(`  agent name:  ${extracted.agentName ? c(GREEN, extracted.agentName) : c(YELLOW, "(none found)")}`);
+  console.log(`  persona:     ${extracted.persona ? c(GREEN, "yes") : c(YELLOW, "none")}`);
+  console.log(`  memories:    ${extracted.memories.length}`);
+  console.log(`  telegram:    ${extracted.telegram.length ? c(GREEN, extracted.telegram.map((t) => t.label).join(", ")) : "none"}`);
+  for (const n of extracted.notes) console.log(c(DIM, `  note: ${n}`));
+
+  if (flags.dryRun || flags.check) { console.log(c(YELLOW, "\n(dry run — nothing applied. Re-run without --dry-run to migrate.)")); return 0; }
+
+  const { client, target } = makeClient(flags);
+  const health = await client.health();
+  if (!health.ok) { console.error(c(RED, `✗ OpenAGI main unreachable at ${target.url} — start it (\`openagi serve\`) or pass --remote`)); return 1; }
+
+  const result = await applyMigration({ extracted, dataDir: resolveDataDir(), client });
+  console.log(c(GREEN, `\n✓ migrated: ${result.importedMemories}/${extracted.memories.length} memories imported`)
+    + (result.persona ? c(GREEN, ", persona written") : "")
+    + (extracted.telegram.length ? c(GREEN, ", telegram configured") : ""));
+  console.log(c(DIM, "Restart the main to apply the persona + telegram (`openagi update`, or restart the service)."));
+  if (extracted.telegram.length) console.log(c(YELLOW, "If OpenClaw/Hermes is still running, stop it first — Telegram allows only one poller per bot token."));
+  return 0;
+}
+
 async function cmdImessageBridge(flags) {
   const { client, target } = makeClient(flags);
   if (!target.remote && !flags.remote) {
@@ -223,6 +261,8 @@ ${c(BOLD, "Use it (local, or a remote main):")}
   openagi setup               print the dashboard/setup URL + token
   openagi update [--check]    fast-forward + restart (or just check); set
                               OPENAGI_AUTO_UPDATE=1 for a daily auto-update
+  openagi migrate <openclaw|hermes> [--from D] [--dry-run]
+                              import another agent's persona, memory + telegram
   openagi tick                fire a scheduler tick
 
 ${c(BOLD, "Turn this device into a node of a remote main:")}
@@ -250,6 +290,7 @@ async function main() {
       case "pair": return cmdPair(positional, flags);
       case "unpair": return cmdUnpair();
       case "update": return await cmdUpdate(positional, flags);
+      case "migrate": return await cmdMigrate(positional, flags);
       case "imessage-bridge": return await cmdImessageBridge(flags);
       case "tick": return await cmdTick(flags);
       default:

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -1,0 +1,154 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Migrator: import an existing OpenClaw or Hermes Agent install into OpenAGI —
+// persona/identity, memory, and the Telegram bot — so the agent moves over as
+// ITSELF, not a fresh one. Generalizes the manual OpenClaw→OpenAGI migration.
+//
+// Each source adapter reads that agent's files and returns a normalized shape:
+//   { source, agentName, persona, memories: [{name, content}], telegram: {token, label}[], notes: [] }
+// The applier writes persona.md + Telegram env into OpenAGI's data dir and
+// POSTs each memory through /memory/remember. Non-destructive: the source
+// install is only read.
+
+const HOME = os.homedir();
+
+// ─── source detection ────────────────────────────────────────────────────
+
+export function defaultSourceDir(source) {
+  if (source === "openclaw") return path.join(HOME, ".openclaw");
+  if (source === "hermes") {
+    // Hermes keeps its workspace under a few known spots depending on version.
+    for (const d of [path.join(HOME, ".hermes"), path.join(HOME, ".hermes-agent"), path.join(HOME, "hermes", "workspace")]) {
+      if (fs.existsSync(d)) return d;
+    }
+    return path.join(HOME, ".hermes");
+  }
+  return null;
+}
+
+export function detectSource(dir = HOME) {
+  if (fs.existsSync(path.join(dir, ".openclaw", "openclaw.json")) || fs.existsSync(path.join(dir, "openclaw.json"))) return "openclaw";
+  if (fs.existsSync(path.join(dir, ".hermes")) || fs.existsSync(path.join(dir, "USER.md")) && fs.existsSync(path.join(dir, "MEMORY.md"))) return "hermes";
+  return null;
+}
+
+const readFile = (p) => { try { return fs.readFileSync(p, "utf8"); } catch { return null; } };
+const readJson = (p) => { try { return JSON.parse(fs.readFileSync(p, "utf8")); } catch { return null; } };
+const readMemoryDir = (dir) => {
+  let out = [];
+  try {
+    for (const f of fs.readdirSync(dir)) {
+      if (!f.endsWith(".md")) continue;
+      const content = readFile(path.join(dir, f))?.trim();
+      if (content) out.push({ name: f.replace(/\.md$/, ""), content });
+    }
+  } catch { /* no dir */ }
+  return out;
+};
+
+// ─── OpenClaw adapter ──────────────────────────────────────────────────────
+
+export function extractOpenClaw(dir) {
+  // dir is the .openclaw root (workspace/, openclaw.json, memory/).
+  const ws = path.join(dir, "workspace");
+  const identity = readFile(path.join(ws, "IDENTITY.md"));
+  const soul = readFile(path.join(ws, "SOUL.md"));
+  const user = readFile(path.join(ws, "USER.md"));
+  const personaParts = [identity, soul, user].filter(Boolean);
+
+  const agentName = identity?.match(/Name:?\**\s*[:|-]?\s*([^\n*]+)/i)?.[1]?.trim() || null;
+  const persona = personaParts.length
+    ? `# ${agentName ?? "Agent"} — persona\n\n${personaParts.join("\n\n")}`
+    : null;
+
+  const memories = readMemoryDir(path.join(ws, "memory"));
+
+  const cfg = readJson(path.join(dir, "openclaw.json"));
+  const telegram = [];
+  const accounts = cfg?.channels?.telegram?.accounts ?? {};
+  for (const [label, acct] of Object.entries(accounts)) {
+    if (acct?.botToken) telegram.push({ token: acct.botToken, label });
+  }
+
+  const notes = [];
+  const jobs = readJson(path.join(dir, "cron", "jobs.json"));
+  const jobList = Array.isArray(jobs) ? jobs : jobs?.jobs ?? [];
+  if (jobList.length) notes.push(`${jobList.length} cron job(s) found (recreate manually): ${jobList.map((j) => j.name).filter(Boolean).join(", ")}`);
+
+  return { source: "openclaw", agentName, persona, memories, telegram, notes };
+}
+
+// ─── Hermes adapter ────────────────────────────────────────────────────────
+
+export function extractHermes(dir) {
+  // Hermes' Tier-1 curated state: USER.md (about the human) + MEMORY.md
+  // (durable memory), at the workspace root. Plus any *.md under memory/.
+  const root = fs.existsSync(path.join(dir, "USER.md")) ? dir : path.join(dir, "workspace");
+  const user = readFile(path.join(root, "USER.md"));
+  const memoryMd = readFile(path.join(root, "MEMORY.md"));
+  const identity = readFile(path.join(root, "IDENTITY.md")) ?? readFile(path.join(root, "AGENT.md"));
+
+  const agentName = identity?.match(/Name:?\**\s*[:|-]?\s*([^\n*]+)/i)?.[1]?.trim() || null;
+  const personaParts = [identity, user].filter(Boolean);
+  const persona = personaParts.length ? `# ${agentName ?? "Agent"} — persona\n\n${personaParts.join("\n\n")}` : null;
+
+  const memories = [];
+  if (memoryMd) memories.push({ name: "MEMORY", content: memoryMd.trim() });
+  memories.push(...readMemoryDir(path.join(root, "memory")));
+
+  const telegram = [];
+  const cfg = readJson(path.join(dir, "config.json")) ?? readJson(path.join(dir, "hermes.json"));
+  const tok = cfg?.channels?.telegram?.botToken ?? cfg?.telegram?.botToken ?? cfg?.TELEGRAM_BOT_TOKEN;
+  if (tok) telegram.push({ token: tok, label: "default" });
+
+  const notes = [];
+  notes.push("Hermes SQLite/FTS memory and external memory plugins are not imported — only the curated USER.md/MEMORY.md state files.");
+
+  return { source: "hermes", agentName, persona, memories, telegram, notes };
+}
+
+export function extract(source, dir) {
+  if (source === "openclaw") return extractOpenClaw(dir);
+  if (source === "hermes") return extractHermes(dir);
+  throw new Error(`unknown source: ${source} (expected openclaw|hermes)`);
+}
+
+// ─── apply to OpenAGI ──────────────────────────────────────────────────────
+
+// Write persona.md + Telegram env to the data dir, POST memories through the
+// daemon. `client` is a CliClient pointed at the target (local or remote main).
+// dryRun → returns the plan without changing anything.
+export async function applyMigration({ extracted, dataDir, client, dryRun = false, env = {} }) {
+  const plan = { persona: Boolean(extracted.persona), memories: extracted.memories.length, telegram: extracted.telegram.length, agentName: extracted.agentName, applied: !dryRun };
+  if (dryRun) return { ...plan, notes: extracted.notes };
+
+  // 1. persona.md
+  if (extracted.persona) {
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(path.join(dataDir, "persona.md"), extracted.persona + "\n", { mode: 0o600 });
+  }
+
+  // 2. Telegram → <dataDir>/.env (first account only; long-poll for headless).
+  if (extracted.telegram[0]?.token) {
+    const envPath = path.join(dataDir, ".env");
+    let text = "";
+    try { text = fs.readFileSync(envPath, "utf8"); } catch { /* fresh */ }
+    if (!/^TELEGRAM_BOT_TOKEN=/m.test(text)) text += `${text.endsWith("\n") || !text ? "" : "\n"}TELEGRAM_BOT_TOKEN=${extracted.telegram[0].token}\n`;
+    if (!/^TELEGRAM_POLLING=/m.test(text)) text += "TELEGRAM_POLLING=1\n";
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(envPath, text, { mode: 0o600 });
+  }
+
+  // 3. memories → /memory/remember
+  let importedMemories = 0;
+  for (const m of extracted.memories) {
+    const res = await client.request("POST", "/memory/remember", {
+      content: m.content, tags: [`${extracted.source}-import`, m.name], importance: "high"
+    });
+    if (res.ok) importedMemories++;
+  }
+
+  return { ...plan, importedMemories, notes: extracted.notes };
+}

--- a/test/migrate.test.js
+++ b/test/migrate.test.js
@@ -1,0 +1,103 @@
+// Migrator: extract persona/memory/telegram from a synthetic OpenClaw and
+// Hermes install, and apply into OpenAGI (persona.md + .env + POSTed memories).
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { extractOpenClaw, extractHermes, detectSource, applyMigration } from "../src/migrate.js";
+
+function makeOpenClaw() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-src-"));
+  fs.mkdirSync(path.join(dir, "workspace", "memory"), { recursive: true });
+  fs.mkdirSync(path.join(dir, "cron"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "workspace", "IDENTITY.md"), "# IDENTITY\n- **Name:** Peri\n- Vibe: sharp");
+  fs.writeFileSync(path.join(dir, "workspace", "SOUL.md"), "# SOUL\nBe helpful, not performatively helpful.");
+  fs.writeFileSync(path.join(dir, "workspace", "USER.md"), "# USER\n- Name: Spencer");
+  fs.writeFileSync(path.join(dir, "workspace", "memory", "car-search.md"), "Evaluating EVs under $60k");
+  fs.writeFileSync(path.join(dir, "workspace", "memory", "cruise.md"), "Australia to New Zealand, March");
+  fs.writeFileSync(path.join(dir, "openclaw.json"), JSON.stringify({
+    channels: { telegram: { accounts: { default: { botToken: "123:ABC" }, wedding: { botToken: "456:DEF" } } } }
+  }));
+  fs.writeFileSync(path.join(dir, "cron", "jobs.json"), JSON.stringify([{ name: "Daily Todo" }]));
+  return dir;
+}
+
+test("extractOpenClaw pulls persona, memories, telegram, cron notes", () => {
+  const dir = makeOpenClaw();
+  const x = extractOpenClaw(dir);
+  assert.equal(x.agentName, "Peri");
+  assert.match(x.persona, /Be helpful, not performatively/);
+  assert.match(x.persona, /Name: Spencer/);
+  assert.equal(x.memories.length, 2);
+  assert.ok(x.memories.some((m) => m.name === "car-search" && /EVs/.test(m.content)));
+  assert.deepEqual(x.telegram.map((t) => t.label).sort(), ["default", "wedding"]);
+  assert.ok(x.notes.some((n) => /cron job/.test(n)));
+  fs.rmSync(dir, { recursive: true });
+});
+
+test("extractHermes reads USER.md + MEMORY.md", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-src-"));
+  fs.writeFileSync(path.join(dir, "USER.md"), "# USER\n- Name: Spencer\n- TZ: PST");
+  fs.writeFileSync(path.join(dir, "MEMORY.md"), "Durable: the standup is 9am Mondays.");
+  fs.writeFileSync(path.join(dir, "config.json"), JSON.stringify({ telegram: { botToken: "999:ZZZ" } }));
+  const x = extractHermes(dir);
+  assert.equal(x.source, "hermes");
+  assert.match(x.persona, /Name: Spencer/);
+  assert.ok(x.memories.some((m) => m.name === "MEMORY" && /standup is 9am/.test(m.content)));
+  assert.equal(x.telegram[0].token, "999:ZZZ");
+  fs.rmSync(dir, { recursive: true });
+});
+
+test("detectSource identifies an OpenClaw home", () => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "home-"));
+  fs.mkdirSync(path.join(home, ".openclaw"));
+  fs.writeFileSync(path.join(home, ".openclaw", "openclaw.json"), "{}");
+  assert.equal(detectSource(home), "openclaw");
+  fs.rmSync(home, { recursive: true });
+});
+
+test("applyMigration writes persona.md + telegram env and POSTs memories", async () => {
+  const src = makeOpenClaw();
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-data-"));
+  const posted = [];
+  const client = { request: async (m, route, body) => { posted.push({ route, body }); return { ok: true }; } };
+  const extracted = extractOpenClaw(src);
+
+  const result = await applyMigration({ extracted, dataDir, client });
+  assert.equal(result.importedMemories, 2);
+  assert.ok(posted.every((p) => p.route === "/memory/remember"));
+  assert.ok(posted[0].body.tags.includes("openclaw-import"));
+
+  const persona = fs.readFileSync(path.join(dataDir, "persona.md"), "utf8");
+  assert.match(persona, /Peri/);
+  const env = fs.readFileSync(path.join(dataDir, ".env"), "utf8");
+  assert.match(env, /TELEGRAM_BOT_TOKEN=123:ABC/);
+  assert.match(env, /TELEGRAM_POLLING=1/);
+
+  fs.rmSync(src, { recursive: true });
+  fs.rmSync(dataDir, { recursive: true });
+});
+
+test("dry run plans without writing anything", async () => {
+  const src = makeOpenClaw();
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-data2-"));
+  const result = await applyMigration({ extracted: extractOpenClaw(src), dataDir, client: { request: async () => ({ ok: true }) }, dryRun: true });
+  assert.equal(result.applied, false);
+  assert.equal(result.memories, 2);
+  assert.ok(!fs.existsSync(path.join(dataDir, "persona.md")), "nothing written on dry run");
+  fs.rmSync(src, { recursive: true });
+  fs.rmSync(dataDir, { recursive: true });
+});
+
+test("applyMigration preserves an existing token (won't overwrite)", async () => {
+  const src = makeOpenClaw();
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-data3-"));
+  fs.writeFileSync(path.join(dataDir, ".env"), "TELEGRAM_BOT_TOKEN=existing:token\n");
+  await applyMigration({ extracted: extractOpenClaw(src), dataDir, client: { request: async () => ({ ok: true }) } });
+  const env = fs.readFileSync(path.join(dataDir, ".env"), "utf8");
+  assert.match(env, /TELEGRAM_BOT_TOKEN=existing:token/);
+  assert.ok(!env.includes("123:ABC"), "did not clobber the existing token");
+  fs.rmSync(src, { recursive: true });
+  fs.rmSync(dataDir, { recursive: true });
+});


### PR DESCRIPTION
Packages the manual OpenClaw→OpenAGI migration (persona, memory, Telegram) into a reusable command so anyone can move an existing agent over as **itself**:

```
openagi migrate <openclaw|hermes> [--from DIR] [--dry-run] [--remote URL]
```

- **`src/migrate.js`** — source adapters normalize each agent's files into `{ agentName, persona, memories[], telegram[], notes[] }`:
  - **OpenClaw**: `workspace/IDENTITY+SOUL+USER.md` → persona; `workspace/memory/*.md` → memories; `openclaw.json` telegram bot tokens; cron note.
  - **Hermes**: `USER.md` + `MEMORY.md` curated state + `memory/*.md`; config telegram.
  - Applier writes `persona.md` + Telegram env to the data dir and POSTs each memory via `/memory/remember`. Non-destructive; `--dry-run` shows the plan; preserves an existing token.

Tests: 6 cases; full suite green. Verified live against a real OpenClaw ("Peri") install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)