### PR TITLE
Per-task model tiering — cheap models for small background jobs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,18 @@ OPENAI_MODEL=gpt-5
 # Optional override:
 # OPENAI_BASE_URL=https://api.openai.com/v1
 
+# --- Model tiering (optional, opt-in) ---
+# One base model (above) handles chat + autopilot. The small, frequent
+# background jobs don't need it — point them at cheaper models and save.
+# Run `openagi models` to see the plan and what's still on the base model.
+#   mini → memory condensing, session mining, daily recap
+#   nano → proactive observer, scrutiny judges (short + very frequent)
+# OPENAI_MODEL_MINI=gpt-5-mini
+# OPENAI_MODEL_NANO=gpt-5-nano
+# Pin a single job to an exact model (wins over its tier). Jobs:
+# OBSERVER, SCRUTINY, CONDENSE, MINE, PLAN, CHAT, AUTOPILOT
+# OPENAI_MODEL_TASK_OBSERVER=gpt-5-nano
+
 # --- Twilio (SMS) ---
 # Inbound: configure your Twilio phone number to POST messages to
 #   https://<your-public-host>/channels/twilio/webhook

--- a/README.md
+++ b/README.md
@@ -456,6 +456,21 @@ Additional defenses:
 
 See `.env.example`. All keys read from `.env` and `~/.openagi/.env` (override the location with `OPENAGI_DATA_DIR`).
 
+### Model tiering
+
+You set **one base model** for everything (`OPENAI_MODEL` / `ANTHROPIC_MODEL`). You do **not** need a top model for every internal job — the small, frequent background work (proactive observation, scrutiny judging, memory condensing, session mining, daily recaps) runs fine on a cheaper `mini`/`nano` model, which is where most of the spend hides. Tiering is **opt-in**: until you set a tier, every task stays on the base model.
+
+Run `openagi models` to see the plan — which job runs on which model, why each is safe to shrink, and exactly what to set to start saving.
+
+| Variable | What it does |
+|---|---|
+| `OPENAI_MODEL` / `ANTHROPIC_MODEL` | Base model — handles chat + autopilot (real reasoning). Default `gpt-5` / `claude-sonnet-4-6`. |
+| `OPENAI_MODEL_MINI` / `ANTHROPIC_MODEL_MINI` | Mini tier — memory condensing, session mining, daily recap. e.g. `gpt-5-mini`. |
+| `OPENAI_MODEL_NANO` / `ANTHROPIC_MODEL_NANO` | Nano tier — proactive observer, scrutiny judges (short, very frequent). e.g. `gpt-5-nano`. |
+| `OPENAI_MODEL_TASK_<JOB>` | Pin one job to an exact model (wins over its tier). Jobs: `OBSERVER`, `SCRUTINY`, `CONDENSE`, `MINE`, `PLAN`, `CHAT`, `AUTOPILOT`. |
+
+Recommended starting point for OpenAI: `OPENAI_MODEL=gpt-5`, `OPENAI_MODEL_MINI=gpt-5-mini`, `OPENAI_MODEL_NANO=gpt-5-nano`. The ledger records the **actual** model each call used, so `openagi status` / `/budget` show where the money really goes.
+
 ### Web search
 
 The agent gains two tools — `web_search` and `fetch_url` — once at least one provider key is set. With no key configured, `web_search` returns a clear "no provider configured" error and `fetch_url` still works via a plain HTTP fetch.

--- a/bin/openagi.js
+++ b/bin/openagi.js
@@ -290,6 +290,26 @@ async function cmdTick(flags) {
   return res.ok ? 0 : 1;
 }
 
+// Show the model tiering plan: base model + which jobs run on cheaper tiers,
+// with recommendations for what to set. Reads the same env the daemon uses.
+async function cmdModels(flags) {
+  const { loadBootEnv } = await import("../src/boot.js");
+  loadBootEnv();
+  const { createModelProvider, renderModelPlan } = await import("../src/index.js");
+  const provider = createModelProvider();
+  if (!provider.router) {
+    console.log(c(DIM, "No LLM provider configured (deterministic mode). Set OPENAI_API_KEY or ANTHROPIC_API_KEY to enable tiering."));
+    return 0;
+  }
+  const providerName = provider.constructor.name === "AnthropicProvider" ? "anthropic" : "openai";
+  if (flags.json) {
+    console.log(JSON.stringify({ provider: providerName, models: provider.router.tierModels(), tasks: provider.router.describe() }, null, 2));
+    return 0;
+  }
+  console.log(renderModelPlan(provider.router, { provider: providerName }));
+  return 0;
+}
+
 function printHelp() {
   console.log(`${c(BOLD, "openagi")} — proactive local agent · CLI
 
@@ -306,6 +326,7 @@ ${c(BOLD, "Use it (local, or a remote main):")}
   openagi migrate <openclaw|hermes> [--from D] [--dry-run]
                               import another agent's persona, memory + telegram
   openagi tick                fire a scheduler tick
+  openagi models              show the model tiering plan + savings tips
 
 ${c(BOLD, "Turn this device into a node of a remote main:")}
   openagi pair <main-url> [--token T]    save the main as this device's target
@@ -345,6 +366,7 @@ async function main() {
       case "imessage-search": return await cmdImessageSearch(positional, flags);
       case "imessage-server": return await cmdImessageServer(flags);
       case "tick": return await cmdTick(flags);
+      case "models": return await cmdModels(flags);
       default:
         console.error(c(RED, `unknown command: ${cmd}`));
         printHelp();

--- a/src/daily-planner.js
+++ b/src/daily-planner.js
@@ -242,6 +242,7 @@ async function synthesizeWithLLM(runtime, inputs) {
   try {
     const result = await provider.generate({
       input: prompt,
+      task: "plan",
       agent: { id: "daily-planner", name: "daily-planner" },
       memoryHits: [], messages: [], tools: [], toolRegistry: null,
       instructions: PLAN_SYSTEM_PROMPT,

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ export { SpecialistRouter } from "./specialist-router.js";
 export { VocabularyCurator } from "./vocabulary-curator.js";
 export { MemorySystem } from "./memory-system.js";
 export { AnthropicProvider, createModelProvider, DeterministicModelProvider, OpenAIResponsesProvider } from "./model-provider.js";
+export { ModelRouter, TASK_PROFILES, TIERS, renderModelPlan } from "./model-router.js";
 export { PropagationController } from "./propagation-controller.js";
 export { SkillRegistry } from "./skills.js";
 export { registerCoreTools, ToolRegistry } from "./tool-registry.js";

--- a/src/memory-condenser.js
+++ b/src/memory-condenser.js
@@ -93,6 +93,7 @@ export class MemoryCondenser {
       try {
         const result = await provider.generate({
           input: prompt,
+          task: "condense",
           agent: { id: "condenser", name: "memory-condenser" },
           memoryHits: [],
           messages: [],

--- a/src/model-provider.js
+++ b/src/model-provider.js
@@ -1,3 +1,5 @@
+import { ModelRouter } from "./model-router.js";
+
 export class DeterministicModelProvider {
   constructor(options = {}) {
     this.name = options.name ?? "deterministic";
@@ -56,13 +58,26 @@ export class OpenAIResponsesProvider {
     this.timeoutMs = options.timeoutMs ?? 120000;
     this.maxToolHops = options.maxToolHops ?? 6;
     this.budgetGuard = options.budgetGuard ?? null;
+    // Per-task model tiering. Defaults to base for everything until tier env
+    // vars are set, so this is a no-op until the user opts in.
+    this.router = options.router ?? new ModelRouter({ envPrefix: "OPENAI", baseModel: this.model });
   }
 
   isConfigured() {
     return Boolean(this.apiKey);
   }
 
-  async generate({ input, instructions, messages = [], memoryHits = [], scrutiny, agent, tools = [], toolRegistry, context = {} }) {
+  // Resolve which model a call should use: explicit `model` wins, then a named
+  // `task` (routed via the configured tiers), then a raw `tier`, else the base.
+  resolveModel({ model, tier, task } = {}) {
+    if (model) return model;
+    if (task) return this.router.resolve(task);
+    if (tier) return this.router.tierModel(tier);
+    return this.model;
+  }
+
+  async generate({ input, instructions, messages = [], memoryHits = [], scrutiny, agent, tools = [], toolRegistry, context = {}, model: modelOverride, tier, task }) {
+    const model = this.resolveModel({ model: modelOverride, tier, task });
     if (!this.apiKey) throw new Error("OPENAI_API_KEY is not configured.");
     this.budgetGuard?.check();
 
@@ -84,7 +99,7 @@ export class OpenAIResponsesProvider {
     let response;
     for (let hop = 0; hop < this.maxToolHops; hop += 1) {
       const body = {
-        model: this.model,
+        model,
         instructions: baseInstructions,
         input: conversationInput
       };
@@ -121,7 +136,7 @@ export class OpenAIResponsesProvider {
 
     return {
       provider: "openai",
-      model: this.model,
+      model,
       id: response?.id,
       text: extractResponseText(response) || "(no text)",
       toolCalls
@@ -144,7 +159,7 @@ export class OpenAIResponsesProvider {
       const json = await response.json().catch(() => ({}));
       if (!response.ok) throw new Error(json?.error?.message ?? `OpenAI request failed with ${response.status}`);
       const callTools = (json.output ?? []).filter((item) => item.type === "function_call").map((item) => item.name);
-      this.budgetGuard?.record(json.usage, this.model, {
+      this.budgetGuard?.record(json.usage, body.model, {
         channel: context.channel,
         agentId: context.agentId,
         sessionId: context.sessionId,
@@ -168,14 +183,23 @@ export class AnthropicProvider {
     this.timeoutMs = options.timeoutMs ?? 120000;
     this.maxToolHops = options.maxToolHops ?? 6;
     this.budgetGuard = options.budgetGuard ?? null;
+    this.router = options.router ?? new ModelRouter({ envPrefix: "ANTHROPIC", baseModel: this.model });
   }
 
   isConfigured() {
     return Boolean(this.apiKey);
   }
 
-  async generate({ input, instructions, messages = [], memoryHits = [], scrutiny, agent, toolRegistry, context = {} }) {
+  resolveModel({ model, tier, task } = {}) {
+    if (model) return model;
+    if (task) return this.router.resolve(task);
+    if (tier) return this.router.tierModel(tier);
+    return this.model;
+  }
+
+  async generate({ input, instructions, messages = [], memoryHits = [], scrutiny, agent, toolRegistry, context = {}, model: modelOverride, tier, task }) {
     if (!this.apiKey) throw new Error("ANTHROPIC_API_KEY is not configured.");
+    const model = this.resolveModel({ model: modelOverride, tier, task });
     this.budgetGuard?.check();
 
     const tools = toolRegistry?.toAnthropicTools?.() ?? [];
@@ -200,7 +224,7 @@ export class AnthropicProvider {
 
     for (let hop = 0; hop < this.maxToolHops; hop += 1) {
       response = await this.postMessages({
-        model: this.model,
+        model,
         max_tokens: this.maxTokens,
         system,
         messages: convo,
@@ -234,7 +258,7 @@ export class AnthropicProvider {
 
     return {
       provider: "anthropic",
-      model: this.model,
+      model,
       id: response?.id,
       text: text || "(no text)",
       toolCalls
@@ -258,7 +282,7 @@ export class AnthropicProvider {
       const json = await response.json().catch(() => ({}));
       if (!response.ok) throw new Error(json?.error?.message ?? `Anthropic request failed with ${response.status}`);
       const callTools = (json.content ?? []).filter((b) => b.type === "tool_use").map((b) => b.name);
-      this.budgetGuard?.record(json.usage, this.model, {
+      this.budgetGuard?.record(json.usage, body.model, {
         channel: context.channel,
         agentId: context.agentId,
         sessionId: context.sessionId,

--- a/src/model-router.js
+++ b/src/model-router.js
@@ -1,0 +1,125 @@
+// Model tiering / routing.
+//
+// One "base" model handles everything by default. Lighter, cheaper models can
+// take the small, frequent background jobs — you do NOT need a top model for
+// every internal task. Out of the box every task still resolves to the base
+// model (no behavior change), so tiering is strictly opt-in: set the tier env
+// vars and the recommended tasks shift automatically. Any task can also be
+// pinned to an exact model.
+//
+// Two knobs:
+//   • Tiers   — name a cheaper model once, reuse it.  e.g. OPENAI_MODEL_NANO=gpt-5-nano
+//   • Tasks   — pin one job to an exact model.        e.g. OPENAI_MODEL_TASK_OBSERVER=gpt-5-mini
+//
+// Resolution for a task:  task pin  >  task's recommended tier  >  base model.
+
+// The "where" — every internal job that calls the model, with a recommended
+// tier and the reason it's safe to shrink. `chat` and `autopilot` intentionally
+// stay on base (real reasoning + tool use); the rest are small and/or frequent,
+// which is exactly where a mini/nano model saves the most money.
+export const TASK_PROFILES = {
+  chat:      { tier: "base", label: "User chat",            why: "Real reasoning, user-facing replies — keep this on your best model." },
+  autopilot: { tier: "base", label: "Autopilot task work", why: "Plans and executes real work with tools — needs the strong model." },
+  observer:  { tier: "nano", label: "Proactive observer",  why: "Mostly 'suggest one thing or stay quiet', runs often — nano is plenty." },
+  scrutiny:  { tier: "nano", label: "Scrutiny judges",     why: "Short act/ask/watch/ignore classification, very frequent — nano is plenty." },
+  condense:  { tier: "mini", label: "Memory condensing",   why: "Summarize a cluster of notes into one — a mini model handles it." },
+  mine:      { tier: "mini", label: "Session mining",      why: "Cluster intents out of a transcript — mini is enough." },
+  plan:      { tier: "mini", label: "Daily plan / recap",  why: "Summarize the day — mini is enough." }
+};
+
+// Order matters for display (strongest → cheapest).
+export const TIERS = ["base", "mini", "nano"];
+
+export class ModelRouter {
+  // envPrefix: "OPENAI" | "ANTHROPIC". baseModel: the already-resolved base model.
+  // overrides (optional, for tests/programmatic config):
+  //   { tiers: { mini, nano }, tasks: { observer: "<model>" } }
+  constructor({ envPrefix = "OPENAI", baseModel, env = process.env, overrides = {} } = {}) {
+    this.envPrefix = envPrefix;
+    this.baseModel = baseModel;
+    this.env = env;
+    this.overrides = overrides;
+  }
+
+  // Model for a tier name. Unset tiers fall back to base, so an undefined
+  // tier is always safe (you just don't save until you configure it).
+  tierModel(tier) {
+    if (!tier || tier === "base") return this.baseModel;
+    const fromOverride = this.overrides.tiers?.[tier];
+    if (fromOverride) return fromOverride;
+    const fromEnv = this.env[`${this.envPrefix}_MODEL_${tier.toUpperCase()}`];
+    return fromEnv || this.baseModel;
+  }
+
+  // Model for a named task: explicit task pin > task's recommended tier > base.
+  resolve(task) {
+    if (!task) return this.baseModel;
+    const taskPin =
+      this.overrides.tasks?.[task] ||
+      this.env[`${this.envPrefix}_MODEL_TASK_${task.toUpperCase()}`];
+    if (taskPin) return taskPin;
+    const profile = TASK_PROFILES[task];
+    return this.tierModel(profile?.tier ?? "base");
+  }
+
+  // Which models are actually wired up (base + any configured tiers).
+  tierModels() {
+    const out = { base: this.baseModel };
+    for (const tier of TIERS) {
+      if (tier === "base") continue;
+      out[tier] = this.tierModel(tier);
+    }
+    return out;
+  }
+
+  // Human-readable plan: every task, its recommended tier, the model it resolves
+  // to right now, and why. `onBase` flags tasks that are NOT yet saving (still
+  // on the base model because their tier isn't configured).
+  describe() {
+    return Object.entries(TASK_PROFILES).map(([task, p]) => {
+      const model = this.resolve(task);
+      return {
+        task,
+        label: p.label,
+        tier: p.tier,
+        model,
+        why: p.why,
+        onBase: model === this.baseModel
+      };
+    });
+  }
+}
+
+// Pretty multi-line summary for the CLI (`openagi models`).
+export function renderModelPlan(router, { provider } = {}) {
+  const lines = [];
+  const models = router.tierModels();
+  lines.push(`Provider: ${provider ?? "?"}   Base model: ${models.base}`);
+  const configured = TIERS.filter((t) => t !== "base" && models[t] !== models.base);
+  if (configured.length === 0) {
+    lines.push("Tiers:    (none configured — everything runs on the base model)");
+  } else {
+    lines.push(`Tiers:    ${configured.map((t) => `${t}=${models[t]}`).join("   ")}`);
+  }
+  lines.push("");
+  lines.push("Where each job runs (→ = recommended smaller model):");
+  for (const row of router.describe()) {
+    const arrow = row.onBase && row.tier !== "base" ? "  ⚠ still on base" : "";
+    const tag = row.tier === "base" ? "[base]" : `[${row.tier}]`;
+    lines.push(`  ${tag.padEnd(7)} ${row.label.padEnd(22)} ${row.model}${arrow}`);
+    lines.push(`          ${row.why}`);
+  }
+  const onBase = router.describe().filter((r) => r.onBase && r.tier !== "base");
+  if (onBase.length > 0) {
+    const prefix = router.envPrefix;
+    lines.push("");
+    lines.push("Recommended savings — set these to use cheaper models for small jobs:");
+    if (router.describe().some((r) => r.tier === "nano" && r.onBase)) {
+      lines.push(`  ${prefix}_MODEL_NANO=${prefix === "OPENAI" ? "gpt-5-nano" : "claude-haiku-4-5"}   # observer, scrutiny judges`);
+    }
+    if (router.describe().some((r) => r.tier === "mini" && r.onBase)) {
+      lines.push(`  ${prefix}_MODEL_MINI=${prefix === "OPENAI" ? "gpt-5-mini" : "claude-haiku-4-5"}   # condensing, mining, daily recap`);
+    }
+  }
+  return lines.join("\n");
+}

--- a/src/proactive-observer.js
+++ b/src/proactive-observer.js
@@ -149,6 +149,7 @@ export class ProactiveObserver {
     try {
       const result = await provider.generate({
         input: prompt,
+        task: "observer",
         agent: { id: "proactive-observer", name: "proactive-observer" },
         memoryHits: [],
         messages: [],
@@ -536,6 +537,7 @@ ProactiveObserver.prototype.scanTasksAgainstActivity = async function ({ now = n
   try {
     const result = await provider.generate({
       input: prompt,
+      task: "observer",
       agent: { id: "task-scanner", name: "task-scanner" },
       memoryHits: [],
       messages: [],

--- a/src/scrutiny-judge.js
+++ b/src/scrutiny-judge.js
@@ -39,6 +39,7 @@ export class ScrutinyJudge {
     const prompt = buildJudgePrompt(sample);
     const result = await provider.generate({
       input: prompt,
+      task: "scrutiny",
       agent: { id: "scrutiny-judge", name: "scrutiny-judge" },
       memoryHits: [],
       messages: [],

--- a/src/session-miner.js
+++ b/src/session-miner.js
@@ -132,6 +132,7 @@ export class SessionMiner {
     try {
       const result = await provider.generate({
         input: prompt,
+        task: "mine",
         agent: { id: "session-miner", name: "session-miner" },
         memoryHits: [],
         messages: [],

--- a/test/model-router.test.js
+++ b/test/model-router.test.js
@@ -1,0 +1,70 @@
+// Model tiering: one base model by default, cheaper tiers for small background
+// jobs, every task pinnable, and nothing changes until you opt in.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ModelRouter, TASK_PROFILES, renderModelPlan } from "../src/model-router.js";
+
+test("default: every task resolves to the base model (opt-in, no behavior change)", () => {
+  const r = new ModelRouter({ envPrefix: "OPENAI", baseModel: "gpt-5", env: {} });
+  for (const task of Object.keys(TASK_PROFILES)) {
+    assert.equal(r.resolve(task), "gpt-5", `${task} should fall back to base`);
+  }
+  assert.equal(r.resolve(undefined), "gpt-5");
+});
+
+test("configured tiers route the recommended tasks to cheaper models", () => {
+  const env = { OPENAI_MODEL_MINI: "gpt-5-mini", OPENAI_MODEL_NANO: "gpt-5-nano" };
+  const r = new ModelRouter({ envPrefix: "OPENAI", baseModel: "gpt-5", env });
+  // nano-tier jobs
+  assert.equal(r.resolve("observer"), "gpt-5-nano");
+  assert.equal(r.resolve("scrutiny"), "gpt-5-nano");
+  // mini-tier jobs
+  assert.equal(r.resolve("condense"), "gpt-5-mini");
+  assert.equal(r.resolve("mine"), "gpt-5-mini");
+  assert.equal(r.resolve("plan"), "gpt-5-mini");
+  // base jobs stay on base even with tiers configured
+  assert.equal(r.resolve("chat"), "gpt-5");
+  assert.equal(r.resolve("autopilot"), "gpt-5");
+});
+
+test("a per-task pin overrides the tier", () => {
+  const env = { OPENAI_MODEL_NANO: "gpt-5-nano", OPENAI_MODEL_TASK_OBSERVER: "gpt-5-mini" };
+  const r = new ModelRouter({ envPrefix: "OPENAI", baseModel: "gpt-5", env });
+  assert.equal(r.resolve("observer"), "gpt-5-mini", "task pin wins over tier");
+  assert.equal(r.resolve("scrutiny"), "gpt-5-nano", "other nano tasks still follow the tier");
+});
+
+test("tierModel falls back to base for unconfigured / base tier", () => {
+  const r = new ModelRouter({ envPrefix: "OPENAI", baseModel: "gpt-5", env: {} });
+  assert.equal(r.tierModel("base"), "gpt-5");
+  assert.equal(r.tierModel("nano"), "gpt-5");
+  assert.equal(r.tierModel(undefined), "gpt-5");
+});
+
+test("programmatic overrides work without env (Anthropic prefix)", () => {
+  const r = new ModelRouter({
+    envPrefix: "ANTHROPIC",
+    baseModel: "claude-sonnet-4-6",
+    env: {},
+    overrides: { tiers: { mini: "claude-haiku-4-5", nano: "claude-haiku-4-5" } }
+  });
+  assert.equal(r.resolve("condense"), "claude-haiku-4-5");
+  assert.equal(r.resolve("chat"), "claude-sonnet-4-6");
+});
+
+test("describe() flags which tasks are still on base (not yet saving)", () => {
+  const r = new ModelRouter({ envPrefix: "OPENAI", baseModel: "gpt-5", env: { OPENAI_MODEL_NANO: "gpt-5-nano" } });
+  const rows = Object.fromEntries(r.describe().map((row) => [row.task, row]));
+  assert.equal(rows.observer.onBase, false, "observer now on nano");
+  assert.equal(rows.condense.onBase, true, "condense still on base (mini unset)");
+  assert.equal(rows.chat.onBase, true, "chat intentionally on base");
+});
+
+test("renderModelPlan shows configured tiers + savings recommendations", () => {
+  const r = new ModelRouter({ envPrefix: "OPENAI", baseModel: "gpt-5", env: { OPENAI_MODEL_NANO: "gpt-5-nano" } });
+  const out = renderModelPlan(r, { provider: "openai" });
+  assert.match(out, /Base model: gpt-5/);
+  assert.match(out, /nano=gpt-5-nano/);
+  // mini is still unset → recommend it
+  assert.match(out, /OPENAI_MODEL_MINI=gpt-5-mini/);
+});


### PR DESCRIPTION
## What

Lets you keep one strong **base model** for chat + autopilot while routing the small, frequent internal jobs to optional cheaper **mini/nano** tiers — which is where most of the daily spend actually hides.

You don't need a top model for everything. `openagi models` shows exactly which job runs where, why each is safe to shrink, and what to set to start saving.

## Where each job runs

| Tier | Jobs | Why it's safe |
|---|---|---|
| **base** | user chat, autopilot task work | real reasoning + tool use |
| **nano** | proactive observer, scrutiny judges | short, very frequent ("suggest one thing or stay quiet" / act-ask-watch-ignore) |
| **mini** | memory condensing, session mining, daily recap | summarize a cluster / a transcript / the day |

## How it works

- `src/model-router.js` — `ModelRouter` + `TASK_PROFILES` + `renderModelPlan`. Resolution is **per-task pin > task's recommended tier > base**. Unset tiers fall back to base, so this is **fully opt-in** — nothing changes until you set `OPENAI_MODEL_MINI` / `OPENAI_MODEL_NANO` (or the `ANTHROPIC_*` equivalents).
- Both providers carry a router; `generate({ task })` resolves the model, and the **budget ledger records the actual model used** per call, so `/budget` reflects reality.
- Per-task pins: `OPENAI_MODEL_TASK_OBSERVER=…` (wins over the tier).
- `openagi models` prints the plan and flags any job still on base.

## Config

```bash
OPENAI_MODEL=gpt-5          # base — chat + autopilot
OPENAI_MODEL_MINI=gpt-5-mini   # condensing, mining, daily recap
OPENAI_MODEL_NANO=gpt-5-nano   # observer, scrutiny judges
```

## Tests

`test/model-router.test.js` (7 new) — opt-in default, tier routing, per-task pins, Anthropic overrides, the savings display. Full suite: **295 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)