### PR TITLE
fix(tools): cap tools advertised to the model (256 tools = OpenAI 500 on every call)

### DIFF
--- a/src/tool-registry.js
+++ b/src/tool-registry.js
@@ -56,8 +56,50 @@ export class ToolRegistry {
     return readOnly ? all.filter((tool) => !tool.sideEffects) : all;
   }
 
+  // Tools advertised to the model, bounded so the array doesn't blow past the
+  // provider's limit. A handful of large MCP servers (e.g. PostHog ~118 tools)
+  // can push the total past ~250, which makes the OpenAI Responses API reject
+  // EVERY call with a server_error. Core/internal tools are always advertised;
+  // MCP tools fill the remaining budget, whole servers at a time (smallest
+  // first, so many small integrations beat one giant one). Anything not
+  // advertised is STILL invokable via run_mcp_tool + discoverable via
+  // list_mcp_tools — no capability is lost, just the direct function affordance.
+  _modelToolList(options = {}) {
+    const all = this.list(options);
+    const max = Number(process.env.OPENAGI_MAX_MODEL_TOOLS) || 128;
+    if (all.length <= max) return all;
+    const core = all.filter((t) => t.source !== "mcp");
+    const mcp = all.filter((t) => t.source === "mcp");
+    const budget = Math.max(0, max - core.length);
+    const byServer = new Map();
+    for (const t of mcp) {
+      const s = t.metadata?.server ?? "?";
+      if (!byServer.has(s)) byServer.set(s, []);
+      byServer.get(s).push(t);
+    }
+    const servers = [...byServer.entries()].sort((a, b) => a[1].length - b[1].length);
+    const picked = [];
+    const advertised = [];
+    const overflow = [];
+    for (const [name, tools] of servers) {
+      if (picked.length + tools.length <= budget) { picked.push(...tools); advertised.push(name); }
+      else overflow.push(`${name}(${tools.length})`);
+    }
+    this._logToolCap(all.length, max, advertised, overflow);
+    return [...core, ...picked];
+  }
+
+  // Surface what got capped (once per distinct overflow set) — never silently
+  // drop tools, per the "no silent caps" rule.
+  _logToolCap(total, max, advertised, overflow) {
+    const key = overflow.join(",");
+    if (key === this._lastToolCapKey || !overflow.length) { this._lastToolCapKey = key; return; }
+    this._lastToolCapKey = key;
+    console.warn(`[tools] ${total} tools exceed model cap ${max}; advertising core + [${advertised.join(", ")}] directly. Reachable only via run_mcp_tool: [${overflow.join(", ")}]. Raise OPENAGI_MAX_MODEL_TOOLS to advertise more.`);
+  }
+
   toOpenAITools(options = {}) {
-    return this.list(options).map((tool) => ({
+    return this._modelToolList(options).map((tool) => ({
       type: "function",
       name: tool.name,
       description: tool.description,
@@ -66,7 +108,7 @@ export class ToolRegistry {
   }
 
   toAnthropicTools(options = {}) {
-    return this.list(options).map((tool) => ({
+    return this._modelToolList(options).map((tool) => ({
       name: tool.name,
       description: tool.description,
       input_schema: tool.parameters
@@ -448,7 +490,7 @@ export function registerCoreTools(registry, runtime) {
   registry.register({
     name: "list_mcp_tools",
     sideEffects: false,
-    description: "List tools exposed by connected MCP servers.",
+    description: "List tools exposed by connected MCP servers — INCLUDING ones not advertised directly as functions (large servers are capped to keep the tool list within provider limits). Use this to discover a tool, then call it with run_mcp_tool.",
     parameters: { type: "object", properties: {}, additionalProperties: false },
     handler: async () => {
       const tools = runtime.mcp?.listTools?.() ?? [];
@@ -458,7 +500,7 @@ export function registerCoreTools(registry, runtime) {
 
   registry.register({
     name: "run_mcp_tool",
-    description: "Invoke a tool on a connected MCP server.",
+    description: "Invoke a tool on a connected MCP server. Use this for any MCP tool that isn't available as a direct function (large servers like PostHog are reached this way). Call list_mcp_tools first if unsure of the exact server/tool name.",
     parameters: {
       type: "object",
       properties: {

--- a/test/tool-registry-cap.test.js
+++ b/test/tool-registry-cap.test.js
@@ -1,0 +1,38 @@
+// The model tool list is bounded so a few large MCP servers can't push the
+// array past the provider's limit (which makes OpenAI reject EVERY call).
+// Core tools are always advertised; MCP servers fill the rest, smallest first;
+// overflow stays reachable via run_mcp_tool.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { ToolRegistry } from "../src/tool-registry.js";
+
+function regCore(reg, n) {
+  for (let i = 0; i < n; i++) reg.register({ name: `core_${i}`, handler: async () => ({}) });
+}
+function regMcp(reg, server, n) {
+  for (let i = 0; i < n; i++) reg.register({ name: `mcp_${server}_${i}`, source: "mcp", metadata: { server }, handler: async () => ({}) });
+}
+
+test("under the cap, every tool is advertised", () => {
+  process.env.OPENAGI_MAX_MODEL_TOOLS = "128";
+  const reg = new ToolRegistry();
+  regCore(reg, 20);
+  regMcp(reg, "airtable", 16);
+  assert.equal(reg.toOpenAITools().length, 36);
+});
+
+test("over the cap: core always kept, small MCP servers win, giant ones overflow", () => {
+  process.env.OPENAGI_MAX_MODEL_TOOLS = "100";
+  const reg = new ToolRegistry();
+  regCore(reg, 50);
+  regMcp(reg, "airtable", 16);
+  regMcp(reg, "linear", 46);
+  regMcp(reg, "posthog", 118);
+  const names = reg.toOpenAITools().map((t) => t.name);
+  // budget = 100 - 50 core = 50 → airtable(16) fits; linear(46) would be 62 > 50; posthog never.
+  assert.ok(names.length <= 100, `advertised ${names.length} must be <= cap`);
+  assert.ok(names.filter((n) => n.startsWith("core_")).length === 50, "all core tools kept");
+  assert.ok(names.some((n) => n.startsWith("mcp_airtable_")), "small server advertised");
+  assert.ok(!names.some((n) => n.startsWith("mcp_posthog_")), "giant server overflowed");
+  delete process.env.OPENAGI_MAX_MODEL_TOOLS;
+});


### PR DESCRIPTION
## Why

With all MCPs connected the registry advertised **256** function tools (PostHog alone ≈118). The OpenAI Responses API rejects an array that large with a generic `server_error` — so **every** tool-bearing call failed (chat, autopilot, computer use), not just the big server. Verified: disconnecting PostHog (→~138) restored tool calls.

## Fix

Bound the advertised set via `OPENAGI_MAX_MODEL_TOOLS` (default **128**):
- core/internal tools always advertised
- MCP tools fill the remaining budget **whole-server at a time, smallest first** (so many small integrations beat one giant one)
- overflow servers stay fully usable via `run_mcp_tool` + discoverable via `list_mcp_tools` — no capability lost
- overflow is logged (no silent caps); the two meta-tool descriptions now point the model at capped servers

Tests cover under-cap (all advertised) and over-cap (core kept, small servers win, giant overflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)