### PR TITLE
docs(skills): operational runbooks (deploy nodes, diagnose iMessage + tool errors)

### DIFF
--- a/examples/skills/deploy-update-node/SKILL.md
+++ b/examples/skills/deploy-update-node/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: deploy-update-node
+description: Roll out new openAGI code to the main and to Mac nodes (iMessage / computer-use), and restart them safely.
+---
+
+Roll out updated code. Critical fact: the MAIN self-updates its own git checkout, but each NODE runs off its OWN separate checkout and does NOT receive the main's update — every node must pull and restart itself.
+
+Main agent host:
+1. Trigger a self-update (fast-forwards `main` and restarts the daemon). After it comes back, confirm the new commit is live before assuming the fix is deployed.
+
+Each Mac node (iMessage bridge, iMessage search server, computer-server):
+1. In that node's repo: `git pull origin main`.
+2. Restart the node's service:
+   - launchd: `launchctl kickstart -k gui/$(id -u)/<label>` (e.g. `app.openagi.imessage-bridge`, `app.openagi.computer-server`).
+   - run by hand: stop it and re-run the same `openagi <subcommand>` line.
+3. Confirm: the process restarted (new pid) and the capability still works — the node's `/health`, a test `search_imessages`, or a test `/screenshot`.
+
+Guidance for the user (you usually can't SSH their nodes):
+- Give the exact `git pull` + restart commands for each affected node.
+- Emphasize: a fix to node-side code (imessage-bridge, computer-server) only takes effect after THAT node pulls + restarts — updating the main is not enough.
+- Never restart something you didn't start without telling the user first.
+
+User asked: {{input}}

--- a/examples/skills/diagnose-agent-tool-errors/SKILL.md
+++ b/examples/skills/diagnose-agent-tool-errors/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: diagnose-agent-tool-errors
+description: Troubleshoot opaque model/tool failures and runaway budget — and their usual root causes.
+---
+
+Diagnose in this order; report the root cause and the concrete fix.
+
+1. Opaque "An error occurred while processing your request" (server_error) on tool-bearing calls, while plain replies (no tools) still work:
+   - Almost always TOO MANY TOOLS. Each connected MCP server adds its tools to the array the model receives; one big server (100+ tools) can push the total past the provider's limit, which then rejects EVERY tool call — not just that server's.
+   - Fix: a cap (`OPENAGI_MAX_MODEL_TOOLS`, default 128) advertises core tools + a budget of MCP tools and routes the rest through `run_mcp_tool`. Confirm the cap is in effect (look for the "[tools] N tools exceed model cap" log), lower it, or disconnect a giant server.
+
+2. "Invalid 'tools[N].name' ... does not match pattern" error:
+   - An MCP server NAME (or a tool name) contains a space or punctuation, producing an invalid `mcp_<server>_<tool>` function name. Rename the server to letters/digits/_/- only.
+
+3. Budget draining unexpectedly fast, especially while idle:
+   - Look for a MISPRICED model — a cheap nano/mini billed at flagship rates because a too-broad price-table prefix matched first. Verify the price table lists the exact model variant.
+   - Look for an UNGATED periodic job calling a big model every cycle regardless of new work (the autopilot pulse should skip when its agent queue is empty; API-diff syncs should spend $0 when nothing's new).
+
+To inspect: use the structural health snapshot, the budget + ledger, and `list_cron_jobs`.
+
+User asked: {{input}}

--- a/examples/skills/diagnose-no-imessage-replies/SKILL.md
+++ b/examples/skills/diagnose-no-imessage-replies/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: diagnose-no-imessage-replies
+description: Troubleshoot why the agent stopped replying to iMessages, in priority order.
+---
+
+Work through these in order and stop at the cause. Report the cause and the specific fix.
+
+1. Budget cap. Check the daily budget. When the cap is hit the agent goes SILENT with no error (texts just stop). Raise the limit or wait for reset.
+
+2. Bridge alive + ingesting. Is the iMessage node still feeding messages in? Look for recent inbound items (source "import", tagged `imessage`) via recall/memory. If the newest is hours/days old, the bridge process on the node is down — have the user restart it (`launchctl kickstart -k …`) and confirm Messages.app is running and signed into iMessage.
+
+3. Text decoding. Are recent captured messages real text, or a replacement char (`�`)? If they decode to `�`, the attributedBody decoder is failing on that node's macOS, so the trigger word never matches. Update + restart that node's bridge.
+
+4. Trigger + allowlist. A reply requires the trigger word (whole-word match) from an allowed sender or chat (unless the bridge runs with `--respond all`). Confirm the message actually contained the trigger and the sender/chat is on the allowlist.
+
+5. Node asleep. A sleeping Mac stalls Messages sync and `osascript` sends. IMPORTANT: silent mode / Do Not Disturb does NOT affect the bridge — it reads chat.db and sends via Messages regardless of notification settings. Only the machine SLEEPING breaks it; keep the node awake.
+
+Most of these require the user to act on the node itself (you usually can't SSH it) — give them the exact step.
+
+User asked: {{input}}


### PR DESCRIPTION
Three more reusable runbook skills distilled from this session:

- **deploy-update-node** — the main self-updates, but nodes run their **own** checkout and must `git pull` + `launchctl kickstart` separately
- **diagnose-no-imessage-replies** — priority order: budget cap (silent) → bridge down → `�` decode failure → trigger/allowlist → node asleep (DND is irrelevant)
- **diagnose-agent-tool-errors** — opaque OpenAI `server_error` = too many tools (cap / `run_mcp_tool`); `Invalid tools[N].name` = spaced MCP name; fast idle spend = mispriced model or an ungated job

Generic, no env-specific values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)