### PR TITLE
feat: search_imessages tool — agent answers questions about your texts

### DIFF
--- a/bin/openagi.js
+++ b/bin/openagi.js
@@ -197,6 +197,20 @@ async function cmdMigrate(positional, flags) {
   return 0;
 }
 
+async function cmdImessageServer(flags) {
+  const { createImessageServer } = await import("../src/integrations/imessage-server.js");
+  const token = flags.token ?? process.env.OPENAGI_IMESSAGE_NODE_TOKEN ?? null;
+  if (!token) { console.error(c(RED, "a token is required — pass --token <secret> (the main uses the same as OPENAGI_IMESSAGE_NODE_TOKEN)")); return 1; }
+  const port = Number(flags.port ?? process.env.OPENAGI_IMESSAGE_PORT ?? 43298);
+  const host = flags.host ?? "0.0.0.0";
+  const server = createImessageServer({ token });
+  await new Promise((resolve) => server.listen(port, host, resolve));
+  console.log(c(GREEN, `iMessage node service on http://${host}:${port}`));
+  console.log(c(DIM, `On the main, set OPENAGI_IMESSAGE_NODE=http://<this-host>:${port} and OPENAGI_IMESSAGE_NODE_TOKEN=<the token>, then restart — the agent gets a search_imessages tool.`));
+  console.log(c(DIM, "Requires Full Disk Access (read chat.db) for this process. Ctrl-C to stop."));
+  await new Promise(() => {}); // run until killed
+}
+
 async function cmdImessageSearch(positional, flags) {
   const { searchMessages } = await import("../src/integrations/imessage-bridge.js");
   const query = positional.join(" ").trim();
@@ -302,6 +316,10 @@ ${c(BOLD, "Turn this device into a node of a remote main:")}
                                          --allow h1,h2   (sender allowlist)
                                          --trigger word  (reply only on a word)
                                          --capture none|allow|all  (→ memory)
+  openagi imessage-search <query>        (macOS) search iMessage history
+                                         [--from h] [--days N] [--limit N]
+  openagi imessage-server --token T      (macOS) serve iMessage search to a
+                                         remote main (gives it search_imessages)
 
 ${c(BOLD, "Global flags:")} --remote <url>  --token <token>  --json
 
@@ -325,6 +343,7 @@ async function main() {
       case "migrate": return await cmdMigrate(positional, flags);
       case "imessage-bridge": return await cmdImessageBridge(flags);
       case "imessage-search": return await cmdImessageSearch(positional, flags);
+      case "imessage-server": return await cmdImessageServer(flags);
       case "tick": return await cmdTick(flags);
       default:
         console.error(c(RED, `unknown command: ${cmd}`));

--- a/src/abi-runtime.js
+++ b/src/abi-runtime.js
@@ -17,6 +17,7 @@ import { registerIMessagePoller } from "./integrations/imessage-poller.js";
 import { registerBuildBetterTaskSource } from "./integrations/buildbetter-tasks.js";
 import { registerCalendarIntegration } from "./integrations/calendar.js";
 import { registerWebSearchTools } from "./integrations/web-search.js";
+import { registerImessageSearchTool } from "./integrations/imessage-search-tool.js";
 import { createEmbedder } from "./embeddings.js";
 import { McpRegistry } from "./mcp-registry.js";
 import { MemoryCondenser } from "./memory-condenser.js";
@@ -404,6 +405,9 @@ export class AbiRuntime {
       // Web search tools (web_search / fetch_url). Always registered; web_search
       // returns a clear "no provider configured" error until a key is set.
       registerWebSearchTools(this);
+      // search_imessages — only when an iMessage node (a Mac running
+      // `openagi imessage-server`) is configured via OPENAGI_IMESSAGE_NODE.
+      registerImessageSearchTool(this);
     }
   }
 

--- a/src/integrations/imessage-search-tool.js
+++ b/src/integrations/imessage-search-tool.js
@@ -1,0 +1,50 @@
+// Main-side tool: `search_imessages`. Lets the agent answer questions about the
+// user's iMessages even though chat.db lives on a different machine (a Mac
+// node). The tool proxies to that node's iMessage service (see
+// imessage-server.js), which the node runs with `openagi imessage-server`.
+//
+// Enabled only when OPENAGI_IMESSAGE_NODE is set (the node's base URL, e.g.
+// http://macmini.tailnet:43298). OPENAGI_IMESSAGE_NODE_TOKEN authenticates.
+// Off by default — no node configured → no tool, so non-Mac mains are clean.
+
+export function registerImessageSearchTool(runtime, { fetchImpl = globalThis.fetch } = {}) {
+  const nodeUrl = (process.env.OPENAGI_IMESSAGE_NODE ?? "").replace(/\/$/, "");
+  if (!nodeUrl) return { registered: false, reason: "OPENAGI_IMESSAGE_NODE not set" };
+  const nodeToken = process.env.OPENAGI_IMESSAGE_NODE_TOKEN ?? null;
+
+  runtime.tools.register({
+    name: "search_imessages",
+    sideEffects: false,
+    description: "Search the user's iMessage / text history by content, person, and recency. Use to answer questions about past texts (e.g. 'what did Sarah say about dinner?', 'find the address someone sent me last week'). Returns matching messages newest-first.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Text to search for in messages (substring match)." },
+        person: { type: "string", description: "Filter to a contact — a phone number or email handle (partial match)." },
+        days: { type: "integer", description: "Only messages from the last N days." },
+        limit: { type: "integer", minimum: 1, maximum: 100, description: "Max results (default 20)." }
+      },
+      additionalProperties: false
+    },
+    handler: async (args) => {
+      try {
+        const res = await fetchImpl(`${nodeUrl}/search`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...(nodeToken ? { authorization: `Bearer ${nodeToken}` } : {}) },
+          body: JSON.stringify({ query: args.query ?? "", handle: args.person ?? null, days: args.days ?? null, limit: args.limit ?? 20 })
+        });
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok) return { error: body.error ?? `iMessage node returned ${res.status}` };
+        const results = (body.results ?? []).map((m) => ({
+          from: m.fromMe ? "me" : m.handle,
+          at: m.date,
+          text: m.text
+        }));
+        return { count: results.length, results };
+      } catch (error) {
+        return { error: `couldn't reach the iMessage node at ${nodeUrl}: ${error.message}` };
+      }
+    }
+  });
+  return { registered: true, nodeUrl };
+}

--- a/src/integrations/imessage-server.js
+++ b/src/integrations/imessage-server.js
@@ -1,0 +1,55 @@
+import http from "node:http";
+import { searchMessages } from "./imessage-bridge.js";
+
+// iMessage node service — runs on the Mac that has chat.db (Full Disk Access),
+// and exposes SEARCH over the network so a remote OpenAGI "main" can answer
+// questions about the user's iMessages. Bearer-token gated; the main calls it
+// via the `search_imessages` tool.
+//
+//   POST /search { query?, handle?, days?, limit? } -> { results: [...] }
+//   GET  /health -> { ok: true }
+//
+// The brain stays on the main; this only serves read-only message search.
+
+export function createImessageServer({ token, dbPath } = {}) {
+  return http.createServer((req, res) => {
+    const send = (code, body) => {
+      res.writeHead(code, { "content-type": "application/json" });
+      res.end(JSON.stringify(body));
+    };
+    // Auth (constant-ish check). /health stays open for reachability probes.
+    const url = new URL(req.url, "http://x");
+    if (url.pathname !== "/health") {
+      const auth = req.headers.authorization ?? "";
+      const presented = auth.startsWith("Bearer ") ? auth.slice(7) : "";
+      if (!token || presented !== token) return send(401, { error: "unauthorized" });
+    }
+
+    if (req.method === "GET" && url.pathname === "/health") return send(200, { ok: true, service: "imessage" });
+
+    if (req.method === "POST" && url.pathname === "/search") {
+      let raw = "";
+      req.on("data", (c) => { raw += c; if (raw.length > 1e6) req.destroy(); });
+      req.on("end", async () => {
+        let body = {};
+        try { body = raw ? JSON.parse(raw) : {}; } catch { return send(400, { error: "bad json" }); }
+        try {
+          const results = await searchMessages(dbPath, {
+            query: body.query ?? "",
+            handle: body.handle ?? body.person ?? null,
+            days: body.days != null ? Number(body.days) : null,
+            limit: Math.min(Number(body.limit) || 30, 100)
+          });
+          send(200, { results });
+        } catch (error) {
+          const msg = /too large|cantopen|unable to open/i.test(error.message)
+            ? "can't read chat.db — grant Full Disk Access to this process"
+            : error.message;
+          send(500, { error: msg });
+        }
+      });
+      return;
+    }
+    send(404, { error: "not found" });
+  });
+}

--- a/test/imessage-search-tool.test.js
+++ b/test/imessage-search-tool.test.js
@@ -1,0 +1,96 @@
+// search_imessages tool (main side) proxies to the node; iMessage node service
+// (node side) serves auth-gated search over chat.db.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { ToolRegistry } from "../src/index.js";
+import { registerImessageSearchTool } from "../src/integrations/imessage-search-tool.js";
+import { createImessageServer } from "../src/integrations/imessage-server.js";
+
+const withEnv = (k, v, fn) => {
+  const saved = process.env[k];
+  if (v === undefined) delete process.env[k]; else process.env[k] = v;
+  try { return fn(); } finally { if (saved === undefined) delete process.env[k]; else process.env[k] = saved; }
+};
+
+test("tool not registered without OPENAGI_IMESSAGE_NODE", () => {
+  withEnv("OPENAGI_IMESSAGE_NODE", undefined, () => {
+    const runtime = { tools: new ToolRegistry() };
+    const r = registerImessageSearchTool(runtime);
+    assert.equal(r.registered, false);
+    assert.equal(runtime.tools.has("search_imessages"), false);
+  });
+});
+
+test("tool registers + proxies to the node with auth", async () => {
+  await withEnv("OPENAGI_IMESSAGE_NODE", "http://node:43298", async () => {
+    await withEnv("OPENAGI_IMESSAGE_NODE_TOKEN", "secret", async () => {
+      const seen = [];
+      const fetchImpl = async (url, opts) => {
+        seen.push({ url, auth: opts.headers.authorization, body: JSON.parse(opts.body) });
+        return { ok: true, json: async () => ({ results: [{ handle: "+1555", fromMe: false, date: "2026-04-13T12:00:00Z", text: "dinner at 7" }] }) };
+      };
+      const runtime = { tools: new ToolRegistry() };
+      assert.equal(registerImessageSearchTool(runtime, { fetchImpl }).registered, true);
+      assert.equal(runtime.tools.get("search_imessages").sideEffects, false, "search is read-only");
+
+      const out = await runtime.tools.invoke("search_imessages", { query: "dinner", person: "sarah", days: 7 });
+      assert.ok(out.ok);
+      assert.equal(out.result.count, 1);
+      assert.equal(out.result.results[0].from, "+1555");
+      assert.match(out.result.results[0].text, /dinner at 7/);
+      assert.equal(seen[0].url, "http://node:43298/search");
+      assert.equal(seen[0].auth, "Bearer secret");
+      assert.deepEqual(seen[0].body, { query: "dinner", handle: "sarah", days: 7, limit: 20 });
+    });
+  });
+});
+
+test("tool returns a friendly error when the node is unreachable", async () => {
+  await withEnv("OPENAGI_IMESSAGE_NODE", "http://node:43298", async () => {
+    const runtime = { tools: new ToolRegistry() };
+    registerImessageSearchTool(runtime, { fetchImpl: async () => { throw new Error("ECONNREFUSED"); } });
+    const out = await runtime.tools.invoke("search_imessages", { query: "x" });
+    assert.match(out.result.error, /couldn't reach the iMessage node/);
+  });
+});
+
+async function makeChatDb() {
+  const { DatabaseSync } = await import("node:sqlite");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "chatdb-srv-"));
+  const file = path.join(dir, "chat.db");
+  const db = new DatabaseSync(file);
+  db.exec(`CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);
+           CREATE TABLE message (ROWID INTEGER PRIMARY KEY, text TEXT, attributedBody BLOB, is_from_me INTEGER, date INTEGER, handle_id INTEGER);`);
+  db.prepare("INSERT INTO handle (ROWID,id) VALUES (1,?)").run("+15551112222");
+  const ns = String(BigInt(Date.now() - 978307200000) * 1000000n);
+  db.prepare("INSERT INTO message (text,is_from_me,date,handle_id) VALUES (?,?,?,?)").run("the gate code is 4821", 0, ns, 1);
+  db.close();
+  return file;
+}
+
+test("node service: rejects bad token, serves search with the right token", async () => {
+  const dbPath = await makeChatDb();
+  const server = createImessageServer({ token: "tok", dbPath });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    // health is open
+    assert.equal((await fetch(`${base}/health`)).status, 200);
+    // no/bad token → 401
+    assert.equal((await fetch(`${base}/search`, { method: "POST", body: "{}" })).status, 401);
+    // right token → results
+    const res = await fetch(`${base}/search`, {
+      method: "POST", headers: { authorization: "Bearer tok", "content-type": "application/json" },
+      body: JSON.stringify({ query: "gate code" })
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.results.length, 1);
+    assert.match(body.results[0].text, /gate code is 4821/);
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
Lets the main's agent search the user's iMessage history even though chat.db lives on a different machine (a Mac node).

```
"what did Sarah text me about dinner?"  →  agent calls search_imessages
   →  main proxies to the Mac node  →  chat.db search  →  answer
```

- **`imessage-server.js`** — small auth-gated HTTP service the Mac node runs (`openagi imessage-server --token T`), exposing `POST /search` over chat.db. Read-only; the brain stays on the main.
- **`imessage-search-tool.js`** — registers a `search_imessages` tool on the main that proxies to the node, **only when `OPENAGI_IMESSAGE_NODE` is set** (non-Mac mains stay clean). Read-only.

Tests: 4 cases (tool gating/proxy/auth/error + node service auth & search against a synthetic chat.db); full suite 288/288. All generic — node URL/token are env config on the devices, nothing environment-specific committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)