### PR TITLE
feat(self-update): auto-recover from upstream history rewrites + v0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagi",
-  "version": "0.1.0",
+  "version": "0.0.6",
   "private": true,
   "type": "module",
   "description": "Generic ABI runtime scaffold for directional adaptive scrutiny, tiered memory, and propagation.",

--- a/src/self-update.js
+++ b/src/self-update.js
@@ -44,8 +44,17 @@ export async function checkForUpdate({ run = gitRun } = {}) {
   const behind = Number.parseInt(await run(["rev-list", "--count", `HEAD..${upstream}`]), 10) || 0;
   const ahead = Number.parseInt(await run(["rev-list", "--count", `${upstream}..HEAD`]), 10) || 0;
   const latest = await run(["rev-parse", "--short", upstream]);
+  // "unrelated": HEAD and upstream share NO common ancestor — the upstream
+  // history was rewritten (e.g. a filter-repo purge / force-push). Distinct from
+  // ordinary divergence (local commits), which always shares a merge-base. We
+  // use this to safely auto-recover without ever discarding real local commits.
+  let unrelated = false;
+  if (behind > 0 && ahead > 0) {
+    try { await run(["merge-base", "HEAD", upstream]); }
+    catch { unrelated = true; }
+  }
   return {
-    ok: true, branch, current, upstream, latest, behind, ahead,
+    ok: true, branch, current, upstream, latest, behind, ahead, unrelated,
     updateAvailable: behind > 0,
     canFastForward: behind > 0 && ahead === 0
   };
@@ -59,6 +68,23 @@ export async function applyUpdate({ run = gitRun, installDeps = defaultInstallDe
   if (!status.ok) return { updated: false, ...status };
   if (!status.updateAvailable) return { updated: false, reason: "already up to date", ...status };
   if (!status.canFastForward) {
+    // Recover from an upstream history rewrite: when the histories are unrelated
+    // (no shared ancestor) AND the working tree is clean, hard-reset onto
+    // upstream. Gated on `unrelated` so real local commits (which share a
+    // merge-base) are never discarded, and on a clean tree so no uncommitted
+    // edits are lost. This auto-heals installs whose ff-update broke after a
+    // history purge — without it they'd silently stop updating.
+    if (status.unrelated) {
+      const dirty = (await run(["status", "--porcelain"]).catch(() => "dirty")).length > 0;
+      if (dirty) {
+        return { updated: false, reason: "upstream history was rewritten but the working tree is dirty — resolve manually with `git reset --hard <upstream>`", ...status };
+      }
+      await run(["reset", "--hard", status.upstream]);
+      try { await installDeps(); }
+      catch (error) { return { updated: true, recovered: true, from: status.current, to: status.latest, depsInstalled: false, depsError: error.message, branch: status.branch }; }
+      const to = await run(["rev-parse", "--short", "HEAD"]);
+      return { updated: true, recovered: true, reason: "recovered from upstream history rewrite (hard reset onto a clean checkout)", from: status.current, to, branch: status.branch };
+    }
     return { updated: false, reason: `local commits / divergence (ahead ${status.ahead}) — not fast-forwardable; resolve manually`, ...status };
   }
 

--- a/test/self-update.test.js
+++ b/test/self-update.test.js
@@ -112,12 +112,54 @@ test("applyUpdate refuses to update a diverged checkout (won't clobber local com
     "fetch": "",
     "rev-list --count HEAD..origin/main": "2",
     "rev-list --count origin/main..HEAD": "1",   // local is ahead → diverged
+    "merge-base HEAD origin/main": "c0mm0n",      // shared ancestor → real local commits
     "rev-parse --short origin/main": "bbbbbbb"
   });
   const r = await applyUpdate({ run, installDeps: async () => {} });
   assert.equal(r.updated, false);
   assert.match(r.reason, /diverg|fast-forward/i);
   assert.ok(!calls.includes("merge --ff-only origin/main"), "must not merge a diverged checkout");
+  assert.ok(!calls.some((c) => c.startsWith("reset --hard")), "must not hard-reset a checkout with real local commits");
+});
+
+test("applyUpdate recovers from an upstream history rewrite (unrelated + clean tree → hard reset)", async () => {
+  let resetTo = null, installed = false;
+  const { run, calls } = fakeGit({
+    "rev-parse --abbrev-ref HEAD": "main",
+    "rev-parse --short HEAD": "0ldhash",
+    "rev-parse --abbrev-ref --symbolic-full-name @{u}": "origin/main",
+    "fetch": "",
+    "rev-list --count HEAD..origin/main": "300",  // looks fully behind...
+    "rev-list --count origin/main..HEAD": "295",  // ...AND ahead (unrelated histories)
+    "merge-base HEAD origin/main": new Error("no merge base"), // ← no shared ancestor
+    "rev-parse --short origin/main": "newhash",
+    "status --porcelain": "",                      // clean working tree
+    "reset --hard origin/main": () => { resetTo = "origin/main"; return ""; }
+  });
+  const r = await applyUpdate({ run, installDeps: async () => { installed = true; } });
+  assert.equal(r.updated, true);
+  assert.equal(r.recovered, true, "flagged as a rewrite recovery");
+  assert.equal(resetTo, "origin/main", "hard-reset onto upstream");
+  assert.ok(installed, "deps reinstalled after recovery");
+  assert.ok(!calls.includes("merge --ff-only origin/main"), "recovers via reset, not merge");
+});
+
+test("applyUpdate will NOT hard-reset a rewrite if the tree is dirty (protects local edits)", async () => {
+  const { run, calls } = fakeGit({
+    "rev-parse --abbrev-ref HEAD": "main",
+    "rev-parse --short HEAD": "0ldhash",
+    "rev-parse --abbrev-ref --symbolic-full-name @{u}": "origin/main",
+    "fetch": "",
+    "rev-list --count HEAD..origin/main": "300",
+    "rev-list --count origin/main..HEAD": "295",
+    "merge-base HEAD origin/main": new Error("no merge base"),
+    "rev-parse --short origin/main": "newhash",
+    "status --porcelain": " M src/foo.js"           // uncommitted local change
+  });
+  const r = await applyUpdate({ run, installDeps: async () => {} });
+  assert.equal(r.updated, false);
+  assert.match(r.reason, /dirty|resolve manually/i);
+  assert.ok(!calls.some((c) => c.startsWith("reset --hard")), "never hard-reset a dirty tree");
 });
 
 test("applyUpdate: already up to date is a clean no-op", async () => {


### PR DESCRIPTION
## Why

The PII history purge force-pushed a rewritten `main`. Existing checkouts now have an **unrelated history**, so self-update's `merge --ff-only` fails and they silently stop updating (this hit both deployed devices).

## Fix

When `HEAD` and upstream share **no merge-base** (a rewrite — *not* ordinary divergence) **and the working tree is clean**, hard-reset onto upstream to auto-heal. Both gates matter:
- **no merge-base** → real local commits always share an ancestor, so they're never discarded
- **clean tree** → uncommitted edits are never lost

Dirty tree → refuses with a clear `git reset --hard <upstream>` hint. Ordinary divergence (local commits) → unchanged behavior.

## Tests
Rewrite-recovery (reset happens), dirty-tree protection (reset refused), and the existing diverged test now also asserts it never hard-resets a checkout with real local commits. Full suite green.

Also bumps `package.json` 0.1.0 → **0.0.6** to align with the release-tag series. Tag/release cut separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)