### PR TITLE
feat(computer-use): real execution via a computer-use node

### DIFF
--- a/bin/openagi.js
+++ b/bin/openagi.js
@@ -212,6 +212,20 @@ async function cmdImessageServer(flags) {
   await new Promise(() => {}); // run until killed
 }
 
+async function cmdComputerServer(flags) {
+  const { createComputerServer } = await import("../src/integrations/computer-server.js");
+  const token = flags.token ?? process.env.OPENAGI_COMPUTER_NODE_TOKEN ?? null;
+  if (!token) { console.error(c(RED, "a token is required — pass --token <secret> (the main uses the same as OPENAGI_COMPUTER_NODE_TOKEN)")); return 1; }
+  const port = Number(flags.port ?? process.env.OPENAGI_COMPUTER_NODE_PORT ?? 43299);
+  const host = flags.host ?? "0.0.0.0";
+  const server = createComputerServer({ token });
+  await new Promise((resolve) => server.listen(port, host, resolve));
+  console.log(c(GREEN, `computer-use node service on http://${host}:${port}`));
+  console.log(c(DIM, `On the main, set OPENAGI_COMPUTER_NODE=http://<this-host>:${port} and OPENAGI_COMPUTER_NODE_TOKEN=<the token>, then restart — the computer_* tools execute here.`));
+  console.log(c(DIM, "Requires: a display (or virtual display), Screen Recording (capture) + Accessibility (input) for this process, and `cliclick` installed. Ctrl-C to stop."));
+  await new Promise(() => {}); // run until killed
+}
+
 async function cmdImessageSearch(positional, flags) {
   const { searchMessages } = await import("../src/integrations/imessage-bridge.js");
   const query = positional.join(" ").trim();
@@ -346,6 +360,8 @@ ${c(BOLD, "Turn this device into a node of a remote main:")}
                                          [--from h] [--days N] [--limit N]
   openagi imessage-server --token T      (macOS) serve iMessage search to a
                                          remote main (gives it search_imessages)
+  openagi computer-server --token T      (macOS) serve screen capture + input to
+                                         a remote main (powers the computer_* tools)
 
 ${c(BOLD, "Global flags:")} --remote <url>  --token <token>  --json
 
@@ -370,6 +386,7 @@ async function main() {
       case "imessage-bridge": return await cmdImessageBridge(flags);
       case "imessage-search": return await cmdImessageSearch(positional, flags);
       case "imessage-server": return await cmdImessageServer(flags);
+      case "computer-server": return await cmdComputerServer(flags);
       case "tick": return await cmdTick(flags);
       case "models": return await cmdModels(flags);
       default:

--- a/src/integrations/computer-server.js
+++ b/src/integrations/computer-server.js
@@ -1,0 +1,121 @@
+import http from "node:http";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const execFileAsync = promisify(execFile);
+
+// Computer-use node service — runs on a Mac with a display (or a virtual
+// display) and exposes screen capture + input synthesis over the network so a
+// remote OpenAGI "main" can actually drive it. Bearer-token gated; the main
+// reaches it through the computer_* tools when OPENAGI_COMPUTER_NODE is set.
+//
+//   GET  /health                         -> { ok, service: "computer" }
+//   POST /screenshot {}                  -> { format, base64, width, height, bytes }
+//   POST /click  { x, y, button? }       -> { ok: true }
+//   POST /move   { x, y }                -> { ok: true }
+//   POST /type   { text }                -> { ok: true }
+//   POST /key    { chord }               -> { ok: true }   ("cmd+a", "enter", …)
+//   POST /scroll { x, y, deltaX, deltaY }-> 501 (not supported via cliclick)
+//
+// Real execution: `screencapture` for the image, `cliclick` for input. The
+// node process needs macOS Screen Recording (capture) + Accessibility (input)
+// permissions — failures surface as explicit errors, never fake success.
+
+export function createComputerServer({ token, run = execFileAsync, screenshot = defaultScreenshot } = {}) {
+  return http.createServer((req, res) => {
+    const send = (code, body) => {
+      res.writeHead(code, { "content-type": "application/json" });
+      res.end(JSON.stringify(body));
+    };
+    const url = new URL(req.url, "http://x");
+    if (url.pathname !== "/health") {
+      const auth = req.headers.authorization ?? "";
+      const presented = auth.startsWith("Bearer ") ? auth.slice(7) : "";
+      if (!token || presented !== token) return send(401, { error: "unauthorized" });
+    }
+    if (req.method === "GET" && url.pathname === "/health") return send(200, { ok: true, service: "computer" });
+    if (req.method !== "POST") return send(404, { error: "not found" });
+
+    let raw = "";
+    req.on("data", (c) => { raw += c; if (raw.length > 2e6) req.destroy(); });
+    req.on("end", async () => {
+      let body = {};
+      try { body = raw ? JSON.parse(raw) : {}; } catch { return send(400, { error: "bad json" }); }
+      try {
+        switch (url.pathname) {
+          case "/screenshot": return send(200, await screenshot(run));
+          case "/click": {
+            const prefix = body.button === "right" ? "rc" : body.button === "middle" ? "tc" : "c";
+            await run("cliclick", [`${prefix}:${int(body.x)},${int(body.y)}`]);
+            return send(200, { ok: true });
+          }
+          case "/move": await run("cliclick", [`m:${int(body.x)},${int(body.y)}`]); return send(200, { ok: true });
+          case "/type": await run("cliclick", ["-w", "20", `t:${String(body.text ?? "")}`]); return send(200, { ok: true });
+          case "/key": await run("cliclick", keyArgsForChord(body.chord)); return send(200, { ok: true });
+          case "/scroll": return send(501, { error: "scroll is not supported on this node (cliclick has no scroll primitive)" });
+          default: return send(404, { error: "not found" });
+        }
+      } catch (error) {
+        return send(500, { error: mapError(error) });
+      }
+    });
+  });
+}
+
+async function defaultScreenshot(run) {
+  const file = path.join(os.tmpdir(), `openagi-cu-${process.pid}-${Math.floor(process.hrtime()[1])}.png`);
+  try {
+    await run("screencapture", ["-x", "-t", "png", file]);
+    const buf = fs.readFileSync(file);
+    const dims = pngDims(buf);
+    return { format: "png", base64: buf.toString("base64"), width: dims.w, height: dims.h, bytes: buf.length };
+  } finally {
+    try { fs.unlinkSync(file); } catch { /* ignore */ }
+  }
+}
+
+// Parse width/height from a PNG IHDR chunk (bytes 16/20, big-endian).
+function pngDims(buf) {
+  if (buf.length >= 24 && buf.toString("ascii", 12, 16) === "IHDR") {
+    return { w: buf.readUInt32BE(16), h: buf.readUInt32BE(20) };
+  }
+  return { w: null, h: null };
+}
+
+// "cmd+shift+t" / "enter" / "a" -> cliclick argv. Modifiers held around the key;
+// named keys use kp:, single printable chars use t:.
+export function keyArgsForChord(chord) {
+  const parts = String(chord ?? "").toLowerCase().split("+").map((s) => s.trim()).filter(Boolean);
+  const MOD = { cmd: "cmd", command: "cmd", ctrl: "ctrl", control: "ctrl", alt: "alt", opt: "alt", option: "alt", shift: "shift", fn: "fn" };
+  const NAMED = {
+    enter: "return", return: "return", esc: "esc", escape: "esc", tab: "tab", space: "space",
+    delete: "delete", backspace: "delete", up: "arrow-up", down: "arrow-down", left: "arrow-left",
+    right: "arrow-right", home: "home", end: "end", pageup: "page-up", pagedown: "page-down"
+  };
+  const mods = [];
+  let key = null;
+  for (const p of parts) {
+    if (MOD[p]) mods.push(MOD[p]);
+    else key = p;
+  }
+  const args = [];
+  if (mods.length) args.push(`kd:${[...new Set(mods)].join(",")}`);
+  if (key) args.push(NAMED[key] ? `kp:${NAMED[key]}` : `t:${key}`);
+  if (mods.length) args.push(`ku:${[...new Set(mods)].join(",")}`);
+  return args;
+}
+
+function int(v) { return Math.round(Number(v)) || 0; }
+
+function mapError(error) {
+  const msg = error?.stderr || error?.message || String(error);
+  if (/ENOENT/.test(msg) && /cliclick/.test(msg)) return "cliclick is not installed on the node (brew install cliclick)";
+  if (/could not create image from display/i.test(msg)) return "no display to capture — attach a display (or virtual display) on the node";
+  if (/not authorized|accessibility|not permitted|operation not permitted/i.test(msg)) {
+    return "permission denied — grant Screen Recording (capture) and Accessibility (input) to the node process in System Settings";
+  }
+  return msg;
+}

--- a/src/integrations/computer-use.js
+++ b/src/integrations/computer-use.js
@@ -56,6 +56,26 @@ export function isComputerUseEnabled() {
   return v === "1" || v === "true" || v === "yes";
 }
 
+/// A configured computer-use node (a Mac running `openagi computer-server`)
+/// turns the stub into real execution: screenshots + input synthesis run on
+/// that node. Without it, input is logged and refused (no fake success).
+function computerNode() {
+  const url = (process.env.OPENAGI_COMPUTER_NODE ?? "").replace(/\/$/, "");
+  if (!url) return null;
+  return { url, token: process.env.OPENAGI_COMPUTER_NODE_TOKEN ?? null };
+}
+
+async function callNode(node, path, body, fetchImpl) {
+  const res = await fetchImpl(`${node.url}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...(node.token ? { authorization: `Bearer ${node.token}` } : {}) },
+    body: JSON.stringify(body ?? {})
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(json.error || `computer node HTTP ${res.status}`);
+  return json;
+}
+
 /// Remove all computer-use tools from the registry. Caller is expected
 /// to also close any active session so the agent doesn't leave a dangling
 /// reference. Returns the number of tools actually unregistered.
@@ -70,7 +90,7 @@ export function unregisterComputerUseTools(registry) {
   return count;
 }
 
-export function registerComputerUseTools(registry, runtime) {
+export function registerComputerUseTools(registry, runtime, { fetchImpl = globalThis.fetch } = {}) {
   if (!runtime.computerUseLog) return { registered: false, reason: "no computer-use log bound" };
 
   const requireActiveSession = () => {
@@ -139,7 +159,28 @@ export function registerComputerUseTools(registry, runtime) {
         args: {},
         reasoning: args.reasoning ?? null
       });
-      // Stub: pull recent OCR + active app from existing observation store.
+      const node = computerNode();
+      if (node) {
+        try {
+          const shot = await callNode(node, "/screenshot", {}, fetchImpl);
+          runtime.computerUseLog.markActionResult(action.id, {
+            status: "executed",
+            result: { width: shot.width, height: shot.height, bytes: shot.bytes }
+          });
+          return {
+            actionId: action.id,
+            image: shot.base64,
+            format: shot.format ?? "png",
+            width: shot.width,
+            height: shot.height,
+            note: "Live screenshot from the computer-use node."
+          };
+        } catch (error) {
+          runtime.computerUseLog.markActionResult(action.id, { status: "error", result: { error: error.message } });
+          throw new Error(`computer-use node screenshot failed: ${error.message}`);
+        }
+      }
+      // No node: fall back to OCR readback from the observation store.
       const snippets = await (runtime.observations?.search?.({ limit: 3 }) ?? Promise.resolve([]));
       const text = snippets.map((s) => s.text ?? "").filter(Boolean).join("\n").slice(0, 1200);
       const app = snippets[0]?.app ?? "(unknown)";
@@ -151,19 +192,19 @@ export function registerComputerUseTools(registry, runtime) {
         actionId: action.id,
         app,
         ocrSample: text || "(no recent OCR — capture may not be running)",
-        note: "Real OCR readback. Raw screenshot image bytes are not available in this build (ships with the Mac app)."
+        note: "OCR readback only — no computer-use node configured, so no raw screenshot. Set OPENAGI_COMPUTER_NODE for live capture."
       };
     }
   });
 
-  // Helper to register an input-synthesis action tool. Production honesty:
-  // the intent + reasoning are recorded to the audit log, the action is
-  // marked "unavailable", and then the handler THROWS so the agent receives
-  // an explicit failure instead of a fabricated success. No silent stub.
-  function registerUnavailableAction(name, description, paramShape) {
+  // Helper to register an input-synthesis action tool. When a computer-use
+  // node is configured the action executes ON that node (real input); without
+  // one, the intent + reasoning are logged and the handler THROWS so the agent
+  // gets an explicit failure instead of a fabricated success. No silent stub.
+  function registerAction(name, nodePath, description, paramShape, payloadOf) {
     registry.register({
       name,
-      description: description + " NOTE: not executable in this build — the call is logged and then refused.",
+      description: description + " Executes on the connected computer-use node; without one (OPENAGI_COMPUTER_NODE unset) the call is logged and refused.",
       parameters: {
         type: "object",
         properties: {
@@ -181,36 +222,47 @@ export function registerComputerUseTools(registry, runtime) {
           args: actionArgs,
           reasoning: reasoning ?? null
         });
-        runtime.computerUseLog.markActionResult(action.id, {
-          status: "unavailable",
-          result: { reason: "input synthesis not available in this build" }
-        });
-        throw new Error(EXECUTION_UNAVAILABLE);
+        const node = computerNode();
+        if (!node) {
+          runtime.computerUseLog.markActionResult(action.id, {
+            status: "unavailable",
+            result: { reason: "no computer-use node configured" }
+          });
+          throw new Error(EXECUTION_UNAVAILABLE);
+        }
+        try {
+          await callNode(node, nodePath, payloadOf(actionArgs), fetchImpl);
+          runtime.computerUseLog.markActionResult(action.id, { status: "executed", result: { via: "node" } });
+          return { actionId: action.id, ok: true };
+        } catch (error) {
+          runtime.computerUseLog.markActionResult(action.id, { status: "error", result: { error: error.message } });
+          throw new Error(`computer-use node ${name} failed: ${error.message}`);
+        }
       }
     });
   }
 
-  registerUnavailableAction("computer_click", "Click at (x, y) coordinates on the user's screen. Coordinates are screen-space pixels with (0,0) at top-left.", {
+  registerAction("computer_click", "/click", "Click at (x, y) coordinates on the screen. Coordinates are screen-space pixels with (0,0) at top-left.", {
     x: { type: "integer", description: "Screen x (pixels)." },
     y: { type: "integer", description: "Screen y (pixels)." },
     button: { type: "string", enum: ["left", "right", "middle"], description: "Default left." }
-  });
-  registerUnavailableAction("computer_type", "Type a string into the focused app.", {
+  }, (a) => ({ x: a.x, y: a.y, button: a.button ?? "left" }));
+  registerAction("computer_type", "/type", "Type a string into the focused app.", {
     text: { type: "string", description: "Text to type. Use computer_key for non-printable keys." }
-  });
-  registerUnavailableAction("computer_key", "Press a key chord. Examples: 'cmd+a', 'enter', 'esc', 'cmd+shift+t'.", {
+  }, (a) => ({ text: a.text ?? "" }));
+  registerAction("computer_key", "/key", "Press a key chord. Examples: 'cmd+a', 'enter', 'esc', 'cmd+shift+t'.", {
     chord: { type: "string", description: "Key chord, plus-separated. Modifiers: cmd, shift, alt, ctrl. Then the key name." }
-  });
-  registerUnavailableAction("computer_scroll", "Scroll at (x, y).", {
+  }, (a) => ({ chord: a.chord }));
+  registerAction("computer_scroll", "/scroll", "Scroll at (x, y).", {
     x: { type: "integer" },
     y: { type: "integer" },
     deltaX: { type: "integer", description: "Horizontal scroll delta in lines." },
     deltaY: { type: "integer", description: "Vertical scroll delta in lines. Negative = down." }
-  });
-  registerUnavailableAction("computer_move", "Move the mouse to (x, y) without clicking.", {
+  }, (a) => ({ x: a.x, y: a.y, deltaX: a.deltaX, deltaY: a.deltaY }));
+  registerAction("computer_move", "/move", "Move the mouse to (x, y) without clicking.", {
     x: { type: "integer" },
     y: { type: "integer" }
-  });
+  }, (a) => ({ x: a.x, y: a.y }));
 
-  return { registered: true };
+  return { registered: true, node: Boolean(computerNode()) };
 }

--- a/test/computer-server.test.js
+++ b/test/computer-server.test.js
@@ -1,0 +1,73 @@
+// Computer-use node service: auth, screenshot, and input synthesis dispatch to
+// cliclick/screencapture. Uses an injected `run` so no real input is sent.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createComputerServer, keyArgsForChord } from "../src/integrations/computer-server.js";
+
+function start(opts) {
+  const server = createComputerServer(opts);
+  return new Promise((resolve) => server.listen(0, "127.0.0.1", () => {
+    const { port } = server.address();
+    resolve({ server, base: `http://127.0.0.1:${port}` });
+  }));
+}
+
+const post = (base, path, body, token = "secret") =>
+  fetch(`${base}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...(token ? { authorization: `Bearer ${token}` } : {}) },
+    body: JSON.stringify(body ?? {})
+  });
+
+test("rejects requests without the bearer token", async () => {
+  const { server, base } = await start({ token: "secret", run: async () => {} });
+  try {
+    const res = await post(base, "/click", { x: 1, y: 2 }, null);
+    assert.equal(res.status, 401);
+  } finally { server.close(); }
+});
+
+test("/click maps button to the right cliclick verb", async () => {
+  const calls = [];
+  const { server, base } = await start({ token: "secret", run: async (cmd, args) => { calls.push([cmd, args]); } });
+  try {
+    await post(base, "/click", { x: 10, y: 20 });
+    await post(base, "/click", { x: 30, y: 40, button: "right" });
+    assert.deepEqual(calls[0], ["cliclick", ["c:10,20"]]);
+    assert.deepEqual(calls[1], ["cliclick", ["rc:30,40"]]);
+  } finally { server.close(); }
+});
+
+test("/type and /key dispatch to cliclick; /screenshot returns the captured image", async () => {
+  const calls = [];
+  const { server, base } = await start({
+    token: "secret",
+    run: async (cmd, args) => { calls.push([cmd, args]); },
+    screenshot: async () => ({ format: "png", base64: "AAAA", width: 1920, height: 1080, bytes: 3 })
+  });
+  try {
+    await post(base, "/type", { text: "hello world" });
+    assert.deepEqual(calls.at(-1), ["cliclick", ["-w", "20", "t:hello world"]]);
+
+    await post(base, "/key", { chord: "cmd+a" });
+    assert.deepEqual(calls.at(-1), ["cliclick", ["kd:cmd", "t:a", "ku:cmd"]]);
+
+    const shot = await (await post(base, "/screenshot", {})).json();
+    assert.equal(shot.width, 1920);
+    assert.equal(shot.base64, "AAAA");
+  } finally { server.close(); }
+});
+
+test("/scroll is honestly reported as unsupported (501), not faked", async () => {
+  const { server, base } = await start({ token: "secret", run: async () => {} });
+  try {
+    const res = await post(base, "/scroll", { x: 1, y: 1, deltaY: -3 });
+    assert.equal(res.status, 501);
+  } finally { server.close(); }
+});
+
+test("keyArgsForChord handles named keys and multi-modifier chords", () => {
+  assert.deepEqual(keyArgsForChord("enter"), ["kp:return"]);
+  assert.deepEqual(keyArgsForChord("cmd+shift+t"), ["kd:cmd,shift", "t:t", "ku:cmd,shift"]);
+  assert.deepEqual(keyArgsForChord("esc"), ["kp:esc"]);
+});


### PR DESCRIPTION
## Why

Computer-use was a stub — `computer_screenshot` returned only OCR text, and `click/type/key/scroll/move` logged intent then threw *"not available in this build."* So Peri couldn't actually drive a screen.

## What

A node service (same shape as the working `imessage-server`) that a Mac with a display runs; the Distiller's `computer_*` tools proxy to it.

- **`src/integrations/computer-server.js`** — `openagi computer-server --token T`. Endpoints: `/screenshot` (`screencapture -x` → base64 PNG + dims), `/click` `/move` `/type` `/key` (`cliclick`), `/scroll` → **501** (cliclick has no scroll — reported honestly, not faked). Bearer-gated; errors map to actionable messages (cliclick missing / no display / TCC denied).
- **`computer-use.js`** — when `OPENAGI_COMPUTER_NODE` (+ `_TOKEN`) is set, the tools execute on the node (real screenshots + input). Without it: unchanged (OCR readback + refuse input, no fabricated success).
- **`bin/openagi.js`** — `computer-server` command + help.

## Deploy notes (the node host)

Needs a **display (or virtual display)**, `cliclick` (`brew install cliclick`), and **Screen Recording + Accessibility** granted to the node process (macOS security — one-time GUI grant). Then on the main: `OPENAGI_COMPUTER_NODE=http://<node>:43299`, `OPENAGI_COMPUTER_NODE_TOKEN=…`, `OPENAGI_COMPUTER_USE=1`.

Tests: auth, click/type/key dispatch, screenshot passthrough, 501 scroll, chord parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)