### PR TITLE
feat(autopilot): gate on queued agent work (kills idle base-model spend)

### DIFF
--- a/src/abi-runtime.js
+++ b/src/abi-runtime.js
@@ -218,7 +218,9 @@ export class AbiRuntime {
         intervalMs: autopilotMin * 60 * 1000,
         input: {
           agentId: "main",
-          prompt: AGENT_PULSE_PROMPT
+          prompt: AGENT_PULSE_PROMPT,
+          // Only fire (spend a base-model call) when there's queued agent work.
+          requireQueuedWork: true
         }
       });
       this.cron.addJob({
@@ -887,6 +889,14 @@ export class AbiRuntime {
 
   async runAutopilot(job) {
     if (!this.agentHost) return { skipped: true, reason: "agent-host-disabled" };
+    // Cheap gate (no tokens): a queue-draining pulse must NOT spend a base-model
+    // call when there's nothing committed to do. Jobs opt in via
+    // input.requireQueuedWork; scheduled review prompts (weekly-harsh-review)
+    // leave it off and run unconditionally. This is the "react only to new work"
+    // rule — the agent wakes only when agentPickNext has a real task.
+    if (job.input?.requireQueuedWork && !this.tasks?.agentPickNext?.()) {
+      return { skipped: true, reason: "no queued agent work" };
+    }
     try {
       this.budget.check();
     } catch (error) {

--- a/test/autopilot-gate.test.js
+++ b/test/autopilot-gate.test.js
@@ -1,0 +1,39 @@
+// Autopilot must not spend a base-model call when there's no committed agent
+// work. The queue-draining pulse opts in via input.requireQueuedWork; scheduled
+// review prompts leave it off and run unconditionally.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { AbiRuntime } from "../src/abi-runtime.js";
+
+const runAutopilot = AbiRuntime.prototype.runAutopilot;
+
+function ctx({ next }) {
+  const state = { called: false };
+  const self = {
+    agentHost: { handleMessage: async () => { state.called = true; return { reply: "worked" }; } },
+    budget: { check() {} },
+    tasks: { agentPickNext: () => next }
+  };
+  return { self, state };
+}
+
+test("gated pulse skips with NO model call when the agent queue is empty", async () => {
+  const { self, state } = ctx({ next: null });
+  const r = await runAutopilot.call(self, { id: "agent-pulse", input: { requireQueuedWork: true, prompt: "x" } });
+  assert.equal(r.skipped, true);
+  assert.equal(r.reason, "no queued agent work");
+  assert.equal(state.called, false, "model must NOT be invoked on an empty queue");
+});
+
+test("gated pulse runs when there IS queued agent work", async () => {
+  const { self, state } = ctx({ next: { id: "task_1", title: "do the thing" } });
+  const r = await runAutopilot.call(self, { id: "agent-pulse", input: { requireQueuedWork: true, prompt: "x" } });
+  assert.equal(state.called, true);
+  assert.equal(r.autopilot, true);
+});
+
+test("un-gated autopilot (scheduled review) runs unconditionally", async () => {
+  const { self, state } = ctx({ next: null });
+  await runAutopilot.call(self, { id: "weekly-harsh-review", input: { prompt: "review" } });
+  assert.equal(state.called, true, "review prompt without requireQueuedWork still runs");
+});


### PR DESCRIPTION
## Why

`agent-pulse` called the **base model every 30 min** whether or not anything was queued — ~48 calls/day just to say "standing by." The ledger showed this was the bulk of idle spend (autopilot **$26/day** vs observer **$0.04**, because the observer already skips when screen activity is idle).

## Fix

A cheap, deterministic gate. `agent-pulse` opts in via `input.requireQueuedWork`; `runAutopilot` skips with **zero tokens** when `tasks.agentPickNext()` is empty. Scheduled review prompts (`weekly-harsh-review`) leave the flag off and run unconditionally.

Autopilot becomes event-driven — it wakes only when there's real committed work (queued by imessage-extract, task-sweep re-homing, or the agent itself). 

## Context (the rest of Camp B was already fine)
- `linear-task-sync` / `buildbetter-task-sync` — API-diff into tasks, **no LLM**.
- `imessage-extract` — returns $0 when no new messages.
- `proactive-observer` / `task-activity-scan` — already skip ("insufficient activity") when the screen is idle.

So this one gate closes the loop on "only spend tokens when there's something new."

🤖 Generated with [Claude Code](https://claude.com/claude-code)