### PR TITLE
fix(mcp): sanitize server name in tool names (a space broke ALL tool calls)

### DIFF
--- a/src/mcp-registry.js
+++ b/src/mcp-registry.js
@@ -16,6 +16,16 @@ const ALLOWED_STDIO_COMMANDS = new Set([
   "docker"
 ]);
 
+// MCP tools are exposed to the model as `mcp_<server>_<tool>`, and that name
+// must match OpenAI's tool-name rule ^[a-zA-Z0-9_-]+$. BOTH segments can carry
+// spaces/punctuation (e.g. a server literally named "BB Staging"), so sanitize
+// each — otherwise the whole tools[] array is rejected and every tool-bearing
+// call (autopilot, chat, sweeps) fails. The handler dispatches via stored
+// server/tool refs, not by parsing this name, so sanitizing is lossless.
+const mcpSeg = (s) => String(s).replace(/[^a-zA-Z0-9_]/g, "_");
+const mcpToolName = (server, tool) => `mcp_${mcpSeg(server)}_${mcpSeg(tool)}`;
+const mcpToolPrefix = (server) => `mcp_${mcpSeg(server)}_`;
+
 export class McpRegistry {
   constructor(options = {}) {
     this.servers = new Map();
@@ -224,7 +234,7 @@ export class McpRegistry {
           name: rawName,
           // The name the tool is actually registered + callable under (matches
           // exposeAsTools). Consumers that build allowlists must use this.
-          registeredName: `mcp_${name}_${String(rawName).replace(/[^a-zA-Z0-9_]/g, "_")}`,
+          registeredName: mcpToolName(name, rawName),
           description: tool.description ?? "",
           inputSchema: tool.inputSchema ?? null,
           connected: Boolean(client?.connected)
@@ -405,7 +415,7 @@ export class McpRegistry {
     this.clients.delete(name);
     if (this.toolRegistry) {
       for (const toolName of [...this.toolRegistry.tools.keys()]) {
-        if (toolName.startsWith(`mcp_${name}_`)) this.toolRegistry.unregister(toolName);
+        if (toolName.startsWith(mcpToolPrefix(name))) this.toolRegistry.unregister(toolName);
       }
     }
     return true;
@@ -428,10 +438,10 @@ export class McpRegistry {
     const client = this.clients.get(serverName);
     if (!client) return;
     for (const toolName of [...this.toolRegistry.tools.keys()]) {
-      if (toolName.startsWith(`mcp_${serverName}_`)) this.toolRegistry.unregister(toolName);
+      if (toolName.startsWith(mcpToolPrefix(serverName))) this.toolRegistry.unregister(toolName);
     }
     for (const tool of client.tools ?? []) {
-      const safeName = `mcp_${serverName}_${String(tool.name).replace(/[^a-zA-Z0-9_]/g, "_")}`;
+      const safeName = mcpToolName(serverName, tool.name);
       this.toolRegistry.register({
         name: safeName,
         description: `[MCP:${serverName}] ${tool.description ?? tool.name}`,

--- a/test/mcp-tool-name-sanitize.test.js
+++ b/test/mcp-tool-name-sanitize.test.js
@@ -1,0 +1,34 @@
+// MCP tools are exposed to the model as `mcp_<server>_<tool>`. OpenAI rejects
+// the whole tools[] array if any name violates ^[a-zA-Z0-9_-]+$, which breaks
+// every tool-bearing call. A server name with a space (e.g. "BB Staging") used
+// to leak the space into the tool name; both segments must be sanitized.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { McpRegistry } from "../src/mcp-registry.js";
+
+const tmp = path.join(os.tmpdir(), `openagi-toolname-${process.pid}`);
+const VALID = /^[a-zA-Z0-9_-]+$/;
+
+test("a server name with a space yields OpenAI-valid tool names", () => {
+  const reg = new McpRegistry({ dataDir: tmp, configPath: null });
+  reg.registerServer({ name: "BB Staging", url: "https://mcp-staging.buildbetter.app/sse", auth: "oauth", trustLevel: "trusted" });
+  // Simulate a connected client exposing a tool whose name also has a dash.
+  reg.clients.set("BB Staging", {
+    connected: true,
+    tools: [{ name: "get-call-transcript", description: "x", inputSchema: {} }],
+    callTool: async () => ({})
+  });
+
+  const listed = reg.listTools().find((t) => t.server === "BB Staging");
+  assert.ok(VALID.test(listed.registeredName), `registeredName not API-valid: ${listed.registeredName}`);
+  assert.equal(listed.registeredName, "mcp_BB_Staging_get_call_transcript");
+
+  // exposeAsTools must register under the same sanitized, valid name.
+  const registered = [];
+  reg.toolRegistry = { tools: new Map(), register: (t) => registered.push(t.name), unregister: () => {} };
+  reg.exposeAsTools("BB Staging");
+  assert.ok(registered.every((n) => VALID.test(n)), `exposed names not API-valid: ${registered.join(", ")}`);
+  assert.ok(registered.includes("mcp_BB_Staging_get_call_transcript"));
+});


### PR DESCRIPTION
## Bug

Connecting an MCP server whose name contains a space — e.g. **`BB Staging`** — made OpenAI reject every request with tools:

```
Invalid 'tools[92].name': string does not match pattern '^[a-zA-Z0-9_-]+$'
```

MCP tools are exposed to the model as `mcp_<server>_<tool>`. `exposeAsTools`/`listTools` sanitized only the **tool** segment, leaving the server segment intact → `mcp_BB Staging_run_query`. Because OpenAI rejects the whole `tools[]` array, this broke **every** tool-bearing call: autopilot, chat, and the new task-sweep.

## Fix

Sanitize **both** segments via shared `mcpToolName` / `mcpToolPrefix` helpers (the prefix helper keeps the disconnect/unregister matching in sync). Dispatch uses the stored `server` + `originalName` refs, so the rename is lossless — invocation still hits the real MCP tool.

Regression test: a server named `BB Staging` now yields `mcp_BB_Staging_get_call_transcript`, valid under the OpenAI pattern, and `exposeAsTools` registers it under the same name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)