### PR TITLE
feat(imessage): proactive extraction — follow-ups/events/links from texts

### DIFF
--- a/src/abi-runtime.js
+++ b/src/abi-runtime.js
@@ -26,6 +26,7 @@ import { OutcomeStore } from "./outcome-store.js";
 import { Introspector } from "./introspector.js";
 import { PatternMiner } from "./pattern-miner.js";
 import { SessionMiner } from "./session-miner.js";
+import { IMessageExtractor } from "./imessage-extractor.js";
 import { ProactiveObserver } from "./proactive-observer.js";
 import { TaskStore } from "./task-store.js";
 import { PendingActionStore } from "./pending-actions.js";
@@ -169,6 +170,7 @@ export class AbiRuntime {
     this.tunnelWatcher = options.tunnelWatcher ?? new TunnelWatcher(options.tunnelWatcherOptions ?? {});
     this.patternMiner = options.patternMiner ?? new PatternMiner({ runtime: this, dataDir: options.dataDir, ...(options.patternMinerOptions ?? {}) });
     this.sessionMiner = options.sessionMiner ?? new SessionMiner({ runtime: this, dataDir: options.dataDir, ...(options.sessionMinerOptions ?? {}) });
+    this.imessageExtractor = options.imessageExtractor ?? new IMessageExtractor({ runtime: this, dataDir: options.dataDir });
     this.proactiveObserver = options.proactiveObserver ?? new ProactiveObserver({ runtime: this, dataDir: options.dataDir, ...(options.proactiveObserverOptions ?? {}) });
     // Story 3: closes the suggestion → outcome → next-suggestion loop.
     // Reads resolved suggestion history + user mute preferences, feeds
@@ -283,6 +285,17 @@ export class AbiRuntime {
         enabled: true,
         task: "session-mine",
         intervalMs: 60 * 60 * 1000
+      });
+      // Proactive iMessage extraction: scan newly-captured texts for follow-ups,
+      // events, and links. Cheap (early-returns when no new messages; nano tier
+      // otherwise). Tunable via OPENAGI_IMESSAGE_EXTRACT_MIN (default 15 min).
+      const extractMin = Number(process.env.OPENAGI_IMESSAGE_EXTRACT_MIN) || 15;
+      this.cron.addJob({
+        id: "imessage-extract",
+        name: `iMessage extraction — surface follow-ups/events/links every ${extractMin} min`,
+        enabled: true,
+        task: "imessage-extract",
+        intervalMs: extractMin * 60 * 1000
       });
       // Proactive observer — fast cadence so the agent reacts within
       // minutes when it sees something worth saying.
@@ -605,6 +618,11 @@ export class AbiRuntime {
       if (job.task === "session-mine") {
         const result = await this.sessionMiner.mine({ now });
         this.events?.emit?.("miner-result", { source: "session-miner", at: nowIso(), ...result });
+        return result;
+      }
+      if (job.task === "imessage-extract") {
+        const result = await this.imessageExtractor.extract();
+        this.events?.emit?.("miner-result", { source: "imessage-extractor", at: nowIso(), ...result });
         return result;
       }
       if (job.task === "proactive-observe") {

--- a/src/imessage-extractor.js
+++ b/src/imessage-extractor.js
@@ -1,0 +1,132 @@
+// Proactive iMessage extraction.
+//
+// The bridge captures every incoming text to memory (tagged "imessage"). This
+// runs periodically on the main and pulls structured, actionable items out of
+// those raw captures so the user doesn't have to ask:
+//   • links   → saved to memory (regex, free)
+//   • events  → saved to memory (date/time-bearing plans)
+//   • follow-ups → created as tasks in the user queue (things the user must do)
+//
+// Cost-aware by design: links/dates are pure regex (no model). The follow-up /
+// event understanding uses the CHEAP "extract" tier (nano) on a batch, and the
+// whole pass early-returns for $0 when there are no new messages — so an idle
+// agent pays nothing. This is the "scan new data, surface what matters" half of
+// the listen-queue idea.
+
+import path from "node:path";
+import { readJsonFile, writeJsonAtomic, ensureDir } from "./file-utils.js";
+import { resolveDataDir } from "./data-dir.js";
+import { nowIso } from "./utils.js";
+
+const STATE_FILE = "imessage-extract.json";
+const MAX_BATCH = 60; // cap the per-run transcript so a busy day stays cheap
+const URL_RE = /https?:\/\/[^\s<>"')]+/gi;
+
+const SYSTEM_PROMPT = [
+  "You extract actionable items from a batch of the user's recent text messages.",
+  "Return STRICT JSON only, no prose:",
+  '{"followups":[{"text":"<what the user needs to do>","who":"<sender if known>"}],',
+  ' "events":[{"title":"<plan>","when":"<date/time as written>"}]}',
+  "Rules:",
+  "- followups: only things the USER must do or reply to — commitments, direct asks",
+  '  ("can you…", "don\'t forget", "let me know", "send me…"). Not their own outgoing chatter.',
+  "- events: plans tied to a date/time (dinner Fri 7pm, flight Tuesday, meeting the 15th).",
+  "- Be conservative. Only real, specific items. Use empty arrays if nothing qualifies."
+].join("\n");
+
+export class IMessageExtractor {
+  constructor({ runtime, dataDir } = {}) {
+    this.runtime = runtime;
+    this.dataDir = dataDir ?? resolveDataDir();
+    this.statePath = path.join(this.dataDir, STATE_FILE);
+  }
+
+  _loadState() { return readJsonFile(this.statePath, { lastRun: null }); }
+  _saveState(state) { ensureDir(this.dataDir); writeJsonAtomic(this.statePath, state); }
+
+  // Captured iMessages newer than `since`, oldest-first, capped to MAX_BATCH.
+  recentMessages(since) {
+    const out = [];
+    for (const item of this.runtime?.memory?.items?.values?.() ?? []) {
+      if (!item.tags?.includes?.("imessage")) continue;
+      // skip items we already created (links/events we wrote back to memory)
+      if (item.tags.includes("link") || item.tags.includes("event")) continue;
+      if (since && item.createdAt <= since) continue;
+      out.push(item);
+    }
+    out.sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1));
+    return out.slice(-MAX_BATCH);
+  }
+
+  async extract() {
+    const state = this._loadState();
+    const msgs = this.recentMessages(state.lastRun);
+    if (msgs.length === 0) return { skipped: true, reason: "no new messages" };
+
+    // 1. Links — pure regex, no model cost.
+    const links = [];
+    for (const m of msgs) {
+      for (const url of String(m.content).match(URL_RE) ?? []) {
+        links.push({ url, from: m.tags?.find((t) => t !== "imessage") ?? null });
+      }
+    }
+
+    // 2. Follow-ups + events — cheap nano pass over the batch.
+    let followups = [];
+    let events = [];
+    const provider = this.runtime?.agentHost?.modelProvider;
+    const haveLLM = provider?.isConfigured?.() && provider.constructor.name !== "DeterministicModelProvider";
+    if (haveLLM) {
+      try {
+        const transcript = msgs.map((m) => m.content).join("\n");
+        const result = await provider.generate({
+          input: transcript,
+          task: "extract",
+          instructions: SYSTEM_PROMPT,
+          agent: { id: "imessage-extractor", name: "imessage-extractor" },
+          memoryHits: [], messages: [], tools: [], toolRegistry: null, context: {}
+        });
+        const parsed = safeJson(result?.text);
+        followups = Array.isArray(parsed?.followups) ? parsed.followups : [];
+        events = Array.isArray(parsed?.events) ? parsed.events : [];
+      } catch { /* extraction is best-effort; links still saved */ }
+    }
+
+    // 3. Persist: links + events → memory; follow-ups → tasks.
+    let savedLinks = 0, savedEvents = 0, createdTasks = 0;
+    for (const l of links) {
+      this.runtime?.memory?.remember?.(
+        { content: `Link from iMessage${l.from ? ` (${l.from})` : ""}: ${l.url}`, tags: ["imessage", "link"], kind: "fact" },
+        { tier: "medium" }
+      );
+      savedLinks++;
+    }
+    for (const e of events) {
+      if (!e?.title) continue;
+      this.runtime?.memory?.remember?.(
+        { content: `Event (from iMessage): ${e.title}${e.when ? ` — ${e.when}` : ""}`, tags: ["imessage", "event"], kind: "fact" },
+        { tier: "medium" }
+      );
+      savedEvents++;
+    }
+    for (const f of followups) {
+      if (!f?.text) continue;
+      try {
+        this.runtime?.tasks?.add?.(
+          { title: f.text, sourceMeta: { from: f.who ?? null, origin: "imessage" } },
+          { source: "imessage", queue: "user" }
+        );
+        createdTasks++;
+      } catch { /* best effort */ }
+    }
+
+    this._saveState({ lastRun: nowIso() });
+    return { processed: msgs.length, links: savedLinks, events: savedEvents, followups: createdTasks };
+  }
+}
+
+function safeJson(text) {
+  if (!text) return null;
+  const m = String(text).match(/\{[\s\S]*\}/);
+  try { return JSON.parse(m ? m[0] : text); } catch { return null; }
+}

--- a/src/model-router.js
+++ b/src/model-router.js
@@ -24,7 +24,8 @@ export const TASK_PROFILES = {
   scrutiny:  { tier: "nano", label: "Scrutiny judges",     why: "Short act/ask/watch/ignore classification, very frequent — nano is plenty." },
   condense:  { tier: "mini", label: "Memory condensing",   why: "Summarize a cluster of notes into one — a mini model handles it." },
   mine:      { tier: "mini", label: "Session mining",      why: "Cluster intents out of a transcript — mini is enough." },
-  plan:      { tier: "mini", label: "Daily plan / recap",  why: "Summarize the day — mini is enough." }
+  plan:      { tier: "mini", label: "Daily plan / recap",  why: "Summarize the day — mini is enough." },
+  extract:   { tier: "nano", label: "iMessage extraction", why: "Pull follow-ups/events from a batch of texts, runs often — nano is plenty." }
 };
 
 // Order matters for display (strongest → cheapest).

--- a/test/imessage-extractor.test.js
+++ b/test/imessage-extractor.test.js
@@ -1,0 +1,99 @@
+// Proactive iMessage extraction: links (regex), follow-ups → tasks, events →
+// memory, with a date cursor so each message is processed once.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { IMessageExtractor } from "../src/imessage-extractor.js";
+
+function makeRuntime({ messages = [], llm = '{"followups":[],"events":[]}' } = {}) {
+  const items = new Map();
+  let n = 0;
+  for (const m of messages) {
+    const id = `mem_${++n}`;
+    items.set(id, { id, content: m.content, tags: m.tags ?? ["imessage", m.from ?? "+1555"], createdAt: m.createdAt });
+  }
+  const remembered = [];
+  const tasks = [];
+  const runtime = {
+    memory: {
+      items,
+      remember: (obs, ctx) => { remembered.push({ content: obs.content, tags: obs.tags, tier: ctx?.tier }); return { id: `new_${remembered.length}` }; }
+    },
+    agentHost: {
+      modelProvider: { isConfigured: () => true, generate: async () => ({ text: llm }) }
+    },
+    tasks: { add: (input, opts) => tasks.push({ input, opts }) }
+  };
+  return { runtime, remembered, tasks };
+}
+
+const dataDir = () => fs.mkdtempSync(path.join(os.tmpdir(), "openagi-imx-"));
+
+test("extracts links via regex and saves them to memory (no model needed)", async () => {
+  const { runtime, remembered } = makeRuntime({
+    messages: [
+      { content: "iMessage from +1555: check this https://example.com/deal and https://foo.bar/x", createdAt: "2026-06-12T10:00:00Z" }
+    ],
+    llm: '{"followups":[],"events":[]}'
+  });
+  const x = new IMessageExtractor({ runtime, dataDir: dataDir() });
+  const r = await x.extract();
+  assert.equal(r.links, 2, "both URLs saved");
+  const links = remembered.filter((m) => m.tags.includes("link"));
+  assert.equal(links.length, 2);
+  assert.match(links[0].content, /https:\/\/example\.com\/deal/);
+});
+
+test("follow-ups become tasks; events become memory", async () => {
+  const { runtime, remembered, tasks } = makeRuntime({
+    messages: [
+      { content: "iMessage from Sarah: can you send me the deck before Friday?", createdAt: "2026-06-12T11:00:00Z" },
+      { content: "iMessage from Mom: dinner Sunday at 6 at our place", createdAt: "2026-06-12T11:01:00Z" }
+    ],
+    llm: JSON.stringify({
+      followups: [{ text: "Send Sarah the deck before Friday", who: "Sarah" }],
+      events: [{ title: "Dinner at Mom's", when: "Sunday 6pm" }]
+    })
+  });
+  const x = new IMessageExtractor({ runtime, dataDir: dataDir() });
+  const r = await x.extract();
+  assert.equal(r.followups, 1, "one task created");
+  assert.equal(tasks[0].input.title, "Send Sarah the deck before Friday");
+  assert.equal(tasks[0].opts.source, "imessage");
+  assert.equal(r.events, 1, "one event saved to memory");
+  assert.ok(remembered.some((m) => m.tags.includes("event") && /Dinner at Mom/.test(m.content)));
+});
+
+test("idle: no new messages → skipped, $0", async () => {
+  const { runtime } = makeRuntime({ messages: [] });
+  const x = new IMessageExtractor({ runtime, dataDir: dataDir() });
+  const r = await x.extract();
+  assert.equal(r.skipped, true);
+});
+
+test("date cursor: a message is only processed once across runs", async () => {
+  const dir = dataDir();
+  const { runtime } = makeRuntime({
+    messages: [{ content: "iMessage from +1555: https://once.example", createdAt: "2026-06-12T12:00:00Z" }]
+  });
+  const x = new IMessageExtractor({ runtime, dataDir: dir });
+  const r1 = await x.extract();
+  assert.equal(r1.links, 1, "first run processes it");
+  const r2 = await x.extract();
+  assert.equal(r2.skipped, true, "second run finds nothing new (cursor advanced)");
+});
+
+test("non-imessage memory items are ignored", async () => {
+  const { runtime, remembered } = makeRuntime({
+    messages: [
+      { content: "a normal note", tags: ["note"], createdAt: "2026-06-12T13:00:00Z" },
+      { content: "iMessage from +1555: https://keep.example", tags: ["imessage", "+1555"], createdAt: "2026-06-12T13:01:00Z" }
+    ]
+  });
+  const x = new IMessageExtractor({ runtime, dataDir: dataDir() });
+  const r = await x.extract();
+  assert.equal(r.processed, 1, "only the imessage-tagged item is in the batch");
+  assert.equal(r.links, 1);
+});


### PR DESCRIPTION
## What

The bridge captures every incoming text to memory; this adds a periodic pass on the main that pulls **actionable** items out so the user doesn't have to ask:

- **links** → saved to memory (regex, **$0** — no model)
- **events** → saved to memory (date/time-bearing plans)
- **follow-ups** → created as **tasks** in the user queue

## Cost-aware (ties to the listen-queue idea)

- **$0 when idle** — early-returns if there are no new messages.
- Follow-up/event understanding runs on the cheap **`extract` tier (nano)** over a batched transcript, capped at 60 messages/run.
- Tunable via `OPENAGI_IMESSAGE_EXTRACT_MIN` (default 15 min).

## How

- `src/imessage-extractor.js` — date-cursor state, regex links, one nano batch call for follow-ups/events, writes memory + tasks.
- `model-router` — new `extract` task → nano.
- `abi-runtime` — instantiate + `imessage-extract` cron + dispatch.

## Tests
5 new: links, follow-ups→tasks, events→memory, idle-skip, cursor-processes-once, ignores non-imessage memory. **Suite 304 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)