### PR TITLE
feat(tasks): queue classification + task-list hygiene sweep

### DIFF
--- a/src/abi-runtime.js
+++ b/src/abi-runtime.js
@@ -27,6 +27,7 @@ import { Introspector } from "./introspector.js";
 import { PatternMiner } from "./pattern-miner.js";
 import { SessionMiner } from "./session-miner.js";
 import { IMessageExtractor } from "./imessage-extractor.js";
+import { TaskSweep } from "./task-sweep.js";
 import { ProactiveObserver } from "./proactive-observer.js";
 import { TaskStore } from "./task-store.js";
 import { PendingActionStore } from "./pending-actions.js";
@@ -177,6 +178,9 @@ export class AbiRuntime {
     // a compact summary into the observer's system prompt each pass.
     this.suggestionFeedback = options.suggestionFeedback ?? new SuggestionFeedback({ runtime: this, dataDir: options.dataDir });
     this.tasks = options.tasks ?? new TaskStore({ runtime: this, dataDir: options.dataDir, ...(options.taskStoreOptions ?? {}) });
+    // Periodic task-list hygiene: dedupe, re-home to the right queue, cancel
+    // stale auto-extracted items, archive old terminal tasks.
+    this.taskSweep = options.taskSweep ?? new TaskSweep({ runtime: this });
     // The "ask me" queue: ambiguous task-reconciliation outcomes become
     // questions instead of bad guesses. dataDir-scoped like other stores.
     this.clarifications = options.clarifications ?? new ClarificationStore({
@@ -379,6 +383,17 @@ export class AbiRuntime {
         enabled: true,
         task: "task-activity-scan",
         intervalMs: 15 * 60 * 1000
+      });
+      // Task-list hygiene — dedupe, re-home to the right queue (agent vs
+      // user), cancel stale auto-extracted items, archive old terminal
+      // tasks. Tunable via OPENAGI_TASK_SWEEP_MIN (default 60 min).
+      const sweepMin = Number(process.env.OPENAGI_TASK_SWEEP_MIN) || 60;
+      this.cron.addJob({
+        id: "task-sweep",
+        name: `Task-list hygiene — dedupe / re-home / archive every ${sweepMin} min`,
+        enabled: true,
+        task: "task-sweep",
+        intervalMs: sweepMin * 60 * 1000
       });
       registerCoreTools(this.tools, this);
       // Computer-use tools register only when explicitly opted-in via env
@@ -671,6 +686,11 @@ export class AbiRuntime {
         if (!this.proactiveObserver?.scanTasksAgainstActivity) return { skipped: true, reason: "no observer" };
         const result = await this.proactiveObserver.scanTasksAgainstActivity({ now });
         this.events?.emit?.("miner-result", { source: "task-activity-scan", at: nowIso(), ...result });
+        return result;
+      }
+      if (job.task === "task-sweep") {
+        const result = await this.taskSweep.sweep({ now });
+        this.events?.emit?.("miner-result", { source: "task-sweep", at: nowIso(), ...result });
         return result;
       }
       return { skipped: true, reason: `No handler for task ${job.task}` };

--- a/src/imessage-extractor.js
+++ b/src/imessage-extractor.js
@@ -24,14 +24,18 @@ const URL_RE = /https?:\/\/[^\s<>"')]+/gi;
 
 const SYSTEM_PROMPT = [
   "You extract actionable items from a batch of the user's recent text messages.",
+  '"Peri" is the AI assistant; "Spencer" is the human owner.',
   "Return STRICT JSON only, no prose:",
-  '{"followups":[{"text":"<what the user needs to do>","who":"<sender if known>"}],',
+  '{"followups":[{"text":"<the action>","who":"<sender if known>","queue":"agent|user","action":"act|draft"}],',
   ' "events":[{"title":"<plan>","when":"<date/time as written>"}]}',
   "Rules:",
-  "- followups: only things the USER must do or reply to — commitments, direct asks",
-  '  ("can you…", "don\'t forget", "let me know", "send me…"). Not their own outgoing chatter.',
+  "- followups: only real, specific commitments or direct asks. Not idle chatter.",
+  '- queue: "agent" if Peri can handle it itself (reply to a text, look something up, remember a fact,',
+  '  draft/introduce); "user" if only Spencer can (in-person, personal decisions, his own accounts).',
+  '- action (queue "agent" only): "draft" if completing it SENDS something externally (a text/email/DM) —',
+  '  prepare but do not send; "act" if safe to just do (lookup, remember, internal note). Use "act" otherwise.',
   "- events: plans tied to a date/time (dinner Fri 7pm, flight Tuesday, meeting the 15th).",
-  "- Be conservative. Only real, specific items. Use empty arrays if nothing qualifies."
+  "- Be conservative. Use empty arrays if nothing qualifies."
 ].join("\n");
 
 export class IMessageExtractor {
@@ -112,9 +116,13 @@ export class IMessageExtractor {
     for (const f of followups) {
       if (!f?.text) continue;
       try {
+        // Route to the right queue, and tag agent tasks that send externally
+        // as `plan-action` (draft-only) so autopilot prepares but never sends.
+        const queue = f.queue === "agent" ? "agent" : "user";
+        const tags = queue === "agent" && f.action === "draft" ? ["plan-action"] : [];
         this.runtime?.tasks?.add?.(
-          { title: f.text, sourceMeta: { from: f.who ?? null, origin: "imessage" } },
-          { source: "imessage", queue: "user" }
+          { title: f.text, tags, sourceMeta: { from: f.who ?? null, origin: "imessage" } },
+          { source: "imessage", queue }
         );
         createdTasks++;
       } catch { /* best effort */ }

--- a/src/model-router.js
+++ b/src/model-router.js
@@ -25,7 +25,8 @@ export const TASK_PROFILES = {
   condense:  { tier: "mini", label: "Memory condensing",   why: "Summarize a cluster of notes into one — a mini model handles it." },
   mine:      { tier: "mini", label: "Session mining",      why: "Cluster intents out of a transcript — mini is enough." },
   plan:      { tier: "mini", label: "Daily plan / recap",  why: "Summarize the day — mini is enough." },
-  extract:   { tier: "nano", label: "iMessage extraction", why: "Pull follow-ups/events from a batch of texts, runs often — nano is plenty." }
+  extract:   { tier: "nano", label: "iMessage extraction", why: "Pull follow-ups/events from a batch of texts, runs often — nano is plenty." },
+  sweep:     { tier: "mini", label: "Task list hygiene",    why: "Classify queue + dedupe/stale-judge the task list — mini has the judgment for it." }
 };
 
 // Order matters for display (strongest → cheapest).

--- a/src/task-store.js
+++ b/src/task-store.js
@@ -251,6 +251,26 @@ export class TaskStore {
     return true;
   }
 
+  // Move a task between the user and agent queues, preserving its id and
+  // history. The snapshot is the authoritative load source, so flipping the
+  // field + re-snapshotting is enough; we log a "move" event on the target
+  // queue for the audit trail. Used by the task-sweep to re-home tasks that
+  // were filed in the wrong queue (e.g. an agent-actionable reply that the
+  // extractor defaulted into the user queue).
+  setQueue(id, queue) {
+    if (!QUEUES.includes(queue)) throw new Error(`unknown queue: ${queue}`);
+    const task = this.tasks.get(id);
+    if (!task || task.queue === queue) return task ?? null;
+    const fromQueue = task.queue;
+    const next = { ...task, queue, updatedAt: nowIso() };
+    this.tasks.set(id, next);
+    this.appendEvent(fromQueue, { op: "delete", id });
+    this.appendEvent(queue, { op: "create", task: next });
+    this.snapshot();
+    this.runtime?.events?.emit?.("task-updated", { op: "update", task: next });
+    return next;
+  }
+
   list({ queue, bucket, status, limit = 50 } = {}) {
     let out = [...this.tasks.values()];
     if (queue) out = out.filter((t) => t.queue === queue);

--- a/src/task-sweep.js
+++ b/src/task-sweep.js
@@ -1,0 +1,158 @@
+// Task-list hygiene sweep.
+//
+// Auto-extracted tasks (iMessage follow-ups, observer suggestions) pile up:
+// near-duplicates, items already handled, and things filed in the wrong queue
+// (the extractor defaults everything to the user queue, but many "reply to X"
+// items are things Peri can do itself). Left alone the list becomes noise and
+// the morning digest / autopilot pickup lose signal.
+//
+// This runs periodically and:
+//   1. Dedupes — rule-based, deterministic. Within each queue, near-identical
+//      titles collapse to the highest-priority/earliest one; the rest are
+//      cancelled. No model cost.
+//   2. Re-homes + judges — a CHEAP "sweep" tier (mini) pass classifies each
+//      remaining active task: which queue it belongs in (agent vs user),
+//      whether an agent task should be acted on or only drafted, and whether
+//      it's stale/obsolete. Stale AUTO-sourced tasks are cancelled; stale
+//      manual/external (Linear, BuildBetter) tasks are only flagged for review
+//      so we never silently drop something the user filed by hand.
+//   3. Archives — terminal tasks (completed/cancelled) older than the archive
+//      window are removed from the active store. The append-only JSONL event
+//      log still retains them for history.
+//
+// Agent-queue convention (matches the autopilot prompt): a task tagged
+// `plan-action` is DRAFT-ONLY — autopilot prepares the artifact but never sends
+// externally. Untagged agent tasks are safe to fully execute.
+
+import { nowIso } from "./utils.js";
+
+// Sources we created automatically — safe to auto-cancel when stale. Anything
+// else (manual, linear, buildbetter) is the user's; we only flag those.
+const AUTO_SOURCES = new Set(["imessage", "observer", "proactive", "proactive-observer", "inbox"]);
+const ACTIVE = new Set(["pending", "in_progress", "blocked"]);
+const ARCHIVE_DAYS_DEFAULT = 14;
+
+const SYSTEM_PROMPT = [
+  "You are tidying an AI assistant's task list. \"Peri\" is the assistant; \"Spencer\" is the human owner.",
+  "You receive a JSON array of tasks: [{i, queue, source, title}].",
+  "For EACH task return an object {i, queue, action, stale} and nothing else:",
+  '- queue: "agent" if Peri can do it itself (reply to a text, look something up, remember a fact,',
+  '  draft/introduce, summarize); "user" if only Spencer can (in-person actions, personal decisions,',
+  "  anything needing his own judgment or accounts).",
+  '- action: only for queue "agent". "draft" if completing it SENDS something externally (a text, email,',
+  '  Slack/DM) — Peri should prepare but not send. "act" if it is safe to just do (lookups, remembering,',
+  '  internal notes). Use null for queue "user".',
+  "- stale: true if the task is obsolete, already handled, superseded by a newer one, or a near-duplicate",
+  "  of another in the list; otherwise false.",
+  "Return STRICT JSON array only — one object per input task, echoing the same i. No prose."
+].join("\n");
+
+export class TaskSweep {
+  constructor({ runtime, archiveDays } = {}) {
+    this.runtime = runtime;
+    this.archiveDays = Number(archiveDays ?? process.env.OPENAGI_TASK_ARCHIVE_DAYS) || ARCHIVE_DAYS_DEFAULT;
+  }
+
+  async sweep({ now = new Date() } = {}) {
+    const tasks = this.runtime?.tasks;
+    if (!tasks?.list) return { skipped: true, reason: "no task store" };
+
+    const summary = { deduped: 0, requeued: 0, cancelledStale: 0, retagged: 0, flagged: 0, archived: 0, considered: 0 };
+
+    // 1) Rule-based dedup within each queue.
+    const active = tasks.list({ limit: 1000 }).filter((t) => ACTIVE.has(t.status));
+    summary.considered = active.length;
+    for (const queue of ["user", "agent"]) {
+      const groups = new Map();
+      for (const t of active.filter((t) => t.queue === queue)) {
+        const key = normalizeTitle(t.title);
+        if (!key) continue;
+        if (!groups.has(key)) groups.set(key, []);
+        groups.get(key).push(t);
+      }
+      for (const group of groups.values()) {
+        if (group.length < 2) continue;
+        group.sort((a, b) => (b.priority - a.priority) || (a.createdAt ?? "").localeCompare(b.createdAt ?? ""));
+        for (const dup of group.slice(1)) {
+          tasks.update(dup.id, { status: "cancelled" });
+          summary.deduped++;
+        }
+      }
+    }
+
+    // 2) Cheap LLM pass: re-home, action-tag, stale-judge what's left.
+    const remaining = tasks.list({ limit: 1000 }).filter((t) => ACTIVE.has(t.status));
+    const provider = this.runtime?.agentHost?.modelProvider;
+    const haveLLM = provider?.isConfigured?.() && provider.constructor.name !== "DeterministicModelProvider";
+    if (haveLLM && remaining.length) {
+      try {
+        const input = remaining.map((t, i) => ({ i, queue: t.queue, source: t.source, title: t.title }));
+        const result = await provider.generate({
+          input: JSON.stringify(input),
+          task: "sweep",
+          instructions: SYSTEM_PROMPT,
+          agent: { id: "task-sweep", name: "task-sweep" },
+          memoryHits: [], messages: [], tools: [], toolRegistry: null, context: {}
+        });
+        for (const v of safeJsonArray(result?.text)) {
+          const t = remaining[v?.i];
+          if (!t) continue;
+          // Stale → cancel auto-sourced; flag everything else for review.
+          if (v.stale === true) {
+            if (AUTO_SOURCES.has(t.source)) { tasks.update(t.id, { status: "cancelled" }); summary.cancelledStale++; continue; }
+            if (addTag(tasks, t, "review")) summary.flagged++;
+          }
+          const targetQueue = v.queue === "agent" || v.queue === "user" ? v.queue : t.queue;
+          if (targetQueue !== t.queue && tasks.setQueue) { tasks.setQueue(t.id, targetQueue); summary.requeued++; }
+          // Agent tasks: draft-only (external send) carry `plan-action`; safe ones don't.
+          if (targetQueue === "agent") {
+            const changed = v.action === "draft" ? addTag(tasks, t, "plan-action") : removeTag(tasks, t, "plan-action");
+            if (changed) summary.retagged++;
+          }
+        }
+      } catch { /* hygiene is best-effort; dedup + archive still applied */ }
+    }
+
+    // 3) Archive terminal tasks older than the window.
+    const cutoff = now.getTime() - this.archiveDays * 86_400_000;
+    for (const t of tasks.list({ limit: 2000 })) {
+      if (t.status !== "completed" && t.status !== "cancelled") continue;
+      const ts = Date.parse(t.completedAt || t.updatedAt || t.createdAt || "");
+      if (Number.isFinite(ts) && ts < cutoff && tasks.remove) { tasks.remove(t.id); summary.archived++; }
+    }
+
+    summary.at = nowIso();
+    return summary;
+  }
+}
+
+// Collapse a title to a comparison key: lowercase, drop punctuation, squash
+// whitespace. Catches "Reply on Slack" / "Reply on Slack." / "reply on  slack".
+function normalizeTitle(title) {
+  return String(title ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function addTag(tasks, task, tag) {
+  const tagsArr = Array.isArray(task.tags) ? task.tags : [];
+  if (tagsArr.includes(tag)) return false;
+  tasks.update(task.id, { tags: [...tagsArr, tag] });
+  return true;
+}
+
+function removeTag(tasks, task, tag) {
+  const tagsArr = Array.isArray(task.tags) ? task.tags : [];
+  if (!tagsArr.includes(tag)) return false;
+  tasks.update(task.id, { tags: tagsArr.filter((x) => x !== tag) });
+  return true;
+}
+
+function safeJsonArray(text) {
+  if (!text) return [];
+  const m = String(text).match(/\[[\s\S]*\]/);
+  try { const v = JSON.parse(m ? m[0] : text); return Array.isArray(v) ? v : []; }
+  catch { return []; }
+}

--- a/test/task-sweep.test.js
+++ b/test/task-sweep.test.js
@@ -1,0 +1,86 @@
+// Task-list hygiene sweep: rule-based dedupe, LLM re-home + action-tag +
+// stale-judge, and archival of old terminal tasks.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { TaskStore } from "../src/task-store.js";
+import { TaskSweep } from "../src/task-sweep.js";
+
+const dataDir = () => fs.mkdtempSync(path.join(os.tmpdir(), "openagi-sweep-"));
+
+// Fake model provider: parses the sweep's JSON input and applies `decide(title)`
+// to each task, echoing the index back. constructor.name is "Object" so the
+// sweep's DeterministicModelProvider guard lets it through.
+function llmProvider(decide) {
+  return {
+    isConfigured: () => true,
+    generate: async ({ input }) => {
+      const arr = JSON.parse(input);
+      return { text: JSON.stringify(arr.map((t) => ({ i: t.i, ...decide(t.title) }))) };
+    }
+  };
+}
+
+test("rule-based dedupe cancels near-identical titles within a queue", async () => {
+  const store = new TaskStore({ runtime: {}, dataDir: dataDir() });
+  store.add({ title: "Reply on Slack" }, { source: "imessage", queue: "user" });
+  store.add({ title: "Reply on Slack." }, { source: "imessage", queue: "user" });
+  store.add({ title: "reply on  slack" }, { source: "imessage", queue: "user" });
+  store.add({ title: "Unique thing" }, { source: "imessage", queue: "user" });
+
+  const sweep = new TaskSweep({ runtime: { tasks: store, agentHost: { modelProvider: null } } });
+  const r = await sweep.sweep();
+
+  assert.equal(r.deduped, 2, "two of the three slack dupes cancelled");
+  const pending = store.list({ status: "pending" });
+  assert.equal(pending.filter((t) => t.title.toLowerCase().includes("slack")).length, 1, "one slack task survives");
+  assert.ok(pending.some((t) => t.title === "Unique thing"), "unrelated task untouched");
+});
+
+test("LLM pass re-homes to agent queue, tags external sends draft-only, and judges staleness", async () => {
+  const store = new TaskStore({ runtime: {}, dataDir: dataDir() });
+  const reply = store.add({ title: "Reply to +1480 about dinner" }, { source: "imessage", queue: "user" });
+  const decide = store.add({ title: "Decide whether to take the meeting" }, { source: "imessage", queue: "user" });
+  const obsolete = store.add({ title: "Old obsolete thing" }, { source: "imessage", queue: "user" });
+  const manual = store.add({ title: "Manual stale item" }, { source: "manual", queue: "user" });
+
+  const provider = llmProvider((title) => {
+    if (title.startsWith("Reply")) return { queue: "agent", action: "draft", stale: false };
+    if (title.startsWith("Decide")) return { queue: "user", action: null, stale: false };
+    return { queue: "user", stale: true }; // both "obsolete" + "manual stale"
+  });
+  const sweep = new TaskSweep({ runtime: { tasks: store, agentHost: { modelProvider: provider } } });
+  const r = await sweep.sweep();
+
+  const replyNow = store.get(reply.id);
+  assert.equal(replyNow.queue, "agent", "agent-actionable reply re-homed to agent queue");
+  assert.ok(replyNow.tags.includes("plan-action"), "external send marked draft-only");
+  assert.equal(r.requeued, 1);
+
+  assert.equal(store.get(decide.id).queue, "user", "decision stays with the user");
+
+  assert.equal(store.get(obsolete.id).status, "cancelled", "stale auto-sourced task cancelled");
+  assert.ok(r.cancelledStale >= 1);
+
+  const manualNow = store.get(manual.id);
+  assert.equal(manualNow.status, "pending", "stale MANUAL task is not auto-cancelled");
+  assert.ok(manualNow.tags.includes("review"), "manual stale task flagged for review instead");
+  assert.ok(r.flagged >= 1);
+});
+
+test("archives terminal tasks older than the window", async () => {
+  const store = new TaskStore({ runtime: {}, dataDir: dataDir() });
+  const done = store.add({ title: "Finished thing" }, { source: "imessage", queue: "agent" });
+  store.complete(done.id);
+  const keep = store.add({ title: "Still pending" }, { source: "imessage", queue: "user" });
+
+  // archiveDays -1 → cutoff is in the future, so every terminal task qualifies.
+  const sweep = new TaskSweep({ runtime: { tasks: store, agentHost: { modelProvider: null } }, archiveDays: -1 });
+  const r = await sweep.sweep();
+
+  assert.equal(r.archived, 1, "the completed task is archived");
+  assert.equal(store.get(done.id), null, "archived task removed from active store");
+  assert.ok(store.get(keep.id), "pending task retained");
+});


### PR DESCRIPTION
## Why

The iMessage extractor filed **every** follow-up into the `user` queue. So tasks Peri can handle itself ("reply to +1480…", "introduce yourself to Morgan", "remember X") piled up as *Spencer's* tasks — with no dedupe and no cleanup. Live state on the Distiller: 24 pending user tasks (many agent-actionable, several near-duplicate "Reply on Slack" / "Introduce yourself to Morgan") + 8 done, and no cron maintaining any of it.

## What

**1. Classify at creation** — the extractor now asks the model for each follow-up's `queue` (agent vs user) and, for agent items, `action` (act vs draft). Agent tasks that send externally get tagged `plan-action` (the autopilot draft-only convention); safe ones (lookups, remembering) stay actionable.

**2. New `task-sweep` cron** (default 60 min, `OPENAGI_TASK_SWEEP_MIN`):
- rule-based dedupe of near-identical titles within a queue (no model cost)
- a cheap **`sweep` tier (mini)** pass that re-homes tasks to the right queue, tags external-send agent tasks draft-only, and judges staleness
- stale **auto-sourced** tasks are cancelled; stale **manual/external** (Linear, BuildBetter) tasks are only flagged `review` — never silently dropped
- terminal tasks older than `OPENAGI_TASK_ARCHIVE_DAYS` (14) are archived

Per the owner's choices: auto-cancel dupes + stale; agent acts on safe items, drafts anything that sends externally.

## Notes
- Adds `TaskStore.setQueue` (move between queues, preserving id + history) and a `sweep` model profile (mini tier — uses whatever GPT-5.x mini you've configured).
- Tests: dedupe, LLM re-home/tag/stale, archival. `imessage-extractor` tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)