### PR TITLE
feat: iMessage bridge response policies + memory capture

### DIFF
--- a/bin/openagi.js
+++ b/bin/openagi.js
@@ -37,6 +37,9 @@ function parseArgs(argv) {
     else if (a === "--check") flags.check = true;
     else if (a === "--from") flags.from = argv[++i];
     else if (a === "--dry-run") flags.dryRun = true;
+    else if (a === "--respond") flags.respond = argv[++i];
+    else if (a === "--capture") flags.capture = argv[++i];
+    else if (a === "--trigger") flags.trigger = argv[++i];
     else if (a === "-h" || a === "--help") flags.help = true;
     else positional.push(a);
   }
@@ -203,16 +206,19 @@ async function cmdImessageBridge(flags) {
 
   const { IMessageBridge } = await import("../src/integrations/imessage-bridge.js");
   const allowFrom = flags.allow ? String(flags.allow).split(",").map((s) => s.trim()).filter(Boolean) : [];
+  const respondMode = flags.respond ?? (allowFrom.length ? "allow" : "all");
+  const captureMode = flags.capture ?? "none";
   const bridge = new IMessageBridge({
-    client,
-    allowFrom,
+    client, allowFrom, respondMode, captureMode, trigger: flags.trigger,
     onEvent: (e) => {
       if (e.kind === "relayed") console.log(c(GREEN, `↔ ${e.handle}: `) + c(DIM, `"${e.in}" → "${e.out}"`));
+      else if (e.kind === "captured") console.log(c(DIM, `· saved to memory — ${e.handle}: "${e.in}"`));
       else if (e.kind && e.error) console.error(c(YELLOW, `! ${e.kind} ${e.handle ?? ""}: ${e.error}`));
     }
   });
   console.log(c(GREEN, `iMessage bridge → main at ${target.url}`));
-  console.log(c(DIM, `Incoming iMessages${allowFrom.length ? ` from ${allowFrom.join(", ")}` : ""} are answered by the main. Ctrl-C to stop.`));
+  const respondDesc = respondMode === "all" ? "everyone" : respondMode === "allow" ? `allowlist (${allowFrom.join(", ")})` : respondMode === "trigger" ? `messages containing "${flags.trigger}"` : "no one (capture-only)";
+  console.log(c(DIM, `Reply to: ${respondDesc}.${captureMode !== "none" ? ` Save to memory: ${captureMode}.` : ""} Ctrl-C to stop.`));
   console.log(c(DIM, "Requires: Full Disk Access (read chat.db) + Automation→Messages (send) for this process."));
   bridge.start({ intervalMs: 2000 });
   await new Promise(() => {}); // run until killed
@@ -268,8 +274,12 @@ ${c(BOLD, "Use it (local, or a remote main):")}
 ${c(BOLD, "Turn this device into a node of a remote main:")}
   openagi pair <main-url> [--token T]    save the main as this device's target
   openagi unpair                         forget it
-  openagi imessage-bridge [--allow h,…]  (macOS) relay incoming iMessages to the
-                                         main and text its replies back
+  openagi imessage-bridge [opts]         (macOS) relay incoming iMessages to the
+                                         main and text its replies back. Opts:
+                                         --respond all|allow|trigger|none
+                                         --allow h1,h2   (sender allowlist)
+                                         --trigger word  (reply only on a word)
+                                         --capture none|allow|all  (→ memory)
 
 ${c(BOLD, "Global flags:")} --remote <url>  --token <token>  --json
 

--- a/src/integrations/imessage-bridge.js
+++ b/src/integrations/imessage-bridge.js
@@ -19,6 +19,7 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 const DEFAULT_DB = path.join(os.homedir(), "Library", "Messages", "chat.db");
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 export class IMessageBridge {
   constructor(options = {}) {
@@ -27,9 +28,27 @@ export class IMessageBridge {
     this.statePath = options.statePath ?? path.join(options.dataDir ?? path.join(os.homedir(), ".openagi"), "imessage-bridge.json");
     this.readMessages = options.readMessages ?? ((sinceRowid) => readNewMessages(this.dbPath, sinceRowid));
     this.sendMessage = options.sendMessage ?? sendViaIMessage;
-    // Optional allowlist of sender handles (phone/email). Empty = anyone.
-    this.allowFrom = new Set((options.allowFrom ?? []).map((h) => String(h).toLowerCase()));
     this.onEvent = options.onEvent ?? (() => {});
+
+    // Sender allowlist (phone/email handles), lower-cased.
+    this.allowFrom = new Set((options.allowFrom ?? []).map((h) => String(h).toLowerCase()));
+
+    // Response policy — WHO/WHAT gets an agent reply:
+    //   all     → reply to every incoming message
+    //   allow   → reply only to allowlisted senders (default when --allow given)
+    //   trigger → reply only when the message contains `trigger` (and, if an
+    //             allowlist is set, the sender is on it) — the trigger word is
+    //             stripped before forwarding ("Peri what's up" → "what's up")
+    //   none    → never reply (capture-only mode)
+    this.respondMode = options.respondMode ?? (this.allowFrom.size ? "allow" : "all");
+    this.trigger = (options.trigger ?? "").toLowerCase();
+
+    // Capture policy — WHICH incoming messages are saved to the main's memory
+    // (ambient awareness, even when not replied to):
+    //   none  → save nothing extra (replies still create their own memory)
+    //   allow → save messages from allowlisted senders
+    //   all   → save every incoming message
+    this.captureMode = options.captureMode ?? "none";
   }
 
   _loadState() {
@@ -40,31 +59,70 @@ export class IMessageBridge {
     fs.writeFileSync(this.statePath, JSON.stringify(state, null, 2) + "\n", { mode: 0o600 });
   }
 
-  allowed(handle) {
+  onAllowlist(handle) {
     return this.allowFrom.size === 0 || this.allowFrom.has(String(handle).toLowerCase());
   }
 
-  // One pass: forward each new allowed incoming message, reply with the main's
-  // answer. Returns a summary { processed, replied, skipped, errors }.
+  // Decide whether to reply, and return the text to forward (trigger stripped).
+  // { respond: bool, forward: string }
+  responseFor(handle, text) {
+    const allowed = this.allowFrom.size === 0 || this.allowFrom.has(String(handle).toLowerCase());
+    if (this.respondMode === "none") return { respond: false };
+    if (this.respondMode === "all") return { respond: true, forward: text };
+    if (this.respondMode === "allow") return { respond: allowed, forward: text };
+    if (this.respondMode === "trigger") {
+      if (!allowed || !this.trigger) return { respond: false };
+      const lower = text.toLowerCase();
+      const at = lower.indexOf(this.trigger);
+      if (at === -1) return { respond: false };
+      // Strip a leading "<trigger>[,:]" prefix; otherwise forward as-is.
+      const stripped = text.replace(new RegExp(`^\\s*${escapeRe(this.trigger)}[\\s,:]+`, "i"), "").trim();
+      return { respond: true, forward: stripped || text };
+    }
+    return { respond: false };
+  }
+
+  shouldCapture(handle) {
+    if (this.captureMode === "all") return true;
+    if (this.captureMode === "allow") return this.allowFrom.has(String(handle).toLowerCase());
+    return false;
+  }
+
+  // One pass: for each new incoming message, optionally capture it to the
+  // main's memory and optionally reply via the agent. Returns a summary.
   async poll() {
     let state = this._loadState();
     // First run: don't replay history — start from the current high-water mark.
     if (state.lastRowid == null) {
       state = { lastRowid: await this.readMaxRowid(), initialized: true };
       this._saveState(state);
-      return { processed: 0, replied: 0, skipped: 0, errors: 0, bootstrapped: true };
+      return { processed: 0, replied: 0, captured: 0, skipped: 0, errors: 0, bootstrapped: true };
     }
 
     const rows = await this.readMessages(state.lastRowid);
-    let processed = 0, replied = 0, skipped = 0, errors = 0, highest = state.lastRowid;
+    let processed = 0, replied = 0, captured = 0, skipped = 0, errors = 0, highest = state.lastRowid;
     for (const row of rows) {
       if (row.rowid > highest) highest = row.rowid;
       processed++;
       const text = (row.text ?? "").trim();
       if (!text || !row.handle) { skipped++; continue; }
-      if (!this.allowed(row.handle)) { skipped++; continue; }
+
+      // 1. Ambient memory capture (independent of replying).
+      if (this.shouldCapture(row.handle)) {
+        try {
+          const cap = await this.client.request("POST", "/memory/remember", {
+            content: `iMessage from ${row.handle}: ${text}`,
+            tags: ["imessage", row.handle], importance: "normal"
+          });
+          if (cap.ok) { captured++; this.onEvent({ kind: "captured", handle: row.handle, in: text.slice(0, 80) }); }
+        } catch { /* capture is best-effort */ }
+      }
+
+      // 2. Reply per the response policy.
+      const decision = this.responseFor(row.handle, text);
+      if (!decision.respond) { skipped++; continue; }
       try {
-        const res = await this.client.chat(text, { from: `imessage:${row.handle}` });
+        const res = await this.client.chat(decision.forward, { from: `imessage:${row.handle}` });
         const reply = res?.json?.reply;
         if (res?.ok && reply) {
           await this.sendMessage(row.handle, reply);
@@ -80,7 +138,7 @@ export class IMessageBridge {
       }
     }
     this._saveState({ ...state, lastRowid: highest });
-    return { processed, replied, skipped, errors };
+    return { processed, replied, captured, skipped, errors };
   }
 
   async readMaxRowid() {

--- a/test/imessage-bridge.test.js
+++ b/test/imessage-bridge.test.js
@@ -97,3 +97,70 @@ test("extractAttributedText returns empty for a body with no NSString marker", (
   assert.equal(extractAttributedText(Buffer.from("garbage")), "");
   assert.equal(extractAttributedText(null), "");
 });
+
+// ── response policies + memory capture ──────────────────────────────────────
+
+function policyBridge(opts) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-imsg-pol-"));
+  const sent = [], forwarded = [], remembered = [];
+  const client = {
+    chat: async (text, o) => { forwarded.push({ text, from: o.from }); return { ok: true, json: { reply: "ok-reply" } }; },
+    request: async (m, route, body) => { if (route === "/memory/remember") remembered.push(body); return { ok: true }; }
+  };
+  const bridge = new IMessageBridge({
+    client, dataDir: dir,
+    readMessages: async () => [],
+    sendMessage: async (h, t) => sent.push({ h, t }),
+    ...opts
+  });
+  bridge._saveState({ lastRowid: 0, initialized: true });
+  return { bridge, sent, forwarded, remembered };
+}
+
+test("respond=all replies to everyone; respond=none never replies", async () => {
+  let b = policyBridge({ respondMode: "all" });
+  b.bridge.readMessages = async () => [{ rowid: 1, handle: "+1999", text: "hi" }];
+  assert.equal((await b.bridge.poll()).replied, 1);
+
+  b = policyBridge({ respondMode: "none" });
+  b.bridge.readMessages = async () => [{ rowid: 1, handle: "+1999", text: "hi" }];
+  const r = await b.bridge.poll();
+  assert.equal(r.replied, 0);
+  assert.equal(b.sent.length, 0);
+});
+
+test("respond=trigger only replies on the trigger word, stripped before forwarding", async () => {
+  const b = policyBridge({ respondMode: "trigger", trigger: "peri", allowFrom: ["+15551112222"] });
+  b.bridge.readMessages = async () => [
+    { rowid: 1, handle: "+15551112222", text: "just chatting, no trigger" },
+    { rowid: 2, handle: "+15551112222", text: "Peri, what's the weather?" }
+  ];
+  const r = await b.bridge.poll();
+  assert.equal(r.replied, 1, "only the triggered message");
+  assert.equal(b.forwarded.length, 1);
+  assert.equal(b.forwarded[0].text, "what's the weather?", "trigger prefix stripped");
+});
+
+test("capture=all saves every incoming message to memory, even unreplied", async () => {
+  const b = policyBridge({ respondMode: "none", captureMode: "all" });
+  b.bridge.readMessages = async () => [
+    { rowid: 1, handle: "+1888", text: "remember the milk" },
+    { rowid: 2, handle: "+1777", text: "and eggs" }
+  ];
+  const r = await b.bridge.poll();
+  assert.equal(r.captured, 2);
+  assert.equal(r.replied, 0, "capture-only: no replies");
+  assert.match(b.remembered[0].content, /iMessage from \+1888: remember the milk/);
+  assert.ok(b.remembered[0].tags.includes("imessage"));
+});
+
+test("capture=allow only saves allowlisted senders", async () => {
+  const b = policyBridge({ respondMode: "all", captureMode: "allow", allowFrom: ["+15551112222"] });
+  b.bridge.readMessages = async () => [
+    { rowid: 1, handle: "+1999", text: "stranger" },
+    { rowid: 2, handle: "+15551112222", text: "trusted" }
+  ];
+  const r = await b.bridge.poll();
+  assert.equal(r.captured, 1);
+  assert.match(b.remembered[0].content, /trusted/);
+});


### PR DESCRIPTION
The iMessage bridge can now choose **who/what it answers** and **what it remembers**:

**Response policy (`--respond`)**: `all` · `allow` (+`--allow h1,h2`) · `trigger` (+`--trigger word`, stripped before forwarding) · `none` (capture-only).

**Memory capture (`--capture`)**: `none` · `allow` · `all` — saves incoming messages to the main's memory via `/memory/remember` independent of replying, giving the agent ambient awareness.

So a Mac becomes a real iMessage agent: capture everything from family to memory but only reply when they say "Peri"; reply to everyone; observe-only; etc. The agent's own tools (remember/add_task) already run when it replies.

Tests: 4 new policy/capture cases; full suite 282/282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)