### PR TITLE
fix(daemon): MCP connect failures must not crash the daemon

### DIFF
--- a/src/boot.js
+++ b/src/boot.js
@@ -40,11 +40,38 @@ export function loadBootEnv() {
   return dataDir;
 }
 
+// A misconfigured, unreachable, or reauth-needed MCP server rejects
+// asynchronously during connect — a 401 (expired/invalid token), an OAuth
+// callback timeout, a DNS failure. Those are recoverable: the server just needs
+// to be reconnected or re-authed, and it already records its own lastError +
+// surfaces "needs auth" via status/SSE. But Node 15+ TERMINATES the process on
+// any unhandled rejection, so without a top-level guard one stray MCP error
+// takes down the whole agent — and the supervisor restarts it straight into the
+// same failure (a crash loop). Log and keep running instead. Installed once,
+// before the runtime/MCP connects, so it covers every daemon launch (the CLI,
+// this example, systemd, the Mac DaemonController) identically.
+let crashGuardsInstalled = false;
+export function installCrashGuards() {
+  if (crashGuardsInstalled) return;
+  crashGuardsInstalled = true;
+  process.on("unhandledRejection", (reason) => {
+    const err = reason instanceof Error ? reason : new Error(String(reason));
+    console.error(`[openagi] unhandled rejection (kept alive): ${err.stack || err.message}`);
+  });
+  // An uncaught synchronous exception can leave state undefined, but for a
+  // supervised, always-on daemon staying up beats crash-looping; the error is
+  // logged loudly so it's still diagnosable in daemon.log / journald.
+  process.on("uncaughtException", (err) => {
+    console.error(`[openagi] uncaught exception (kept alive): ${err?.stack || err}`);
+  });
+}
+
 // Boot env + start the hosted interface. Returns the listen address.
 // host/port fall back to HOST/PORT env then sane defaults; callers (the CLI)
 // can override. Binding to 0.0.0.0 is safe because the HTTP interface enforces
 // the bearer token — but we warn so it's a deliberate choice.
 export async function startServer({ host, port } = {}) {
+  installCrashGuards();
   const dataDir = loadBootEnv();
   const resolvedHost = host ?? process.env.HOST ?? "127.0.0.1";
   const resolvedPort = Number.parseInt(String(port ?? process.env.PORT ?? "43210"), 10);

--- a/test/boot-crash-guards.test.js
+++ b/test/boot-crash-guards.test.js
@@ -1,0 +1,46 @@
+// test/boot-crash-guards.test.js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { installCrashGuards } from "../src/boot.js";
+
+// A reauth-needed / unreachable MCP server rejects asynchronously during
+// connect (401, OAuth callback timeout, DNS failure). Node 15+ would terminate
+// the daemon on that unhandled rejection — crash-looping a recoverable error.
+// installCrashGuards must turn those into logged, non-fatal events.
+test("installCrashGuards installs non-fatal handlers and is idempotent", () => {
+  const beforeRej = process.listeners("unhandledRejection").length;
+  const beforeExc = process.listeners("uncaughtException").length;
+
+  installCrashGuards();
+  const rejListeners = process.listeners("unhandledRejection");
+  const excListeners = process.listeners("uncaughtException");
+  assert.equal(rejListeners.length, beforeRej + 1, "adds one unhandledRejection listener");
+  assert.equal(excListeners.length, beforeExc + 1, "adds one uncaughtException listener");
+
+  // Idempotent: a second call must not stack more listeners.
+  installCrashGuards();
+  assert.equal(process.listeners("unhandledRejection").length, beforeRej + 1, "idempotent (rejection)");
+  assert.equal(process.listeners("uncaughtException").length, beforeExc + 1, "idempotent (exception)");
+
+  // The handlers must log and NOT rethrow — an MCP 401 / OAuth timeout is not fatal.
+  const ourRej = rejListeners[rejListeners.length - 1];
+  const ourExc = excListeners[excListeners.length - 1];
+  const origErr = console.error;
+  const logged = [];
+  console.error = (...a) => logged.push(a.join(" "));
+  try {
+    assert.doesNotThrow(() => ourRej(new Error("HTTP 401 from buildbetter staging: invalid_token")));
+    assert.doesNotThrow(() => ourExc(new Error("OAuth callback timed out")));
+    // A non-Error reason (e.g. a rejected string) must also be handled.
+    assert.doesNotThrow(() => ourRej("bare string rejection"));
+  } finally {
+    console.error = origErr;
+  }
+  assert.ok(logged.some((l) => l.includes("401")), "logged the 401 rejection");
+  assert.ok(logged.some((l) => l.includes("OAuth callback timed out")), "logged the exception");
+  assert.ok(logged.some((l) => l.includes("bare string rejection")), "logged a non-Error reason");
+
+  // Clean up the listeners we added so they don't leak into the test runner.
+  process.removeListener("unhandledRejection", ourRej);
+  process.removeListener("uncaughtException", ourExc);
+});


### PR DESCRIPTION
## Why

A reauth-needed or unreachable MCP server rejects **asynchronously** during connect — a 401 (invalid/expired token), an OAuth callback timeout, a DNS failure. The daemon had **no top-level `unhandledRejection` handler**, so since Node 15+ one stray MCP rejection terminated the whole process. The Mac DaemonController (and systemd) then restarted it straight into the same failure — a **crash loop**.

Observed live on a local install:
- `buildbetter staging` → `HTTP 401: Token missing organization context`
- `rize` → `OAuth callback timed out`

A recoverable "this server needs reauth" was killing the entire agent.

## Fix

Install a top-level guard in `src/boot.js` — the shared entrypoint for **every** daemon launch (the `openagi serve` CLI, the hosted-server example, systemd, the Mac `DaemonController`). Unhandled rejections and uncaught exceptions are logged loudly but kept **non-fatal**. Reauth-needed becomes a logged warning; the server already records its own `lastError` and surfaces "needs auth" via status/SSE. The daemon stays up.

## Verification

- New `test/boot-crash-guards.test.js` — asserts handlers install (idempotently) and log without rethrowing, incl. a non-Error reason.
- End-to-end: a process that installs the guard **survives** `Promise.reject` of the exact two MCP errors (exit 0) where it previously `exit(1)`.
- Full suite: 323/325 pass. The 2 failures are **pre-existing** (require a live model key; confirmed identical on `main` without this change). No regressions.

## Scope note

This fixes the root resilience gap — a reauth/connect failure can never crash the daemon. It does not hunt down the specific path that fired an interactive OAuth at boot; the guard makes that (and any future variant) non-fatal regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)