### PR TITLE
fix(test): genericize identity fixture (no real name/work email)

### DIFF
--- a/test/buildbetter-auth.test.js
+++ b/test/buildbetter-auth.test.js
@@ -19,10 +19,10 @@ test("ensureIdentity auto-derives email from the me query", async () => {
   const src = new BuildBetterTaskSource({ apiKey: "k" }); // no email/name given
   src.query = async (q) => {
     assert.match(q, /\bme\b/);
-    return { me: { person: { first_name: "Spencer", last_name: "Shulem", email: "spencer@buildbetter.app" } } };
+    return { me: { person: { first_name: "Test", last_name: "User", email: "test@example.com" } } };
   };
   await src.ensureIdentity();
-  assert.equal(src.userEmail, "spencer@buildbetter.app");
+  assert.equal(src.userEmail, "test@example.com");
 });
 
 test("ensureIdentity falls back to full name when me has no email", async () => {


### PR DESCRIPTION
Test fixture used a real name + work email; now `Test User` / `test@example.com`. Tests green.