### PR TITLE
Route autopilot through model tiering + env-tunable cadence

### DIFF
--- a/src/abi-runtime.js
+++ b/src/abi-runtime.js
@@ -200,12 +200,16 @@ export class AbiRuntime {
         task: "condense",
         dailyAt: "03:30"
       });
+      // Cadence is env-tunable: autopilot pulses carry a large prompt, so on a
+      // metered model the interval is the single biggest cost lever. Default
+      // 30 min; set OPENAGI_AUTOPILOT_INTERVAL_MIN to slow it (e.g. 120 = 2h).
+      const autopilotMin = Number(process.env.OPENAGI_AUTOPILOT_INTERVAL_MIN) || 30;
       this.cron.addJob({
         id: "agent-pulse",
-        name: "Agent autopilot — drain agent queue every 30 min",
+        name: `Agent autopilot — drain agent queue every ${autopilotMin} min`,
         enabled: true,
         task: "autopilot",
-        intervalMs: 30 * 60 * 1000,
+        intervalMs: autopilotMin * 60 * 1000,
         input: {
           agentId: "main",
           prompt: AGENT_PULSE_PROMPT

--- a/src/agent-host.js
+++ b/src/agent-host.js
@@ -133,6 +133,10 @@ export class AgentHost {
     const modelResult = await this.modelProvider.generate({
       input: text,
       agent,
+      // Route by what the call IS, so model tiering applies: autonomous pulses
+      // (autopilot/cron) are cheap "anything to do?" work; everything else is
+      // user-facing chat. Both default to the base model until tiers/pins are set.
+      task: (channel === "autopilot" || channel === "cron") ? "autopilot" : "chat",
       scrutiny: output.scrutiny,
       memoryHits: output.customContext.map((entry) => ({
         score: entry.score,


### PR DESCRIPTION
## Why

An idle agent was burning ~$25/day. Root cause: autopilot pulses every 30 min, each carrying a ~170K-token prompt (mostly 205 tool schemas, re-sent on each tool hop in the stateless/ZDR loop), all on the flagship model. The model-tiering shipped earlier never applied to autopilot because the agent-host path didn't tag its calls with a task.

## Changes

- **agent-host**: tag each model call by channel — `autopilot`/`cron` → task `"autopilot"`, else `"chat"` — so `ModelRouter` routes autonomous pulses. Both still resolve to the base model until a tier/pin is configured (no behavior change by default).
- **abi-runtime**: `OPENAGI_AUTOPILOT_INTERVAL_MIN` makes pulse cadence tunable (default 30; `120` = every 2h).

## Impact (with `OPENAI_MODEL_TASK_AUTOPILOT=gpt-5-nano` + 2h cadence)

Autopilot drops from ~$26/day → well under $1/day: cheaper per-token model **and** 4× fewer pulses. Pure pings (observer/scrutiny) already route to nano.

## Tests
agent-host + abi-runtime + model-router suites green (128 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)