### PR TITLE
iMessage keyword trigger: whole-word match + listen-only-until-invoked

### DIFF
--- a/src/integrations/imessage-bridge.js
+++ b/src/integrations/imessage-bridge.js
@@ -36,9 +36,11 @@ export class IMessageBridge {
     // Response policy — WHO/WHAT gets an agent reply:
     //   all     → reply to every incoming message
     //   allow   → reply only to allowlisted senders (default when --allow given)
-    //   trigger → reply only when the message contains `trigger` (and, if an
-    //             allowlist is set, the sender is on it) — the trigger word is
-    //             stripped before forwarding ("Peri what's up" → "what's up")
+    //   trigger → reply only when the message contains `trigger` as a whole
+    //             word (and, if an allowlist is set, the sender is on it) — a
+    //             leading mention is stripped ("Peri what's up" → "what's up").
+    //             Everything else is still captured per captureMode, so the
+    //             agent silently listens + saves until you invoke it by name.
     //   none    → never reply (capture-only mode)
     this.respondMode = options.respondMode ?? (this.allowFrom.size ? "allow" : "all");
     this.trigger = (options.trigger ?? "").toLowerCase();
@@ -72,11 +74,13 @@ export class IMessageBridge {
     if (this.respondMode === "allow") return { respond: allowed, forward: text };
     if (this.respondMode === "trigger") {
       if (!allowed || !this.trigger) return { respond: false };
-      const lower = text.toLowerCase();
-      const at = lower.indexOf(this.trigger);
-      if (at === -1) return { respond: false };
-      // Strip a leading "<trigger>[,:]" prefix; otherwise forward as-is.
-      const stripped = text.replace(new RegExp(`^\\s*${escapeRe(this.trigger)}[\\s,:]+`, "i"), "").trim();
+      // Match the trigger as a whole word so "Peri, what's up?" fires but
+      // "perimeter" / "period" don't.
+      const wordRe = new RegExp(`\\b${escapeRe(this.trigger)}\\b`, "i");
+      if (!wordRe.test(text)) return { respond: false };
+      // Strip a leading "<trigger>" mention so it isn't echoed back into the
+      // prompt ("Peri what's up" → "what's up"); a bare "Peri" forwards as-is.
+      const stripped = text.replace(new RegExp(`^\\s*${escapeRe(this.trigger)}\\b[\\s,:!.?]*`, "i"), "").trim();
       return { respond: true, forward: stripped || text };
     }
     return { respond: false };

--- a/test/imessage-bridge.test.js
+++ b/test/imessage-bridge.test.js
@@ -141,6 +141,21 @@ test("respond=trigger only replies on the trigger word, stripped before forwardi
   assert.equal(b.forwarded[0].text, "what's the weather?", "trigger prefix stripped");
 });
 
+test("respond=trigger matches the keyword as a whole word, not a substring", async () => {
+  const b = policyBridge({ respondMode: "trigger", trigger: "peri", allowFrom: ["+15551112222"], captureMode: "all" });
+  b.bridge.readMessages = async () => [
+    { rowid: 1, handle: "+15551112222", text: "the perimeter is huge" },   // contains 'peri' but not as a word
+    { rowid: 2, handle: "+15551112222", text: "by the end of the period" }, // 'peri' inside 'period'
+    { rowid: 3, handle: "+15551112222", text: "Peri what's the weather?" }, // real invocation
+    { rowid: 4, handle: "+15551112222", text: "hey peri!" }                 // mid-sentence + punctuation
+  ];
+  const r = await b.bridge.poll();
+  assert.equal(r.replied, 2, "only the two real invocations reply");
+  assert.equal(b.forwarded[0].text, "what's the weather?", "leading mention stripped");
+  assert.equal(b.forwarded[1].text, "hey peri!", "non-leading mention forwarded as-is");
+  assert.equal(r.captured, 4, "but every message is still captured to memory");
+});
+
 test("capture=all saves every incoming message to memory, even unreplied", async () => {
   const b = policyBridge({ respondMode: "none", captureMode: "all" });
   b.bridge.readMessages = async () => [


### PR DESCRIPTION
## What

You wanted: *"if I invoke it like **Peri**, respond — otherwise it just listens and saves."* That's the bridge's existing `trigger` respond mode, but it matched the keyword as a raw **substring**, so "Peri" would also fire on "**peri**meter" or "**peri**od". This tightens it to a **whole-word** match.

- `Peri, what's up?` → replies (leading mention stripped → `what's up?`)
- `hey peri!` → replies (forwarded as-is)
- `perimeter` / `period` → **no reply**, still **saved to memory**

Capture is independent of replies, so it silently listens + saves everything until you call it by name.

## Config (already supported)

```
openagi imessage-bridge --respond trigger --trigger Peri \
  --allow zargle@me.com,+1805... --capture all
```
or via the launchd installer: `IMESSAGE_RESPOND=trigger IMESSAGE_TRIGGER=Peri IMESSAGE_CAPTURE=all`.

## Tests
`test/imessage-bridge.test.js` — whole-word matching (perimeter/period don't fire), mention stripping, and that non-invoked messages are still captured. Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)