### PR TITLE
docs(skills): bundle operational skills (nodes, iMessage, MCP, cron, computer use)

### DIFF
--- a/examples/skills/connect-mcp/SKILL.md
+++ b/examples/skills/connect-mcp/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: connect-mcp
+description: Connect an MCP server (catalog or custom URL/stdio) and make its tools usable — including completing OAuth on a headless host.
+---
+
+Connect an MCP server so its tools become available to the agent.
+
+1. Pick the registration path:
+   - Known integration → `list_mcp_catalog`, then `connect_catalog_mcp` with the catalog id.
+   - Custom server → `register_mcp_server` with one of: stdio (a `command` + `args`), http+bearer (a `url` + `apiKey`, using `${ENV_VAR}` for the secret), or http+oauth (a `url`). Then `connect_mcp_server`.
+
+2. OAuth servers: connecting surfaces an authorization URL. The OAuth callback is a loopback (`http://127.0.0.1:<port>/callback`) on the AGENT HOST. If the host is headless (no browser), a laptop browser can't reach that loopback — tell the user to tunnel it first, then approve:
+   - on the laptop: `ssh -L <port>:127.0.0.1:<port> <host>`  (the host pins the port via `OPENAGI_OAUTH_CALLBACK_PORT`)
+   - open the auth URL in the laptop browser, sign in, approve → the redirect tunnels back and the server flips to connected.
+
+3. Verify with `list_mcp_tools`. Large servers (lots of tools) may NOT be advertised as direct functions — a cap keeps the model's tool list within provider limits. Reach any capped tool with `run_mcp_tool(server, tool, args)`; `list_mcp_tools` shows them all.
+
+4. Secrets hygiene: never commit real keys. Reference them as `${ENV_VAR}` that resolves from the host's `.env`.
+
+User asked: {{input}}

--- a/examples/skills/drive-computer-use/SKILL.md
+++ b/examples/skills/drive-computer-use/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: drive-computer-use
+description: Operate a connected computer-use node to accomplish an on-screen task — screenshot, reason, act in a loop.
+---
+
+You can see and control a connected Mac via the `computer_*` tools. Accomplish the user's on-screen goal carefully and verify each step.
+
+1. Call `start_computer_use_session` with a one-sentence goal. This requires user approval. Once a session is active, DO NOT call start again — go straight to acting.
+
+2. Work the loop:
+   - `computer_screenshot` to see the current state. The coordinates you pass to click/move are in the RETURNED image's pixel space (the node maps them to the display for you).
+   - Decide the single next action and take it:
+     - `computer_key {chord}` — e.g. "cmd+space" (Spotlight), "enter", "cmd+a", "esc".
+     - `computer_type {text}` — type into the focused field.
+     - `computer_click {x,y,button}` / `computer_move {x,y}`.
+   - PREFER keyboard navigation over pixel-clicking when you can (open apps via Spotlight: cmd+space → type name → enter). Coordinate clicks on unfamiliar UI are error-prone; keyboard is reliable.
+   - Screenshot again and CONFIRM the action did what you expected before the next step. Don't chain actions blindly.
+
+3. Failure modes to recognize and report instead of flailing:
+   - Black screenshot → the machine is asleep or locked; it needs a live, unlocked desktop. Stop and tell the user.
+   - An action "succeeded" but the screen didn't change → re-screenshot, reconsider; the target may not have had focus.
+   - `scroll` is unsupported — find another way (keyboard, or click a scrollbar target).
+
+4. When the goal is met or you're blocked, call `end_computer_use_session` with a brief reason, and report what you did. Every action is logged for the user to review.
+
+User asked: {{input}}

--- a/examples/skills/schedule-recurring-check/SKILL.md
+++ b/examples/skills/schedule-recurring-check/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: schedule-recurring-check
+description: Set up a recurring check that only does work (and spends tokens) when there's something new — e.g. "every hour, check BuildBetter for new calls".
+---
+
+The user wants a recurring check. Design it as a CHEAP probe that only acts on a delta — never a blind poll that burns tokens on an empty result.
+
+1. Pin down three things:
+   - WHAT to check (which tool/source — e.g. a BuildBetter search, a Linear query, an MCP tool via `run_mcp_tool`).
+   - HOW OFTEN (a fixed interval, or a daily time).
+   - What "new" means here — the cursor that separates old from new (a since-last-run timestamp, an id you haven't seen, a count that changed).
+
+2. Create it with `schedule_message`:
+   - `prompt`: a SELF-CONTAINED instruction that, when it fires, will:
+     (a) fetch only items newer than the last check (use the cursor),
+     (b) if there is NOTHING new → reply with a single short line like "nothing new" and STOP (don't elaborate, don't call more tools),
+     (c) only if there IS something new → summarize it and/or take the action the user asked for.
+   - `intervalSeconds` (recurring every N seconds) OR `dailyAt` "HH:MM".
+   - Leave `channel`/`target` default so the result returns on the user's channel.
+
+3. Confirm back: what you scheduled, how often, and how to stop it (`list_cron_jobs` to find the id, then `cancel_cron_job`).
+
+Principle: react to deltas, not to the clock. The fired prompt must short-circuit cheaply when nothing changed — that's what keeps an idle agent at ~$0.
+
+User asked: {{input}}

--- a/examples/skills/setup-computer-use-node/SKILL.md
+++ b/examples/skills/setup-computer-use-node/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: setup-computer-use-node
+description: Guide setting up a Mac as a computer-use node so the agent can see the screen and control mouse/keyboard.
+---
+
+Walk the user through turning a Mac into a computer-use node. macOS-only; needs a display and user-granted permissions you can't grant for them. Produce copy-pasteable steps; substitute `<host>`, `<port>`, `<secret>`.
+
+1. Install `cliclick` (`brew install cliclick`) — used for input synthesis (click/type/key/move).
+2. Ensure a DISPLAY exists. A headless Mac has no framebuffer and capture fails with "could not create image from display." Options: attach an HDMI dummy plug, OR create a virtual display (e.g. BetterDisplay) — which needs a one-time GUI session (Screen Sharing).
+3. Grant permissions to the runtime's `node` binary in System Settings → Privacy & Security:
+   - **Screen Recording** (for screenshots)
+   - **Accessibility** (for mouse/keyboard via cliclick)
+   These require a GUI session to approve; on a headless box, do it once over Screen Sharing.
+4. Run `openagi computer-server --token <secret> --port <port>`. Persist via launchd, and put `/opt/homebrew/bin` on the job's PATH so cliclick is found.
+5. On the MAIN: set `OPENAGI_COMPUTER_USE=1`, `OPENAGI_COMPUTER_NODE=http://<host>:<port>`, `OPENAGI_COMPUTER_NODE_TOKEN=<secret>`, then restart. The `computer_*` tools now execute on the node.
+
+Notes to pass along:
+- Screenshots are auto-downscaled to ~`OPENAGI_COMPUTER_SCALE_WIDTH` (default 1280) and click coordinates are mapped to the display's LOGICAL points (Retina-correct) — the model works in the returned image's space.
+- `scroll` is not supported (cliclick has no scroll primitive); it returns an honest error.
+- Verify via the node's `/screenshot` HTTP endpoint (it runs in the GUI session) — NOT a plain SSH shell, which has no WindowServer access and will report "could not create image from display" even when a display exists.
+- The screen must be UNLOCKED and awake — a locked/asleep display captures black. Disable auto-lock / display sleep on a dedicated node.
+
+User asked: {{input}}

--- a/examples/skills/setup-imessage-node/SKILL.md
+++ b/examples/skills/setup-imessage-node/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: setup-imessage-node
+description: Guide setting up a Mac as an iMessage node — relays incoming texts to the main agent (trigger word) and answers iMessage searches.
+---
+
+Walk the user through turning a Mac (signed into iMessage) into an iMessage node. macOS-only, and it needs system permissions you can't grant for them — so produce clear, copy-pasteable steps and explain each grant. Substitute `<host>`, `<port>`, `<secret>`, `<TriggerWord>` for their values; never hardcode real numbers/tokens.
+
+Two processes (run from the openAGI repo on that Mac):
+- `openagi imessage-bridge --respond trigger --trigger <TriggerWord> --allow <handle,handle> --allow-chat <chatId> --capture all`
+  Reads `~/Library/Messages/chat.db` read-only, relays messages containing the trigger to the main, and replies via Messages. Omit `--allow*` to respond to everyone; `--allow-chat` opts a group thread in.
+- `openagi imessage-server --token <secret> --port <port>` (optional)
+  Serves iMessage SEARCH to the main, giving it a `search_imessages` tool.
+
+Steps to give the user:
+1. Clone/run the openAGI repo on the Mac.
+2. System Settings → Privacy & Security: grant the runtime that launches these (the `node` binary; Terminal while testing) **Full Disk Access** (read chat.db) and **Automation → Messages** (send replies).
+3. Run the bridge (and optionally the search server). For persistence install a launchd USER agent (`RunAtLoad` + `KeepAlive`) that runs the command; restart it with `launchctl kickstart -k gui/$(id -u)/<label>`.
+4. On the MAIN agent host, point at the node: `OPENAGI_IMESSAGE_NODE=http://<host>:<port>` and `OPENAGI_IMESSAGE_NODE_TOKEN=<secret>`, then restart.
+
+Gotchas to mention:
+- chat.db MUST be opened read-only — a read-write connection on the live WAL database can hang/crash Messages.
+- On recent macOS the message text often lives only in `attributedBody` (the `text` column is NULL); the bridge decodes that typedstream blob.
+- A process launched by launchd needs its OWN TCC grant — granting Terminal is not enough; the launchd-spawned `node` must be approved separately.
+- Track messages by date, not ROWID (a chat.db rebuild renumbers ROWIDs non-chronologically).
+
+User asked: {{input}}


### PR DESCRIPTION
Turns the recurring setup/operation knowledge from building this out into **reusable skills** the agent reads and executes (each becomes a `skill_<name>` tool):

- **schedule-recurring-check** — a cron check that only spends tokens on a delta (react to new, not the clock)
- **connect-mcp** — register/connect an MCP, headless OAuth via `ssh -L` tunnel, reaching capped tools via `run_mcp_tool`
- **setup-imessage-node** — Mac iMessage bridge + search server (TCC, launchd, read-only chat.db, attributedBody decode)
- **setup-computer-use-node** — Mac computer-server (cliclick, virtual display, Screen Recording + Accessibility)
- **drive-computer-use** — the screenshot→reason→act loop, keyboard-first grounding, failure modes

All **generic** — placeholders for hosts/tokens, nothing environment-specific. Verified they load (8 skills total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)