### PR TITLE
Run iMessage nodes under the signed OpenAGI daemon

### DIFF
--- a/bin/openagi.js
+++ b/bin/openagi.js
@@ -388,15 +388,15 @@ async function cmdImessageBridge(flags) {
   const bridge = new IMessageBridge({
     clientProvider, allowFrom, allowChats, respondMode, captureMode, trigger: flags.trigger,
     onEvent: (e) => {
-      if (e.kind === "relayed") console.log(c(GREEN, `↔ ${e.handle}: `) + c(DIM, `"${e.in}" → "${e.out}"`));
-      else if (e.kind === "captured") console.log(c(DIM, `· saved to memory — ${e.handle}: "${e.in}"`));
-      else if (e.kind && e.error) console.error(c(YELLOW, `! ${e.kind} ${e.handle ?? ""}: ${e.error}`));
+      if (e.kind === "relayed") console.log(c(GREEN, "↔ relayed one iMessage"));
+      else if (e.kind === "captured") console.log(c(DIM, "· saved one iMessage to memory"));
+      else if (e.detailCode) console.error(c(YELLOW, `! ${e.kind}: ${e.detailCode}`));
     }
   });
   console.log(c(GREEN, `iMessage bridge → main at ${probe.url}`));
-  const respondDesc = respondMode === "all" ? "everyone" : respondMode === "allow" ? `allowlist (${allowFrom.join(", ")})` : respondMode === "trigger" ? `messages containing "${flags.trigger}"` : "no one (capture-only)";
+  const respondDesc = respondMode === "all" ? "everyone" : respondMode === "allow" ? `the ${allowFrom.length + allowChats.length} allowlisted conversation(s)` : respondMode === "trigger" ? "messages containing the configured trigger" : "no one (capture-only)";
   console.log(c(DIM, `Reply to: ${respondDesc}.${captureMode !== "none" ? ` Save to memory: ${captureMode}.` : ""} Ctrl-C to stop.`));
-  if (allowChats.length) console.log(c(DIM, `Group chats where anyone can invoke: ${allowChats.join(", ")}`));
+  if (allowChats.length) console.log(c(DIM, `${allowChats.length} group chat(s) can invoke the trigger.`));
   console.log(c(DIM, "Requires: Full Disk Access (read chat.db) + Automation→Messages (send) for this process."));
   bridge.start(); // default 10s, read-only-safe
   await new Promise(() => {}); // run until killed

--- a/docs/3-minute-workflow-demo.md
+++ b/docs/3-minute-workflow-demo.md
@@ -65,17 +65,19 @@ Do this before the audience is present.
    openagi imessage-search "demo preflight" --days 1 --limit 1
    ```
 
-6. Start the conversational bridge in a separate terminal. Use the trigger mode
-   so unrelated texts never invoke the agent:
+6. In OpenAGI Setup, enable the signed-app conversational bridge with trigger
+   mode so unrelated texts never invoke the agent:
 
    ```bash
-   SELF_HANDLE="your iCloud email or phone"
-   openagi imessage-bridge \
-     --allow "$SELF_HANDLE" \
-     --respond trigger \
-     --trigger OpenAGI \
-     --capture allow
+   OPENAGI_IMESSAGE_BRIDGE=1
+   IMESSAGE_ALLOW="your iCloud email or phone"
+   IMESSAGE_RESPOND=trigger
+   IMESSAGE_TRIGGER=OpenAGI
+   IMESSAGE_CAPTURE=none
    ```
+
+   Restart OpenAGI after saving. Do not use the deprecated Node LaunchAgent;
+   the signed app must own the Full Disk Access grant.
 
 7. In **Skills**, preselect one safe suggested workflow with a clear action
    sequence and more than one observation. Do not depend on a miner producing a

--- a/examples/skills/setup-imessage-node/SKILL.md
+++ b/examples/skills/setup-imessage-node/SKILL.md
@@ -5,22 +5,20 @@ description: Guide setting up a Mac as an iMessage node — relays incoming text
 
 Walk the user through turning a Mac (signed into iMessage) into an iMessage node. macOS-only, and it needs system permissions you can't grant for them — so produce clear, copy-pasteable steps and explain each grant. Substitute `<host>`, `<port>`, `<secret>`, `<TriggerWord>` for their values; never hardcode real numbers/tokens.
 
-Two processes (run from the openAGI repo on that Mac):
-- `openagi imessage-bridge --respond trigger --trigger <TriggerWord> --allow <handle,handle> --allow-chat <chatId> --capture all`
-  Reads `~/Library/Messages/chat.db` read-only, relays messages containing the trigger to the main, and replies via Messages. Omit `--allow*` to respond to everyone; `--allow-chat` opts a group thread in.
-- `openagi imessage-server --token <secret> --port <port>` (optional)
-  Serves iMessage SEARCH to the main, giving it a `search_imessages` tool.
+The normal setup is one signed OpenAGI app process, not separate Node services:
+- Set `OPENAGI_IMESSAGE_BRIDGE=1`, `IMESSAGE_RESPOND=trigger`, and `IMESSAGE_TRIGGER=<TriggerWord>` on the Messages Mac. Optional `IMESSAGE_ALLOW=<handle,handle>` and `IMESSAGE_ALLOW_CHAT=<chatId>` narrow who can invoke it. Ambient capture stays off unless explicitly enabled.
+- Set `OPENAGI_IMESSAGE_SEARCH=1` only when the user wants the paired main to perform bounded read-only searches. Search travels over the authenticated outbound node relay; do not open an inbound iMessage port.
 
 Steps to give the user:
-1. Clone/run the openAGI repo on the Mac.
-2. System Settings → Privacy & Security: grant the runtime that launches these (the `node` binary; Terminal while testing) **Full Disk Access** (read chat.db) and **Automation → Messages** (send replies).
-3. Run the bridge (and optionally the search server). For persistence install a launchd USER agent (`RunAtLoad` + `KeepAlive`) that runs the command; restart it with `launchctl kickstart -k gui/$(id -u)/<label>`.
-4. On the MAIN agent host, point at the node: `OPENAGI_IMESSAGE_NODE=http://<host>:<port>` and `OPENAGI_IMESSAGE_NODE_TOKEN=<secret>`, then restart.
+1. Install and launch the signed OpenAGI app on the Mac, then pair it to the HTTPS main with `openagi pair <main>` using the documented hidden token input.
+2. In OpenAGI Setup, enable the signed-app bridge and optionally history search. Restart OpenAGI so the daemon loads the settings and enrolls its scoped node credential.
+3. System Settings → Privacy & Security: grant **OpenAGI.app** Full Disk Access (read chat.db) and **Automation → Messages** (send replies), then restart OpenAGI once more.
+4. On the main, verify one fresh node heartbeat and the nested `imessage-search` capability. Send a harmless trigger message and confirm the bridge status records a successful poll before relying on it.
 
 Gotchas to mention:
 - chat.db MUST be opened read-only — a read-write connection on the live WAL database can hang/crash Messages.
 - On recent macOS the message text often lives only in `attributedBody` (the `text` column is NULL); the bridge decodes that typedstream blob.
-- A process launched by launchd needs its OWN TCC grant — granting Terminal is not enough; the launchd-spawned `node` must be approved separately.
+- Full Disk Access belongs to a code-signing identity. Do not replace the signed-app bridge with a checkout-specific Node LaunchAgent; that recreates the permission-loss bug on updates.
 - Track messages by date, not ROWID (a chat.db rebuild renumbers ROWIDs non-chronologically).
 
 User asked: {{input}}

--- a/scripts/install-imessage-launchd.sh
+++ b/scripts/install-imessage-launchd.sh
@@ -4,12 +4,16 @@
 # the Mac that's signed into iMessage (the "node"); it relays iMessages to a
 # remote OpenAGI main you've already paired with (`openagi pair <main>`).
 #
+# The normal supported path is now the signed OpenAGI app/daemon. Keeping the
+# bridge under that identity makes the Full Disk Access grant survive runtime
+# and checkout updates. This script remains only for explicit legacy recovery.
+#
 # Usage:
-#   ./scripts/install-imessage-launchd.sh            # install + load
+#   ./scripts/install-imessage-launchd.sh legacy-install  # unsupported fallback
 #   ./scripts/install-imessage-launchd.sh uninstall  # stop + remove
 #
 # Config (env vars):
-#   IMESSAGE_RESPOND   all|allow|trigger|none   reply policy (default: all)
+#   IMESSAGE_RESPOND   all|allow|trigger|none   reply policy (default: trigger)
 #   IMESSAGE_ALLOW     h1,h2                     sender allowlist (for respond=allow)
 #   IMESSAGE_ALLOW_CHATS c1,c2                   group chat ids where ANY member
 #                                                can invoke the trigger (chat787…)
@@ -46,12 +50,26 @@ if [[ "${1:-install}" == "uninstall" ]]; then
   exit 0
 fi
 
+if [[ "${1:-}" != "legacy-install" ]]; then
+  cat >&2 <<'EOF'
+This installer is deprecated. The supported iMessage node runs inside the
+signed OpenAGI app so its Full Disk Access permission remains attached to a
+stable identity.
+
+Enable OPENAGI_IMESSAGE_BRIDGE=1 (and optionally
+OPENAGI_IMESSAGE_SEARCH=1) in OpenAGI Setup, grant Full Disk Access to
+OpenAGI.app, then restart OpenAGI. Run this script with "uninstall" to remove
+old Node-based agents, or "legacy-install" only for temporary recovery.
+EOF
+  exit 2
+fi
+
 [[ -n "${NODE_BIN}" ]] || { echo "ERROR: node not found. Install Node 22+ or set OPENAGI_NODE_BIN." >&2; exit 1; }
 [[ -f "${BIN}" ]] || { echo "ERROR: ${BIN} not found. Set OPENAGI_DIR to your openAGI checkout." >&2; exit 1; }
 mkdir -p "$(dirname "${BRIDGE_PLIST}")" "${LOG_DIR}"
 
 # Build the bridge argument array.
-bridge_args=("imessage-bridge" "--respond" "${IMESSAGE_RESPOND:-all}")
+bridge_args=("imessage-bridge" "--respond" "${IMESSAGE_RESPOND:-trigger}" "--trigger" "${IMESSAGE_TRIGGER:-openagi}")
 [[ -n "${IMESSAGE_ALLOW:-}" ]]   && bridge_args+=("--allow" "${IMESSAGE_ALLOW}")
 [[ -n "${IMESSAGE_ALLOW_CHATS:-}" ]] && bridge_args+=("--allow-chat" "${IMESSAGE_ALLOW_CHATS}")
 [[ -n "${IMESSAGE_TRIGGER:-}" ]] && bridge_args+=("--trigger" "${IMESSAGE_TRIGGER}")
@@ -91,7 +109,7 @@ EOF
 emit_plist "${BRIDGE_LABEL}" "imessage-bridge" "${bridge_args[@]}" > "${BRIDGE_PLIST}"
 launchctl bootout "${GUI}" "${BRIDGE_PLIST}" 2>/dev/null || true
 launchctl bootstrap "${GUI}" "${BRIDGE_PLIST}"
-echo "Installed ${BRIDGE_LABEL} (respond=${IMESSAGE_RESPOND:-all}, capture=${IMESSAGE_CAPTURE:-none})."
+echo "Installed unsupported legacy ${BRIDGE_LABEL} (respond=${IMESSAGE_RESPOND:-trigger}, capture=${IMESSAGE_CAPTURE:-none})."
 
 if [[ -n "${IMESSAGE_NODE_TOKEN:-}" ]]; then
   emit_plist "${SERVER_LABEL}" "imessage-server" \

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -38,6 +38,7 @@ import { summarizeRegisterMcpServer } from "./tool-registry.js";
 import { logAgentFailure, publicAgentFailure } from "./agent-failure.js";
 import { NodeControlBroker, createNodeControlWorker, sanitizeNodeCapabilities, pinnedRemoteOrigin } from "./node-control.js";
 import { createComputerExecutor } from "./integrations/computer-server.js";
+import { createImessageBridgeRuntime } from "./integrations/imessage-bridge-runtime.js";
 import {
   createImessageNodeCapability,
   isImessageSearchEnabled
@@ -511,6 +512,7 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
   let nodeControlWorker = null;
   let computerExecutor = null;
   let imessageNodeCapability = null;
+  let imessageBridgeRuntime = null;
   const tickerMs = options.tickerMs ?? Number.parseInt(process.env.OPENAGI_TICKER_MS ?? "10000", 10);
 
   const computerUseEnabledHere = () => {
@@ -537,6 +539,17 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
     }));
     localCapabilityCache = sanitizeNodeCapabilities(capabilities.filter(Boolean));
     return localCapabilityCache;
+  };
+  const ensureImessageBridge = () => {
+    imessageBridgeRuntime ??= options.imessageBridgeRuntime
+      ?? createImessageBridgeRuntime({
+        dataDir,
+        env: getServiceEnv(),
+        fetchImpl: options.nodeControlFetch ?? globalThis.fetch,
+        allowInsecureRemote: allowInsecureNodeRelay
+      });
+    imessageBridgeRuntime.start();
+    return imessageBridgeRuntime;
   };
   const ensureNodeControlWorker = () => {
     if (nodeControlWorker || activeNodeCapabilityProviders().size === 0) return nodeControlWorker;
@@ -2061,8 +2074,8 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
           },
           {
             id: "imessage",
-            name: "iMessage (text yourself as inbox)",
-            description: "Reads ~/Library/Messages/chat.db read-only and converts messages from a 1:1 self-chat into tasks. macOS only · requires Full Disk Access · opt-in.",
+            name: "iMessage",
+            description: "Read-only local Messages access for task inbox, paired-node conversations, and explicitly enabled history search. macOS only · requires Full Disk Access · opt-in.",
             paths: [
               (() => {
                 const s = runtime.imessagePoller?.status?.() ?? null;
@@ -2082,6 +2095,42 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
                         : !s.selfHandle
                           ? "Set IMESSAGE_SELF_HANDLE to the iCloud email or phone you text yourself from."
                           : `Reading from ${s.selfHandle}. Last imported ROWID: ${s.lastImportedRowid ?? 0}.`
+                };
+              })(),
+              (() => {
+                const s = imessageBridgeRuntime?.status?.() ?? {
+                  enabled: false, running: false, detailCode: "disabled", lastSuccessAt: null
+                };
+                return {
+                  kind: "channel",
+                  label: "Paired-node conversation bridge",
+                  configured: Boolean(s.enabled && s.running && s.detailCode === "ready"),
+                  envKeys: ["OPENAGI_IMESSAGE_BRIDGE", "IMESSAGE_RESPOND", "IMESSAGE_TRIGGER", "IMESSAGE_ALLOW", "IMESSAGE_ALLOW_CHAT", "IMESSAGE_CAPTURE"],
+                  lastSyncedAt: s.lastSuccessAt ?? null,
+                  feeds: "messages",
+                  detail: !s.enabled
+                    ? "Disabled. Set OPENAGI_IMESSAGE_BRIDGE=1; the safe default requires a self-handle/allowlist plus the ‘openagi’ trigger and captures no ambient messages."
+                    : s.detailCode === "full-disk-access-required"
+                      ? "Full Disk Access is required for the signed OpenAGI app; restart OpenAGI after granting it."
+                      : s.detailCode === "ready"
+                        ? "Running under the signed OpenAGI daemon identity with scoped node authentication."
+                        : `Bridge ${s.running ? "is running" : "is stopped"}; status: ${s.detailCode}.`
+                };
+              })(),
+              (() => {
+                const enabled = isImessageSearchEnabled(getServiceEnv());
+                const capability = localCapabilityCache.find((item) => item.id === "imessage-search");
+                return {
+                  kind: "node-capability",
+                  label: "Paired-node history search",
+                  configured: Boolean(enabled && capability?.ready),
+                  envKeys: ["OPENAGI_IMESSAGE_SEARCH"],
+                  feeds: "agent-tools",
+                  detail: !enabled
+                    ? "Disabled. Enable explicitly to let the main ask this node for bounded read-only message searches."
+                    : capability?.ready
+                      ? "Ready and advertised through the authenticated outbound node relay."
+                      : `Enabled but not ready${capability?.detail ? `: ${capability.detail}` : "."}`
                 };
               })()
             ]
@@ -2796,6 +2845,10 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
                   });
                   if (!res.ok) throw new Error(`heartbeat rejected: ${res.status}`);
                 } finally { clearTimeout(timer); }
+                // Do not advance the private message cursor until scoped node
+                // enrollment and a live main heartbeat both succeed. Starting
+                // earlier could consume a message that cannot yet be relayed.
+                ensureImessageBridge();
                 if (heartbeatFailStreak > 0) {
                   console.warn("[openagi] heartbeat to main recovered");
                 }
@@ -2814,6 +2867,10 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
             sendHeartbeat().catch(() => {});
             heartbeatHandle = setInterval(() => { sendHeartbeat().catch(() => {}); }, heartbeatIntervalMs);
             ensureNodeControlWorker();
+          } else {
+            // A standalone/main Mac can bridge to its own authenticated local
+            // daemon as soon as that daemon is listening.
+            ensureImessageBridge();
           }
           const address = server.address();
           const actualPort = typeof address === "object" && address ? address.port : port;
@@ -2831,6 +2888,7 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
         for (const client of sseClients) try { client.end(); } catch { /* ignore */ }
         sseClients.clear();
         channels?.stop?.();
+        imessageBridgeRuntime?.stop?.();
         runtime.tunnelWatcher?.stop?.();
         runtime.mcp?.disconnectAll?.().catch(() => {});
         Promise.resolve(computerExecutor?.close?.())

--- a/src/integrations/imessage-bridge-runtime.js
+++ b/src/integrations/imessage-bridge-runtime.js
@@ -1,0 +1,105 @@
+import { IMessageBridge, classifyBridgeError } from "./imessage-bridge.js";
+import { createRefreshingNodeClientProvider, readNodeConfig } from "../cli-client.js";
+import { resolveDataDir } from "../data-dir.js";
+
+const truthy = (value) => ["1", "true", "yes"].includes(String(value ?? "").trim().toLowerCase());
+const csv = (value) => String(value ?? "").split(",").map((item) => item.trim()).filter(Boolean);
+
+export function imessageBridgeConfig(env = process.env) {
+  const allowFrom = csv(env.IMESSAGE_ALLOW || env.IMESSAGE_SELF_HANDLE);
+  const allowChats = csv(env.IMESSAGE_ALLOW_CHAT ?? env.IMESSAGE_ALLOW_CHATS);
+  const requestedRespond = String(env.IMESSAGE_RESPOND ?? "").trim().toLowerCase();
+  const requestedCapture = String(env.IMESSAGE_CAPTURE ?? "").trim().toLowerCase();
+  const respond = ["all", "allow", "trigger", "none"].includes(requestedRespond)
+    ? requestedRespond
+    : (allowFrom.length || allowChats.length ? "trigger" : "none");
+  const capture = ["all", "allow", "none"].includes(requestedCapture)
+    ? requestedCapture
+    : "none";
+  const requestedInterval = Number.parseInt(env.IMESSAGE_INTERVAL_MS ?? "10000", 10);
+  return {
+    enabled: truthy(env.OPENAGI_IMESSAGE_BRIDGE),
+    allowFrom,
+    allowChats,
+    respondMode: respond,
+    captureMode: capture,
+    trigger: String(env.IMESSAGE_TRIGGER ?? "openagi").trim().slice(0, 80),
+    intervalMs: Number.isFinite(requestedInterval)
+      ? Math.min(300_000, Math.max(2_000, requestedInterval))
+      : 10_000
+  };
+}
+
+export function createImessageBridgeRuntime(options = {}) {
+  const dataDir = options.dataDir ?? resolveDataDir();
+  const env = options.env ?? process.env;
+  const config = imessageBridgeConfig(env);
+  let bridge = null;
+  let lastEvent = null;
+  let startupDetail = null;
+
+  const status = () => ({
+    enabled: config.enabled,
+    mode: config.respondMode,
+    capture: config.captureMode,
+    ...(bridge?.status?.() ?? {
+      running: false,
+      startedAt: null,
+      lastPollAt: null,
+      lastSuccessAt: null,
+      lastErrorAt: null,
+      detailCode: startupDetail ?? (config.enabled ? "not-started" : "disabled"),
+      totals: { processed: 0, replied: 0, captured: 0, skipped: 0, errors: 0 }
+    }),
+    lastEvent
+  });
+
+  return {
+    status,
+    start() {
+      if (!config.enabled || bridge) return status();
+      try {
+        const pairing = readNodeConfig(dataDir);
+        const rawProvider = options.clientProvider ?? createRefreshingNodeClientProvider({
+          dataDir,
+          fetchImpl: options.fetchImpl,
+          timeoutMs: options.timeoutMs ?? 60_000,
+          allowInsecureRemote: options.allowInsecureRemote === true
+        });
+        // A paired node may not relay private messages with its one-time broad
+        // enrollment credential. Until the daemon confirms scoped enrollment,
+        // polling remains local and reports a categorical main-unavailable state.
+        const clientProvider = () => {
+          const current = readNodeConfig(dataDir);
+          if ((pairing?.remote || current?.remote) && current?.nodeEnrollmentConfirmed !== true) {
+            throw new Error("iMessage bridge main client is unavailable until scoped node enrollment completes");
+          }
+          return rawProvider();
+        };
+        bridge = (options.bridgeFactory ?? ((bridgeOptions) => new IMessageBridge(bridgeOptions)))({
+          dataDir,
+          dbPath: env.IMESSAGE_DB_PATH || undefined,
+          allowFrom: config.allowFrom,
+          allowChats: config.allowChats,
+          respondMode: config.respondMode,
+          captureMode: config.captureMode,
+          trigger: config.trigger,
+          clientProvider,
+          onEvent(event) {
+            lastEvent = { kind: event.kind, at: event.at ?? new Date().toISOString(), detailCode: event.detailCode ?? null };
+          }
+        });
+        bridge.start({ intervalMs: config.intervalMs });
+      } catch (error) {
+        startupDetail = classifyBridgeError(error);
+        lastEvent = { kind: "startup-error", at: new Date().toISOString(), detailCode: startupDetail };
+        bridge = null;
+      }
+      return status();
+    },
+    stop() {
+      bridge?.stop?.();
+      return status();
+    }
+  };
+}

--- a/src/integrations/imessage-bridge.js
+++ b/src/integrations/imessage-bridge.js
@@ -3,6 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { resolveDataDir } from "../data-dir.js";
+import { writeJsonAtomic } from "../file-utils.js";
 
 // iMessage bridge (node-side). Turns a Mac into a conversational gateway for a
 // remote OpenAGI "main": new INCOMING iMessages are forwarded to the main's
@@ -68,7 +70,7 @@ export class IMessageBridge {
     this.client = options.client ?? null;
     this.clientProvider = options.clientProvider ?? null;
     this.dbPath = options.dbPath ?? DEFAULT_DB;
-    this.statePath = options.statePath ?? path.join(options.dataDir ?? path.join(os.homedir(), ".openagi"), "imessage-bridge.json");
+    this.statePath = options.statePath ?? path.join(options.dataDir ?? resolveDataDir(), "imessage-bridge.json");
     // "Note to self": also read your OWN texts in your self-thread so you can
     // command the agent by texting yourself. On by default; your handles come
     // from the allowlist. (Resolved lazily at poll time — allowFrom is set below.)
@@ -104,6 +106,15 @@ export class IMessageBridge {
     });
     this.sendMessage = options.sendMessage ?? sendViaIMessage;
     this.onEvent = options.onEvent ?? (() => {});
+    this._status = {
+      running: false,
+      startedAt: null,
+      lastPollAt: null,
+      lastSuccessAt: null,
+      lastErrorAt: null,
+      detailCode: "stopped",
+      totals: { processed: 0, replied: 0, captured: 0, skipped: 0, errors: 0 }
+    };
     // Texts the bridge itself just sent — so reading the self-thread doesn't
     // echo our own replies back into capture/reply (would otherwise loop).
     this._recentSends = [];
@@ -147,8 +158,33 @@ export class IMessageBridge {
     try { return JSON.parse(fs.readFileSync(this.statePath, "utf8")); } catch { return { lastRowid: null }; }
   }
   _saveState(state) {
-    fs.mkdirSync(path.dirname(this.statePath), { recursive: true });
-    fs.writeFileSync(this.statePath, JSON.stringify(state, null, 2) + "\n", { mode: 0o600 });
+    writeJsonAtomic(this.statePath, state, 0o600);
+  }
+
+  status() {
+    return structuredClone(this._status);
+  }
+
+  _recordEvent(kind, detailCode = null, summary = null) {
+    const at = new Date().toISOString();
+    if (kind === "poll-success") {
+      this._status.lastPollAt = at;
+      this._status.lastSuccessAt = at;
+      this._status.detailCode = Number(summary?.errors ?? 0) > 0
+        ? (this._status.detailCode === "starting" ? "partial-failure" : this._status.detailCode)
+        : "ready";
+      for (const key of Object.keys(this._status.totals)) {
+        this._status.totals[key] += Number(summary?.[key] ?? 0);
+      }
+    } else if (kind.endsWith("error")) {
+      this._status.lastPollAt = at;
+      this._status.lastErrorAt = at;
+      this._status.detailCode = detailCode ?? "runtime-error";
+    }
+    // This event boundary is intentionally metadata-only. Handles, message
+    // text, replies, paths, URLs, and raw provider/SQLite errors must never
+    // enter daemon logs, SSE, or integration status.
+    this.onEvent({ kind, at, ...(detailCode ? { detailCode } : {}) });
   }
 
   onAllowlist(handle) {
@@ -227,7 +263,7 @@ export class IMessageBridge {
             content: `iMessage from ${row.handle}: ${text}`,
             tags: ["imessage", row.handle], importance: "normal"
           });
-          if (cap.ok) { captured++; this.onEvent({ kind: "captured", handle: row.handle, in: text.slice(0, 80) }); }
+          if (cap.ok) { captured++; this.onEvent({ kind: "captured" }); }
         } catch { /* capture is best-effort */ }
       }
 
@@ -247,14 +283,14 @@ export class IMessageBridge {
           this._recentSends.push(reply.trim());
           if (this._recentSends.length > 50) this._recentSends.shift();
           replied++;
-          this.onEvent({ kind: "relayed", handle: row.handle, in: text.slice(0, 80), out: reply.slice(0, 80) });
+          this.onEvent({ kind: "relayed" });
         } else {
           errors++;
-          this.onEvent({ kind: "main-error", handle: row.handle, error: res?.error ?? `HTTP ${res?.status}` });
+          this._recordEvent("main-error", "main-unavailable");
         }
-      } catch (error) {
+      } catch {
         errors++;
-        this.onEvent({ kind: "send-error", handle: row.handle, error: error.message });
+        this._recordEvent("send-error", "send-unavailable");
       }
     }
     this._saveState({ ...state, lastDate: highest });
@@ -265,20 +301,41 @@ export class IMessageBridge {
   // gentle, but a longer interval further reduces any chance of contending with
   // Messages, and iMessage commands don't need sub-10s latency.
   start({ intervalMs = 10000 } = {}) {
+    if (this._status.running) return;
     this._stopped = false;
+    this._status.running = true;
+    this._status.startedAt = new Date().toISOString();
+    this._status.detailCode = "starting";
     const tick = async () => {
       if (this._stopped) return;
-      try { await this.poll(); } catch (error) { this.onEvent({ kind: "poll-error", error: error.message }); }
+      try {
+        const result = await this.poll();
+        this._recordEvent("poll-success", null, result);
+      } catch (error) {
+        this._recordEvent("poll-error", classifyBridgeError(error));
+      }
       if (!this._stopped) this._timer = setTimeout(tick, intervalMs);
     };
     tick();
   }
   stop() {
     this._stopped = true;
+    this._status.running = false;
+    this._status.detailCode = "stopped";
     if (this._timer) clearTimeout(this._timer);
     try { this._db?.close(); } catch { /* ignore */ } // release chat.db
     this._db = null;
   }
+}
+
+export function classifyBridgeError(error) {
+  const value = `${error?.code ?? ""} ${error?.message ?? error ?? ""}`.toLowerCase();
+  if (/sqlite.*(unavailable|not found)|cannot find.*node:sqlite/.test(value)) return "sqlite-unavailable";
+  if (/operation not permitted|permission denied|not authorized|full disk|cantopen|unable to open/.test(value)) {
+    return "full-disk-access-required";
+  }
+  if (/main client|fetch|timeout|econn|main.*unavailable/.test(value)) return "main-unavailable";
+  return "database-unavailable";
 }
 
 // Read new messages newer than `sinceDate`. By default only INCOMING

--- a/src/setup-wizard.js
+++ b/src/setup-wizard.js
@@ -24,6 +24,8 @@ const WIZARD_FIELDS = [
   // Staging/dev environment overrides (default to prod when unset).
   "BUILDBETTER_API_URL", "BUILDBETTER_APP_URL", "BUILDBETTER_MCP_URL",
   "IMESSAGE_ENABLED", "IMESSAGE_SELF_HANDLE", "IMESSAGE_INTERVAL_MS", "IMESSAGE_MODE", "IMESSAGE_BACKFILL_DAYS",
+  "OPENAGI_IMESSAGE_BRIDGE", "OPENAGI_IMESSAGE_SEARCH", "IMESSAGE_RESPOND", "IMESSAGE_TRIGGER",
+  "IMESSAGE_ALLOW", "IMESSAGE_ALLOW_CHAT", "IMESSAGE_ALLOW_CHATS", "IMESSAGE_CAPTURE",
   "OPENAGI_COMPUTER_USE",
   "OPENAGI_PUBLIC_URL",
   "OPENAGI_DAILY_USD_LIMIT",
@@ -342,6 +344,21 @@ export function renderWizard({ proposedToken, existingEnv = {} } = {}) {
           <input type="text" name="IMESSAGE_SELF_HANDLE" placeholder="+14155551234 or you@icloud.com">
           <label style="margin-top:8px;">IMESSAGE_BACKFILL_DAYS <span class="sub">— optional; leave blank for forward-only. Set to e.g. <code>7</code> to also seed the last week's self-texts</span></label>
           <input type="number" name="IMESSAGE_BACKFILL_DAYS" placeholder="0" min="0" max="365">
+          <hr style="margin:18px 0;border:0;border-top:1px solid #333;">
+          <p class="sub"><strong>Paired Mac node:</strong> the signed OpenAGI app can also relay explicitly invoked conversations to your main and offer bounded history search over the authenticated outbound node connection. No extra listener or Node LaunchAgent is required.</p>
+          <div class="opt" style="margin-top:8px;">
+            <input type="checkbox" id="imBridge" name="OPENAGI_IMESSAGE_BRIDGE" value="1">
+            <label for="imBridge" style="margin:0;">Enable the signed-app conversation bridge</label>
+          </div>
+          <label style="margin-top:8px;">IMESSAGE_TRIGGER <span class="sub">— only messages containing this whole word invoke the agent; defaults to <code>openagi</code></span></label>
+          <input type="text" name="IMESSAGE_TRIGGER" placeholder="openagi" value="${val("IMESSAGE_TRIGGER")}">
+          <label style="margin-top:8px;">IMESSAGE_ALLOW <span class="sub">— optional comma-separated sender handles; leave blank to allow the trigger in any conversation</span></label>
+          <input type="text" name="IMESSAGE_ALLOW" placeholder="you@icloud.com,+14155551234" value="${val("IMESSAGE_ALLOW")}">
+          <div class="opt" style="margin-top:8px;">
+            <input type="checkbox" id="imSearch" name="OPENAGI_IMESSAGE_SEARCH" value="1">
+            <label for="imSearch" style="margin:0;">Let the paired main run bounded read-only history searches on this Mac</label>
+          </div>
+          <p class="sub">Privacy defaults: the bridge responds to nobody until a self-handle/allowlist exists, then requires the trigger; ambient message capture remains off. Advanced installs can set <code>IMESSAGE_RESPOND</code>, <code>IMESSAGE_ALLOW_CHAT</code>, or <code>IMESSAGE_CAPTURE</code> in <code>.env</code>.</p>
         </div>
       </details>
     </div>

--- a/test/imessage-bridge-runtime.test.js
+++ b/test/imessage-bridge-runtime.test.js
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createImessageBridgeRuntime, imessageBridgeConfig } from "../src/integrations/imessage-bridge-runtime.js";
+import { writeNodeConfig } from "../src/cli-client.js";
+
+test("integrated bridge is opt-in and cannot answer anyone without an allowlist", () => {
+  assert.deepEqual(imessageBridgeConfig({}), {
+    enabled: false,
+    allowFrom: [],
+    allowChats: [],
+    respondMode: "none",
+    captureMode: "none",
+    trigger: "openagi",
+    intervalMs: 10_000
+  });
+  assert.equal(imessageBridgeConfig({ IMESSAGE_SELF_HANDLE: "me@example.test" }).respondMode, "trigger");
+});
+
+test("daemon-owned bridge starts and stops once with bounded public status", () => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-imessage-runtime-"));
+  let starts = 0;
+  let stops = 0;
+  let received = null;
+  const bridge = {
+    start(options) { starts += 1; received.start = options; },
+    stop() { stops += 1; },
+    status() {
+      return {
+        running: starts > stops,
+        startedAt: "2026-08-18T00:00:00.000Z",
+        lastPollAt: null,
+        lastSuccessAt: null,
+        lastErrorAt: null,
+        detailCode: "starting",
+        totals: { processed: 0, replied: 0, captured: 0, skipped: 0, errors: 0 }
+      };
+    }
+  };
+  const runtime = createImessageBridgeRuntime({
+    dataDir,
+    env: {
+      OPENAGI_IMESSAGE_BRIDGE: "1",
+      IMESSAGE_RESPOND: "allow",
+      IMESSAGE_ALLOW: "first@example.test, second@example.test",
+      IMESSAGE_CAPTURE: "allow",
+      IMESSAGE_INTERVAL_MS: "500"
+    },
+    clientProvider: () => ({ chat() {}, request() {} }),
+    bridgeFactory(options) { received = options; return bridge; }
+  });
+
+  runtime.start();
+  runtime.start();
+  assert.equal(starts, 1);
+  assert.equal(received.respondMode, "allow");
+  assert.deepEqual(received.allowFrom, ["first@example.test", "second@example.test"]);
+  assert.equal(received.start.intervalMs, 2_000, "poll interval is clamped to the safe minimum");
+  assert.deepEqual(Object.keys(runtime.status()).sort(), [
+    "capture", "detailCode", "enabled", "lastErrorAt", "lastEvent", "lastPollAt",
+    "lastSuccessAt", "mode", "running", "startedAt", "totals"
+  ]);
+  runtime.stop();
+  assert.equal(stops, 1);
+});
+
+test("paired bridge refuses the broad enrollment credential until scoped enrollment is confirmed", () => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-imessage-enroll-"));
+  writeNodeConfig({
+    remote: "https://main.example.test",
+    token: "broad-secret",
+    nodeToken: "pending-node-secret",
+    nodeEnrollmentConfirmed: false
+  }, dataDir);
+  let bridgeOptions;
+  const runtime = createImessageBridgeRuntime({
+    dataDir,
+    env: { OPENAGI_IMESSAGE_BRIDGE: "true" },
+    clientProvider: () => ({ chat() {}, request() {} }),
+    bridgeFactory(options) {
+      bridgeOptions = options;
+      return { start() {}, stop() {}, status: () => ({ running: true, detailCode: "starting" }) };
+    }
+  });
+  runtime.start();
+  assert.throws(() => bridgeOptions.clientProvider(), /scoped node enrollment/);
+});

--- a/test/imessage-bridge.test.js
+++ b/test/imessage-bridge.test.js
@@ -6,7 +6,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { IMessageBridge, extractAttributedText, toPlainText } from "../src/integrations/imessage-bridge.js";
+import { IMessageBridge, classifyBridgeError, extractAttributedText, toPlainText } from "../src/integrations/imessage-bridge.js";
 
 test("toPlainText strips markdown so iMessage replies aren't wack", () => {
   const md = "## Plan\n\nHere's the **budget**:\n- venue: $12k\n- food: *catered*\n\nSee [the doc](https://x.com/d) and `run this`.\n\n~~old~~ done";
@@ -95,6 +95,29 @@ test("advances the date high-water mark even when a send errors", async () => {
   assert.equal(r.errors, 1);
   const state = JSON.parse(fs.readFileSync(path.join(dir, "imessage-bridge.json"), "utf8"));
   assert.equal(state.lastDate, "101", "won't reprocess the same failed message forever");
+});
+
+test("bridge state is atomic, owner-only, and operational events contain no private message data", async () => {
+  const events = [];
+  const { bridge, dir } = makeBridge({});
+  bridge.onEvent = (event) => events.push(event);
+  bridge._saveState({ lastDate: "0", initialized: true });
+  bridge.readMessages = async () => [{ rowid: 1, appleDate: "1", handle: "private@example.test", text: "secret body" }];
+  bridge.client.chat = async () => ({ ok: true, json: { reply: "private reply" } });
+  await bridge.poll();
+
+  const file = path.join(dir, "imessage-bridge.json");
+  assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+  assert.equal(fs.readdirSync(dir).some((name) => name.endsWith(".tmp")), false);
+  const serializedEvents = JSON.stringify(events);
+  assert.doesNotMatch(serializedEvents, /private@example|secret body|private reply/);
+  assert.ok(events.some((event) => event.kind === "relayed"));
+});
+
+test("bridge failures are reported as stable categories, never raw diagnostics", () => {
+  assert.equal(classifyBridgeError(new Error("SQLITE_CANTOPEN: unable to open database file at /private/path")), "full-disk-access-required");
+  assert.equal(classifyBridgeError(new Error("fetch failed ECONNREFUSED 10.0.0.8")), "main-unavailable");
+  assert.equal(classifyBridgeError(new Error("unexpected database format at /private/path")), "database-unavailable");
 });
 
 test("extractAttributedText pulls text from an attributedBody blob", () => {


### PR DESCRIPTION
## Summary
- move the opt-in iMessage conversation bridge into the signed daemon lifecycle so Full Disk Access stays bound to OpenAGI.app across updates
- require scoped node enrollment and a live heartbeat before consuming messages; use trigger/no-capture safe defaults and categorical privacy-safe status
- expose bridge and paired history-search readiness in Integrations, update Setup, and deprecate the checkout-specific Node LaunchAgent path

## Security and privacy
- no inbound iMessage service is required for paired search
- no raw handles, message text, reply text, paths, URLs, or provider/SQLite errors enter bridge logs or status
- a bridge without a self-handle/allowlist answers nobody; ambient capture remains off unless explicitly enabled
- state is written atomically with mode 0600

## Verification
- bundled Node full suite: 997/997 passing
- focused iMessage/node/onboarding suite: 56/56 passing
- shell syntax, JS syntax, and git diff checks pass
- staged Git safety guard passes