### PR TITLE
fix(mac): release build fails to compile on newer runner toolchain (breaks Sparkle updates)

### DIFF
--- a/mac/Sources/OpenAGI/Capture/ActivityTracker.swift
+++ b/mac/Sources/OpenAGI/Capture/ActivityTracker.swift
@@ -23,7 +23,8 @@ final class ActivityTracker {
       Task { @MainActor in self.handleAppFocus(bundleId: app?.bundleIdentifier, name: app?.localizedName) }
     }
     pollTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
-      Task { @MainActor in self?.pollFrontmostWindow() }
+      guard let self else { return }
+      Task { @MainActor in self.pollFrontmostWindow() }
     }
     pollFrontmostWindow()
   }

--- a/mac/Sources/OpenAGI/Capture/CaptureController.swift
+++ b/mac/Sources/OpenAGI/Capture/CaptureController.swift
@@ -15,7 +15,8 @@ final class CaptureController {
   func start() {
     apply()
     retentionTimer = Timer.scheduledTimer(withTimeInterval: 6 * 3600, repeats: true) { [weak self] _ in
-      Task { @MainActor in self?.runRetention() }
+      guard let self else { return }
+      Task { @MainActor in self.runRetention() }
     }
     runRetention()
   }


### PR DESCRIPTION
## Why

Users on **0.0.5** hit **"Update Error! An error occurred in retrieving update information"** when checking for updates.

Root cause chain:
1. App's Sparkle feed is `…/releases/latest/download/appcast.xml`; `latest` now points to **v0.0.6**.
2. The **v0.0.6 release is empty** — no `.dmg`, no `appcast.xml` — so Sparkle 302→404s on the missing appcast.
3. v0.0.6 is empty because its **release-mac CI build failed to compile** (run `27456787443`, died at the build step in 28s).
4. The compile failure:
   ```
   ActivityTracker.swift:26: error: reference to captured var 'self' in concurrently-executing code
   CaptureController.swift:18: error: reference to captured var 'self' in concurrently-executing code
   ```

This is **toolchain drift**, not a code regression: the two files are byte-identical between v0.0.6 and main, `Package.swift` is unchanged (`swift-tools-version: 5.9`), and v0.0.5 built fine on 2026-05-10. Between then and the v0.0.6 build (2026-06-13), GitHub's `macos-14` runner bumped its Xcode/Swift toolchain, and the newer compiler now treats `reference to captured var 'self'` in those `Task { @MainActor in self?… }` timer closures as a hard error.

## Fix

Both `Timer` closures referenced the weakly-captured `self` directly inside a concurrent `Task`. The sibling `addObserver` closure in `ActivityTracker` already does the right thing — `guard let self` before the `Task` — and did **not** error in the failing CI build. This PR mirrors that proven pattern in both timer closures.

## Verification

- `swift build` in `mac/` → **Build complete**, both files compile.
- Caveat: local toolchain (Swift 6.3.2) is newer than the CI runner's and doesn't reproduce the exact diagnostic, so the definitive proof is a green `release-mac` run. The fix is structurally identical to the closure the strict compiler already accepted.

## Follow-ups (after merge)
- Cut **v0.0.7** from main → CI builds + uploads `.dmg` + `appcast.xml` → restores Sparkle updates for 0.0.5 users. **This is the real verification.**
- Clean up the empty **v0.0.6** release/tag (currently GitHub's "Latest" with no assets).
- Optional: pin the Xcode/toolchain in `release-mac.yml` so a future runner bump can't silently break releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)