### PR TITLE
fix+feat: iMessage date overflow fix + searchMessages / openagi imessage-search

### DIFF
--- a/bin/openagi.js
+++ b/bin/openagi.js
@@ -40,6 +40,8 @@ function parseArgs(argv) {
     else if (a === "--respond") flags.respond = argv[++i];
     else if (a === "--capture") flags.capture = argv[++i];
     else if (a === "--trigger") flags.trigger = argv[++i];
+    else if (a === "--days") flags.days = argv[++i];
+    else if (a === "--limit") flags.limit = argv[++i];
     else if (a === "-h" || a === "--help") flags.help = true;
     else positional.push(a);
   }
@@ -195,6 +197,26 @@ async function cmdMigrate(positional, flags) {
   return 0;
 }
 
+async function cmdImessageSearch(positional, flags) {
+  const { searchMessages } = await import("../src/integrations/imessage-bridge.js");
+  const query = positional.join(" ").trim();
+  let rows;
+  try {
+    rows = await searchMessages(undefined, { query, handle: flags.from, days: flags.days ? Number(flags.days) : null, limit: flags.limit ? Number(flags.limit) : 30 });
+  } catch (error) {
+    console.error(c(RED, `✗ ${/too large|cantopen|unable to open/i.test(error.message) ? "can't read chat.db — grant Full Disk Access to this process" : error.message}`));
+    return 1;
+  }
+  if (flags.json) { console.log(JSON.stringify(rows, null, 2)); return 0; }
+  if (!rows.length) { console.log(c(DIM, "no matching messages")); return 0; }
+  for (const m of rows) {
+    const who = m.fromMe ? c(GREEN, "me →") : c(BOLD, `${m.handle} →`);
+    const when = m.date ? c(DIM, m.date.slice(0, 16).replace("T", " ")) : "";
+    console.log(`${when} ${who} ${m.text.replace(/\s+/g, " ").slice(0, 200)}`);
+  }
+  return 0;
+}
+
 async function cmdImessageBridge(flags) {
   const { client, target } = makeClient(flags);
   if (!target.remote && !flags.remote) {
@@ -302,6 +324,7 @@ async function main() {
       case "update": return await cmdUpdate(positional, flags);
       case "migrate": return await cmdMigrate(positional, flags);
       case "imessage-bridge": return await cmdImessageBridge(flags);
+      case "imessage-search": return await cmdImessageSearch(positional, flags);
       case "tick": return await cmdTick(flags);
       default:
         console.error(c(RED, `unknown command: ${cmd}`));

--- a/src/integrations/imessage-bridge.js
+++ b/src/integrations/imessage-bridge.js
@@ -167,9 +167,12 @@ export async function readNewMessages(dbPath, sinceRowid) {
   const { DatabaseSync } = await import("node:sqlite");
   const db = new DatabaseSync(dbPath);
   try {
+    // CAST date to TEXT: chat.db `date` is nanoseconds since 2001 (~8e17),
+    // which overflows a JS number and makes node:sqlite throw. We only need it
+    // as a string timestamp anyway.
     const rows = db.prepare(`
       SELECT m.ROWID AS rowid, m.text AS text, m.attributedBody AS body,
-             m.date AS appleDate, h.id AS handle
+             CAST(m.date AS TEXT) AS appleDate, h.id AS handle
       FROM message m
       LEFT JOIN handle h ON h.ROWID = m.handle_id
       WHERE m.ROWID > ? AND m.is_from_me = 0 AND h.id IS NOT NULL
@@ -205,6 +208,49 @@ export function extractAttributedText(body) {
   let end = i;
   while (end > start && buf[end - 1] < 0x20) end--;
   return buf.slice(start, end).toString("utf8").trim();
+}
+
+// Search the iMessage history (both directions). Filters: text `query`
+// (substring, case-insensitive), `handle` (sender/recipient), `days` (lookback).
+// Returns newest-first [{ rowid, handle, fromMe, text, date }]. This is what an
+// "ask questions about my iMessages" capability calls. chat.db `date` is
+// nanoseconds since the 2001-01-01 Apple epoch.
+const APPLE_EPOCH_MS = 978307200000; // 2001-01-01 UTC in unix ms
+export async function searchMessages(dbPath, { query = "", handle = null, days = null, limit = 50 } = {}) {
+  const { DatabaseSync } = await import("node:sqlite");
+  const db = new DatabaseSync(dbPath);
+  try {
+    const where = ["(m.text IS NOT NULL OR m.attributedBody IS NOT NULL)"];
+    const params = [];
+    if (handle) { where.push("h.id LIKE ?"); params.push(`%${handle}%`); }
+    if (days) {
+      const cutoffNs = String(BigInt(Math.floor((Date.now() - days * 86400000 - APPLE_EPOCH_MS))) * 1000000n);
+      where.push("CAST(m.date AS TEXT) > ?"); params.push(cutoffNs);
+    }
+    // Pull a window newest-first, then filter text in JS (covers attributedBody).
+    const rows = db.prepare(`
+      SELECT m.ROWID AS rowid, m.text AS text, m.attributedBody AS body,
+             m.is_from_me AS fromMe, CAST(m.date AS TEXT) AS dateNs, h.id AS handle
+      FROM message m
+      LEFT JOIN handle h ON h.ROWID = m.handle_id
+      WHERE ${where.join(" AND ")}
+      ORDER BY m.ROWID DESC
+      LIMIT 2000
+    `).all(...params);
+    const q = query.trim().toLowerCase();
+    const out = [];
+    for (const r of rows) {
+      const text = r.text && r.text.trim() ? r.text : extractAttributedText(r.body);
+      if (!text) continue;
+      if (q && !text.toLowerCase().includes(q)) continue;
+      const ns = r.dateNs ? Number(BigInt(r.dateNs) / 1000000n) + APPLE_EPOCH_MS : null;
+      out.push({ rowid: r.rowid, handle: r.handle, fromMe: r.fromMe === 1, text, date: ns ? new Date(ns).toISOString() : null });
+      if (out.length >= limit) break;
+    }
+    return out;
+  } finally {
+    db.close();
+  }
 }
 
 // Send a message back over iMessage via AppleScript. Requires Automation

--- a/test/imessage-bridge.test.js
+++ b/test/imessage-bridge.test.js
@@ -164,3 +164,41 @@ test("capture=allow only saves allowlisted senders", async () => {
   assert.equal(r.captured, 1);
   assert.match(b.remembered[0].content, /trusted/);
 });
+
+// ── search ──────────────────────────────────────────────────────────────────
+
+import { searchMessages } from "../src/integrations/imessage-bridge.js";
+
+async function makeChatDb() {
+  const { DatabaseSync } = await import("node:sqlite");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "chatdb-"));
+  const file = path.join(dir, "chat.db");
+  const db = new DatabaseSync(file);
+  db.exec(`CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);
+           CREATE TABLE message (ROWID INTEGER PRIMARY KEY, text TEXT, attributedBody BLOB, is_from_me INTEGER, date INTEGER, handle_id INTEGER);`);
+  db.prepare("INSERT INTO handle (ROWID,id) VALUES (1,?),(2,?)").run("+15551112222", "sarah@example.com");
+  const nowNs = String(BigInt(Date.now() - 978307200000) * 1000000n);
+  const oldNs = String(BigInt(Date.now() - 978307200000 - 40 * 86400000) * 1000000n);
+  db.prepare("INSERT INTO message (text,is_from_me,date,handle_id) VALUES (?,?,?,?)").run("dinner at 7 tonight", 0, nowNs, 1);
+  db.prepare("INSERT INTO message (text,is_from_me,date,handle_id) VALUES (?,?,?,?)").run("sounds good, see you then", 1, nowNs, 1);
+  db.prepare("INSERT INTO message (text,is_from_me,date,handle_id) VALUES (?,?,?,?)").run("old message about taxes", 0, oldNs, 2);
+  db.close();
+  return file;
+}
+
+test("searchMessages finds by text, both directions", async () => {
+  const file = await makeChatDb();
+  const hits = await searchMessages(file, { query: "dinner" });
+  assert.equal(hits.length, 1);
+  assert.match(hits[0].text, /dinner at 7/);
+  assert.equal(hits[0].fromMe, false);
+  assert.ok(hits[0].date, "has an ISO date");
+});
+
+test("searchMessages filters by handle and by days", async () => {
+  const file = await makeChatDb();
+  assert.equal((await searchMessages(file, { handle: "sarah" })).length, 1, "by handle (email)");
+  const recent = await searchMessages(file, { days: 7 });
+  assert.ok(recent.every((m) => !/taxes/.test(m.text)), "40-day-old message excluded by days=7");
+  assert.ok(recent.length >= 2);
+});


### PR DESCRIPTION
**Fix:** chat.db `date` (ns since 2001, ~8e17) overflowed a JS number → `node:sqlite` threw "Value is too large" on every bridge poll. CAST to TEXT.

**Feature:** `searchMessages(dbPath, {query, handle, days, limit})` searches iMessage history both directions (with attributedBody fallback + ISO dates). CLI: `openagi imessage-search <query> [--from h] [--days N]`. Foundation for the agent answering questions about your iMessages.

Tests: search by text/handle/days; full suite 284/284.