### PR TITLE
feat(imessage): reply in group chats + invoke from allowlisted groups

### DIFF
--- a/bin/openagi.js
+++ b/bin/openagi.js
@@ -34,6 +34,7 @@ function parseArgs(argv) {
     else if (a === "--host") flags.host = argv[++i];
     else if (a === "--port") flags.port = argv[++i];
     else if (a === "--allow") flags.allow = argv[++i];
+    else if (a === "--allow-chat") flags.allowChat = argv[++i];
     else if (a === "--check") flags.check = true;
     else if (a === "--from") flags.from = argv[++i];
     else if (a === "--dry-run") flags.dryRun = true;
@@ -242,10 +243,11 @@ async function cmdImessageBridge(flags) {
 
   const { IMessageBridge } = await import("../src/integrations/imessage-bridge.js");
   const allowFrom = flags.allow ? String(flags.allow).split(",").map((s) => s.trim()).filter(Boolean) : [];
-  const respondMode = flags.respond ?? (allowFrom.length ? "allow" : "all");
+  const allowChats = flags.allowChat ? String(flags.allowChat).split(",").map((s) => s.trim()).filter(Boolean) : [];
+  const respondMode = flags.respond ?? (allowFrom.length || allowChats.length ? "allow" : "all");
   const captureMode = flags.capture ?? "none";
   const bridge = new IMessageBridge({
-    client, allowFrom, respondMode, captureMode, trigger: flags.trigger,
+    client, allowFrom, allowChats, respondMode, captureMode, trigger: flags.trigger,
     onEvent: (e) => {
       if (e.kind === "relayed") console.log(c(GREEN, `↔ ${e.handle}: `) + c(DIM, `"${e.in}" → "${e.out}"`));
       else if (e.kind === "captured") console.log(c(DIM, `· saved to memory — ${e.handle}: "${e.in}"`));
@@ -255,8 +257,9 @@ async function cmdImessageBridge(flags) {
   console.log(c(GREEN, `iMessage bridge → main at ${target.url}`));
   const respondDesc = respondMode === "all" ? "everyone" : respondMode === "allow" ? `allowlist (${allowFrom.join(", ")})` : respondMode === "trigger" ? `messages containing "${flags.trigger}"` : "no one (capture-only)";
   console.log(c(DIM, `Reply to: ${respondDesc}.${captureMode !== "none" ? ` Save to memory: ${captureMode}.` : ""} Ctrl-C to stop.`));
+  if (allowChats.length) console.log(c(DIM, `Group chats where anyone can invoke: ${allowChats.join(", ")}`));
   console.log(c(DIM, "Requires: Full Disk Access (read chat.db) + Automation→Messages (send) for this process."));
-  bridge.start({ intervalMs: 2000 });
+  bridge.start(); // default 10s, read-only-safe
   await new Promise(() => {}); // run until killed
 }
 
@@ -335,6 +338,8 @@ ${c(BOLD, "Turn this device into a node of a remote main:")}
                                          main and text its replies back. Opts:
                                          --respond all|allow|trigger|none
                                          --allow h1,h2   (sender allowlist)
+                                         --allow-chat c1,c2  (group chats where
+                                                          anyone can invoke)
                                          --trigger word  (reply only on a word)
                                          --capture none|allow|all  (→ memory)
   openagi imessage-search <query>        (macOS) search iMessage history

--- a/scripts/install-imessage-launchd.sh
+++ b/scripts/install-imessage-launchd.sh
@@ -11,6 +11,8 @@
 # Config (env vars):
 #   IMESSAGE_RESPOND   all|allow|trigger|none   reply policy (default: all)
 #   IMESSAGE_ALLOW     h1,h2                     sender allowlist (for respond=allow)
+#   IMESSAGE_ALLOW_CHATS c1,c2                   group chat ids where ANY member
+#                                                can invoke the trigger (chat787…)
 #   IMESSAGE_TRIGGER   word                      trigger word (for respond=trigger)
 #   IMESSAGE_CAPTURE   none|allow|all            save incoming → memory (default: none)
 #   IMESSAGE_NODE_TOKEN  secret                  if set, ALSO install the search
@@ -51,6 +53,7 @@ mkdir -p "$(dirname "${BRIDGE_PLIST}")" "${LOG_DIR}"
 # Build the bridge argument array.
 bridge_args=("imessage-bridge" "--respond" "${IMESSAGE_RESPOND:-all}")
 [[ -n "${IMESSAGE_ALLOW:-}" ]]   && bridge_args+=("--allow" "${IMESSAGE_ALLOW}")
+[[ -n "${IMESSAGE_ALLOW_CHATS:-}" ]] && bridge_args+=("--allow-chat" "${IMESSAGE_ALLOW_CHATS}")
 [[ -n "${IMESSAGE_TRIGGER:-}" ]] && bridge_args+=("--trigger" "${IMESSAGE_TRIGGER}")
 [[ -n "${IMESSAGE_CAPTURE:-}" ]] && bridge_args+=("--capture" "${IMESSAGE_CAPTURE}")
 

--- a/src/integrations/imessage-bridge.js
+++ b/src/integrations/imessage-bridge.js
@@ -82,6 +82,10 @@ export class IMessageBridge {
 
     // Sender allowlist (phone/email handles), lower-cased.
     this.allowFrom = new Set((options.allowFrom ?? []).map((h) => String(h).toLowerCase()));
+    // Group-chat allowlist (chat identifiers, e.g. "chat787…"). In an allowed
+    // group, ANY member's message can invoke the trigger, and the reply is
+    // posted back to the group. Members' messages are still captured regardless.
+    this.allowChats = new Set((options.allowChats ?? []).map((c) => String(c).toLowerCase()));
 
     // Response policy — WHO/WHAT gets an agent reply:
     //   all     → reply to every incoming message
@@ -116,9 +120,15 @@ export class IMessageBridge {
   }
 
   // Decide whether to reply, and return the text to forward (trigger stripped).
-  // { respond: bool, forward: string }
-  responseFor(handle, text) {
-    const allowed = this.allowFrom.size === 0 || this.allowFrom.has(String(handle).toLowerCase());
+  // { respond: bool, forward: string }. `chatId` lets an allowlisted GROUP
+  // authorize any member's message (not just allowlisted senders).
+  responseFor(handle, text, chatId = null) {
+    // No allowlist of any kind → open to all. Otherwise a sender qualifies via
+    // the handle allowlist OR by being in an allowlisted group chat.
+    const noAllowlist = this.allowFrom.size === 0 && this.allowChats.size === 0;
+    const allowed = noAllowlist
+      || this.allowFrom.has(String(handle).toLowerCase())
+      || (chatId != null && this.allowChats.has(String(chatId).toLowerCase()));
     if (this.respondMode === "none") return { respond: false };
     if (this.respondMode === "all") return { respond: true, forward: text };
     if (this.respondMode === "allow") return { respond: allowed, forward: text };
@@ -181,13 +191,17 @@ export class IMessageBridge {
       }
 
       // 2. Reply per the response policy.
-      const decision = this.responseFor(row.handle, text);
+      const decision = this.responseFor(row.handle, text, row.chatId);
       if (!decision.respond) { skipped++; continue; }
       try {
-        const res = await this.client.chat(decision.forward, { from: `imessage:${row.handle}` });
+        // Session keys off the conversation so a group has one shared thread.
+        const sessionKey = row.isGroup ? row.chatId : row.handle;
+        const res = await this.client.chat(decision.forward, { from: `imessage:${sessionKey}` });
         const reply = res?.json?.reply;
         if (res?.ok && reply) {
-          await this.sendMessage(row.handle, reply);
+          // Reply to the GROUP chat if it's a group; otherwise DM the sender.
+          if (row.isGroup) await this.sendMessage(row.chatId, reply, { group: true });
+          else await this.sendMessage(row.handle, reply);
           // Remember it so the self-thread echo of this reply is ignored next poll.
           this._recentSends.push(reply.trim());
           if (this._recentSends.length > 50) this._recentSends.shift();
@@ -259,7 +273,8 @@ export async function readNewMessages(dbPath, sinceDate, { selfHandles = [], db:
     const rows = db.prepare(`
       SELECT m.ROWID AS rowid, m.text AS text, m.attributedBody AS body,
              m.is_from_me AS fromMe, CAST(m.date AS TEXT) AS appleDate,
-             COALESCE(h.id, c.chat_identifier) AS handle
+             COALESCE(h.id, c.chat_identifier) AS handle,
+             c.chat_identifier AS chatId
       FROM message m
       LEFT JOIN handle h ON h.ROWID = m.handle_id
       LEFT JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
@@ -274,6 +289,9 @@ export async function readNewMessages(dbPath, sinceDate, { selfHandles = [], db:
     return rows.map((r) => ({
       rowid: r.rowid,
       handle: r.handle,
+      chatId: r.chatId,
+      // Group chats use a "chat<digits>" identifier; 1:1s use the person's handle.
+      isGroup: typeof r.chatId === "string" && /^chat\d/.test(r.chatId),
       fromMe: r.fromMe === 1,
       appleDate: r.appleDate,
       text: r.text && r.text.trim() ? r.text : extractAttributedText(r.body)
@@ -358,9 +376,19 @@ export async function searchMessages(dbPath = DEFAULT_DB, { query = "", handle =
 }
 
 // Send a message back over iMessage via AppleScript. Requires Automation
-// permission for Messages granted to the controlling process.
-export async function sendViaIMessage(handle, text, { run = execFileAsync } = {}) {
-  const script = `
+// permission for Messages granted to the controlling process. For a group
+// (`group: true`), `target` is the chat identifier (e.g. "chat787…") and the
+// reply is posted to the GROUP; otherwise `target` is a person's handle (DM).
+export async function sendViaIMessage(target, text, { run = execFileAsync, group = false } = {}) {
+  const script = group
+    ? `
+    on run {chatId, msgText}
+      tell application "Messages"
+        set theChat to first chat whose id contains chatId
+        send msgText to theChat
+      end tell
+    end run`
+    : `
     on run {targetHandle, msgText}
       tell application "Messages"
         set svc to 1st account whose service type = iMessage
@@ -368,5 +396,5 @@ export async function sendViaIMessage(handle, text, { run = execFileAsync } = {}
         send msgText to theBuddy
       end tell
     end run`;
-  await run("osascript", ["-e", script, handle, text], { timeout: 15000 });
+  await run("osascript", ["-e", script, target, text], { timeout: 15000 });
 }

--- a/test/imessage-bridge.test.js
+++ b/test/imessage-bridge.test.js
@@ -114,7 +114,7 @@ function policyBridge(opts) {
   const bridge = new IMessageBridge({
     client, dataDir: dir,
     readMessages: async () => [],
-    sendMessage: async (h, t) => sent.push({ h, t }),
+    sendMessage: async (h, t, sendOpts) => sent.push({ h, t, group: sendOpts?.group ?? false }),
     ...opts
   });
   bridge._saveState({ lastDate: "0", initialized: true });
@@ -202,6 +202,26 @@ test("hardening: reads chat.db via ONE reused read-only connection (no per-poll 
 
   bridge.stop();
   assert.equal(bridge._db, null, "stop() releases chat.db");
+});
+
+test("group chat: any member can invoke the trigger; reply goes to the GROUP, not the sender", async () => {
+  const b = policyBridge({ respondMode: "trigger", trigger: "peri", allowChats: ["chat787"], captureMode: "all" });
+  b.bridge.readMessages = async () => [
+    // a non-allowlisted member of the allowed group invokes Peri
+    { rowid: 1, appleDate: "1", handle: "+1999", chatId: "chat787", isGroup: true, text: "Peri what's the plan?" },
+    // same member, no trigger → captured, no reply
+    { rowid: 2, appleDate: "2", handle: "+1999", chatId: "chat787", isGroup: true, text: "just chatting" },
+    // a DIFFERENT group not on the allowlist → no reply even with the trigger
+    { rowid: 3, appleDate: "3", handle: "+1888", chatId: "chat999", isGroup: true, text: "Peri hello" }
+  ];
+  const r = await b.bridge.poll();
+  assert.equal(r.replied, 1, "only the allowed group's triggered message replies");
+  assert.equal(b.sent.length, 1);
+  assert.equal(b.sent[0].h, "chat787", "reply sent to the GROUP chat id, not +1999");
+  assert.equal(b.sent[0].group, true, "sent with the group flag");
+  assert.equal(b.forwarded[0].text, "what's the plan?", "trigger mention stripped");
+  assert.equal(b.forwarded[0].from, "imessage:chat787", "session keyed to the group");
+  assert.equal(r.captured, 3, "all group messages still captured");
 });
 
 test("note-to-self: replies to your own self-texts but never loops on its own replies", async () => {


### PR DESCRIPTION
## What

Lets Peri participate in **group chats**: in an allowlisted group, any member can say "Peri …" and the reply is posted **back to the group** (not DM'd to the sender).

- `readNewMessages` returns `chatId` + `isGroup` per row.
- `allowChats`: group-chat allowlist. Anyone in an allowed group can invoke the trigger; reply targets the group via `sendViaIMessage` group mode; session keyed to the group thread so it's one shared conversation.
- Both allowlists gate together — setting `allowFrom` **or** `allowChats` turns off "reply to everyone" (closes an open-to-all gap).
- CLI `--allow-chat`, installer `IMESSAGE_ALLOW_CHATS`, help/docs.
- CLI bridge now starts at the **10s read-only-safe** interval (was hardcoded 2s — important after the read-only chat.db fix).

## Tests
A non-allowlisted member of an allowed group invokes the trigger → reply lands in the group (not a DM); a different non-allowlisted group with the trigger does **not** reply; all group messages still captured. Suite **299 green**.

## Note
Per the user's choice, allowed groups let **any member** invoke Peri (which has tool access via the main). Scrutiny still gates side-effecting actions, but worth being aware the trigger is open to the group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)