### PR TITLE
fix(imessage): decode attributedBody correctly (Peri trigger was broken)

### DIFF
--- a/src/integrations/imessage-bridge.js
+++ b/src/integrations/imessage-bridge.js
@@ -337,23 +337,30 @@ export async function readMaxAppleDate(dbPath, reuseDb = null) {
 }
 
 // Best-effort text out of the NSAttributedString typedstream blob Messages
-// stores in `attributedBody`. Byte-walk (no fragile control-char regex): find
-// the "NSString" class marker, skip the short length-prefix of control bytes
-// (and a leading '+'), then collect UTF-8 until the 0x86/0x84 end marker.
-// Not a full typedstream parser — pragmatic, handles the common case.
+// stores in `attributedBody` (used when the `text` column is NULL, which is the
+// default on recent macOS). The layout after the class name is:
+//   NSString 01 9x 84 01 2b <len> <utf8 bytes…> 86 …
+// The 0x2b ('+') marker introduces a length-prefixed string; <len> is a
+// typedstream integer — a single byte when < 0x80, else 0x81 + uint16LE or
+// 0x82 + uint32LE for longer strings. Read exactly <len> UTF-8 bytes.
+// (The old version byte-walked from a fixed offset and stopped on the first
+// high byte (0x94), so it emitted a lone replacement char for every message —
+// breaking the "Peri" trigger on the bridge host. See PR that added this note.)
 export function extractAttributedText(body) {
   if (!body) return "";
   const buf = Buffer.isBuffer(body) ? body : Buffer.from(body);
   const marker = buf.indexOf(Buffer.from("NSString", "ascii"));
   if (marker === -1) return "";
-  let i = marker + "NSString".length;
-  while (i < buf.length && (buf[i] < 0x20 || buf[i] === 0x2b)) i++; // skip ctrl bytes + leading '+'
-  const start = i;
-  while (i < buf.length && buf[i] !== 0x86 && buf[i] !== 0x84) i++;
-  // Trim any trailing control bytes that slipped in.
-  let end = i;
-  while (end > start && buf[end - 1] < 0x20) end--;
-  return buf.slice(start, end).toString("utf8").trim();
+  let i = buf.indexOf(0x2b, marker + "NSString".length); // the '+' string marker
+  if (i === -1) return "";
+  i += 1;
+  if (i >= buf.length) return "";
+  let len = buf[i++];
+  if (len === 0x81) { len = buf.readUInt16LE(i); i += 2; }
+  else if (len === 0x82) { len = buf.readUInt32LE(i); i += 4; }
+  if (!Number.isFinite(len) || len <= 0) return "";
+  // Strip U+FFFC (object-replacement) placeholders that mark inline attachments.
+  return buf.slice(i, Math.min(i + len, buf.length)).toString("utf8").replace(/￼/g, "").trim();
 }
 
 // Search the iMessage history (both directions). Filters: text `query`

--- a/test/imessage-bridge.test.js
+++ b/test/imessage-bridge.test.js
@@ -98,11 +98,27 @@ test("advances the date high-water mark even when a send errors", async () => {
 });
 
 test("extractAttributedText pulls text from an attributedBody blob", () => {
-  // Minimal synthetic typedstream: ...NSString <ctrl> + <text> 0x86...
+  // Real chat.db typedstream layout: NSString 01 94 84 01 2b <len> <utf8> 86…
+  // where <len> is the UTF-8 byte length (single byte when < 0x80).
   const text = "hello from imessage";
   const blob = Buffer.concat([
     Buffer.from("streamtyped...NSString", "binary"),
-    Buffer.from([0x01, 0x2b]),
+    Buffer.from([0x01, 0x94, 0x84, 0x01, 0x2b, text.length]),
+    Buffer.from(text, "utf8"),
+    Buffer.from([0x86, 0x84])
+  ]);
+  assert.equal(extractAttributedText(blob), text);
+});
+
+test("extractAttributedText handles long strings (0x81 + uint16 length)", () => {
+  // Strings >= 0x80 bytes encode the length as 0x81 followed by a uint16 LE.
+  const text = "x".repeat(200);
+  const len = Buffer.alloc(2);
+  len.writeUInt16LE(text.length, 0);
+  const blob = Buffer.concat([
+    Buffer.from("streamtyped...NSString", "binary"),
+    Buffer.from([0x01, 0x94, 0x84, 0x01, 0x2b, 0x81]),
+    len,
     Buffer.from(text, "utf8"),
     Buffer.from([0x86, 0x84])
   ]);


### PR DESCRIPTION
## The bug

Peri stopped replying to iMessages. Root cause: **`extractAttributedText` returned a single `�` for every message.**

The decoder byte-walked from a fixed offset after the `NSString` marker and stopped on the first high byte (`0x94`), so it read a control byte and emitted a lone U+FFFD. On bridge hosts where the chat.db `text` column is `NULL` (the default on recent macOS), the bridge falls back to this decoder — so **every inbound iMessage became `�`, the `\bPeri\b` trigger never matched, and the agent never responded.** (This also explains the earlier "I sent *Peri list my Airtable bases* and it never replied".)

## The fix

Parse the actual NSAttributedString typedstream layout:

```
NSString 01 9x 84 01 2b <len> <utf8 bytes…> 86 …
```

`<len>` is the UTF-8 byte length — a single byte when `< 0x80`, else `0x81 + uint16LE` / `0x82 + uint32LE`. Read exactly `<len>` bytes. Also strips U+FFFC inline-attachment placeholders.

## Verification

- **60/60** real `chat.db` messages now decode to an exact match against the `text` column (was **0/60**).
- Fixed the synthetic test fixture (it had been written to satisfy the *old buggy* parser, not the real format) and added a long-string (`0x81` length) case.
- Full `imessage-bridge.test.js` suite: 18/18 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)