### PR TITLE
feat(imessage): plain-text replies (strip markdown)

### DIFF
--- a/src/integrations/imessage-bridge.js
+++ b/src/integrations/imessage-bridge.js
@@ -21,6 +21,29 @@ const execFileAsync = promisify(execFile);
 const DEFAULT_DB = path.join(os.homedir(), "Library", "Messages", "chat.db");
 const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
+// iMessage has no markdown — agent replies full of **bold**, ## headers, and
+// [links](url) render literally and look broken. Convert to clean plain text:
+// strip emphasis/headers/code fences, turn list bullets into •, flatten links
+// to "text (url)", and collapse excess blank lines.
+export function toPlainText(md) {
+  if (!md) return "";
+  let t = String(md);
+  t = t.replace(/```[^\n]*\n?([\s\S]*?)```/g, "$1");        // code fences → inner text
+  t = t.replace(/`([^`]+)`/g, "$1");                          // inline code
+  t = t.replace(/!\[[^\]]*\]\([^)]*\)/g, "");                // images → drop
+  t = t.replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1 ($2)");      // [text](url) → text (url)
+  t = t.replace(/^\s{0,3}#{1,6}\s+/gm, "");                  // # headers → text
+  t = t.replace(/^\s{0,3}>\s?/gm, "");                       // blockquotes
+  t = t.replace(/^(\s*)[-*+]\s+/gm, "$1• ");                 // bullets → •
+  t = t.replace(/\*\*([^*]+)\*\*/g, "$1").replace(/__([^_]+)__/g, "$1"); // bold
+  t = t.replace(/(^|[^*])\*([^*\n]+)\*/g, "$1$2");           // *italic*
+  t = t.replace(/(^|[^_])_([^_\n]+)_/g, "$1$2");             // _italic_
+  t = t.replace(/~~([^~]+)~~/g, "$1");                       // strikethrough
+  t = t.replace(/^\s{0,3}([-*_]){3,}\s*$/gm, "");            // --- rules
+  t = t.replace(/\n{3,}/g, "\n\n").trim();                   // collapse blank lines
+  return t;
+}
+
 // Open chat.db as a strictly READ-ONLY, non-locking reader. This is critical:
 // node:sqlite opens read-WRITE by default, and a read-write connection on a
 // live WAL database (which Messages.app is constantly writing) attempts WAL
@@ -197,7 +220,7 @@ export class IMessageBridge {
         // Session keys off the conversation so a group has one shared thread.
         const sessionKey = row.isGroup ? row.chatId : row.handle;
         const res = await this.client.chat(decision.forward, { from: `imessage:${sessionKey}` });
-        const reply = res?.json?.reply;
+        const reply = toPlainText(res?.json?.reply);
         if (res?.ok && reply) {
           // Reply to the GROUP chat if it's a group; otherwise DM the sender.
           if (row.isGroup) await this.sendMessage(row.chatId, reply, { group: true });

--- a/test/imessage-bridge.test.js
+++ b/test/imessage-bridge.test.js
@@ -6,7 +6,19 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { IMessageBridge, extractAttributedText } from "../src/integrations/imessage-bridge.js";
+import { IMessageBridge, extractAttributedText, toPlainText } from "../src/integrations/imessage-bridge.js";
+
+test("toPlainText strips markdown so iMessage replies aren't wack", () => {
+  const md = "## Plan\n\nHere's the **budget**:\n- venue: $12k\n- food: *catered*\n\nSee [the doc](https://x.com/d) and `run this`.\n\n~~old~~ done";
+  const out = toPlainText(md);
+  assert.ok(!/\*\*|##|~~|`/.test(out), "no markdown markers remain");
+  assert.match(out, /Plan/);
+  assert.match(out, /budget:/);
+  assert.match(out, /• venue: \$12k/, "bullets become •");
+  assert.match(out, /the doc \(https:\/\/x\.com\/d\)/, "links flattened to text (url)");
+  assert.match(out, /run this/);
+  assert.match(out, /old done|done/);
+});
 
 function makeBridge({ messages = [], replies = {}, allowFrom = [] } = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-imsg-"));


### PR DESCRIPTION
Agent replies rendered as raw markdown in iMessage (looked wack). `toPlainText()` strips emphasis/headers/code/bullets and flattens links before sending. Test added. Suite 307 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)