### PR TITLE
Rehabilitate legacy review, memory, and outcome quality

### DIFF
--- a/src/abi-runtime.js
+++ b/src/abi-runtime.js
@@ -484,15 +484,15 @@ export class AbiRuntime {
         intervalMs: sweepMin * 60 * 1000
       });
       // Daily deterministic cleanup drains legacy duplicate/dead suggestions
-      // in bounded reversible passes. BacklogTriage itself rate-limits the LLM
-      // judgement phase to weekly, so this faster housekeeping cadence does
-      // not multiply model cost. 05:45 stays clear of observation retention
+      // in bounded reversible passes. BacklogTriage caps and budget-bounds the
+      // daily LLM judgement phase so a legacy queue drains without an
+      // unbounded spend. 05:45 stays clear of observation retention
       // and the nightly miners, then lands before the morning plan reads the
       // review queue.
       const existingBacklogTriageJob = this.cron.listJobs().find((job) => job.id === "backlog-triage") ?? null;
       this.cron.addJob({
         id: "backlog-triage",
-        name: "Daily backlog hygiene — retire duplicates; review relevance weekly",
+        name: "Daily backlog hygiene — retire duplicates and review relevance",
         enabled: true,
         task: "backlog-triage",
         dailyAt: "05:45"
@@ -501,7 +501,7 @@ export class AbiRuntime {
       // weekly default without changing a user's enabled/disabled choice.
       if (existingBacklogTriageJob?.intervalMs === 7 * 24 * 60 * 60 * 1000) {
         this.cron.updateJob("backlog-triage", {
-          name: "Daily backlog hygiene — retire duplicates; review relevance weekly",
+          name: "Daily backlog hygiene — retire duplicates and review relevance",
           intervalMs: null,
           dailyAt: "05:45",
           ...(existingBacklogTriageJob.enabled ? {} : { nextRunAt: null })

--- a/src/agent-host.js
+++ b/src/agent-host.js
@@ -296,6 +296,7 @@ export class AgentHost {
       scrutinyDimensions: output.scrutiny.dimensions,
       toolCalls: recordedToolCalls,
       metadata: {
+        qualityEligible: input.origin !== "autopilot" || meaningfulAutopilotWork,
         specialistId: agent.role === "specialist" ? agent.id : null,
         signalSummary: signal.summary,
         scrutinyScore: output.scrutiny.score,

--- a/src/backlog-triage.js
+++ b/src/backlog-triage.js
@@ -111,9 +111,10 @@ const DEFAULTS = {
   deadlineMs: 7 * 60 * 1000,
   // Share of the remaining daily budget one pass is allowed to plan to spend.
   budgetFraction: 0.25,
-  // Deterministic cleanup is cheap and safe enough to run daily. The model
-  // judgement remains weekly so faster queue draining does not multiply cost.
-  llmIntervalDays: 7
+  // The model pass is also daily, but remains capped and budget-fraction
+  // bounded. A four-figure legacy queue should rotate through review in days,
+  // not remain misleadingly attached to the task surface for months.
+  llmIntervalDays: 1
 };
 
 function envNumber(name, fallback) {
@@ -269,12 +270,15 @@ export class BacklogTriage {
     const latest = safely(degraded, "read-latest", () => readJsonFile(path.join(dir, "backlog-triage", "latest.json"), null), null);
     const previousLlmAt = latest?.llm?.lastAttemptAt
       ?? (latest?.llm?.itemsSent > 0 ? latest.startedAt : null);
+    const previousProviderFailure = latest?.llm?.stoppedEarly === "provider-error";
     report.llm.lastAttemptAt = previousLlmAt;
     if (!useLLM) {
       report.llm.skipped = "disabled";
     } else if (plan.ambiguous.length === 0) {
       report.llm.skipped = "no-candidates";
-    } else if (!llmReviewDue(previousLlmAt, startedAt, this.options.llmIntervalDays)) {
+    } else if (!llmReviewDue(previousLlmAt, startedAt, previousProviderFailure
+      ? Math.max(7, this.options.llmIntervalDays)
+      : this.options.llmIntervalDays)) {
       report.llm.skipped = "cadence";
       report.llm.deferred = plan.ambiguous.length;
     } else {

--- a/src/file-backed-memory-system.js
+++ b/src/file-backed-memory-system.js
@@ -93,6 +93,34 @@ export class FileBackedMemorySystem extends MemorySystem {
     return result;
   }
 
+  retireWeakAutomatedNoise(options = {}) {
+    const result = super.retireWeakAutomatedNoise({
+      ...options,
+      // Recovery receipt is deliberately content-free. The active snapshot is
+      // rebuilt atomically only after every receipt append succeeds.
+      archive: ({ at, item }) => appendJsonLine(this.duplicateArchivePath, {
+        version: 1,
+        op: "retire-weak-automated-memory",
+        at,
+        removedId: item.id,
+        rawContentHash: item.rawContentHash ?? null,
+        tier: item.tier ?? null,
+        source: item.source ?? null,
+        scope: item.scope ?? null,
+        createdAt: item.createdAt ?? null,
+        lastObservedAt: item.lastObservedAt ?? null
+      })
+    });
+    if (result.removed.length > 0) {
+      this.persist("retire-weak-automated-memory", {
+        removed: result.removed.map((item) => item.id),
+        archivePath: path.basename(this.duplicateArchivePath),
+        deferred: result.deferred
+      });
+    }
+    return result;
+  }
+
   compactEventLog() {
     writeTextAtomic(this.eventsPath, `${JSON.stringify({
       version: 1,

--- a/src/memory-condenser.js
+++ b/src/memory-condenser.js
@@ -18,6 +18,7 @@ const MIN_GROUP_SIZE = 3;
 const MAX_GROUPS_PER_RUN = 8;
 const QUARANTINE_DAYS = 7;
 const MAX_DUPLICATES_PER_RUN = 250;
+const MAX_WEAK_NOISE_PER_RUN = 100;
 
 export class MemoryCondenser {
   constructor(options = {}) {
@@ -26,6 +27,7 @@ export class MemoryCondenser {
     this.maxGroupsPerRun = options.maxGroupsPerRun ?? MAX_GROUPS_PER_RUN;
     this.quarantineDays = options.quarantineDays ?? QUARANTINE_DAYS;
     this.maxDuplicateRemovals = options.maxDuplicateRemovals ?? MAX_DUPLICATES_PER_RUN;
+    this.maxWeakNoiseRemovals = options.maxWeakNoiseRemovals ?? MAX_WEAK_NOISE_PER_RUN;
   }
 
   async condense({ now = new Date(), scope = null, writeScope = null, originSpecialistId = null } = {}) {
@@ -37,6 +39,10 @@ export class MemoryCondenser {
       maxRemovals: this.maxDuplicateRemovals,
       now
     }) ?? { groups: 0, removed: [] };
+    const weakNoise = this.runtime.memory.retireWeakAutomatedNoise?.({
+      maxRemovals: this.maxWeakNoiseRemovals,
+      now
+    }) ?? { removed: [], deferred: 0 };
     let candidates = [...this.runtime.memory.byTier("medium"), ...this.runtime.memory.byTier("short")]
       .filter((item) => item.kind !== "principle" && !item.metadata?.condensedInto);
     if (scope) {
@@ -45,7 +51,7 @@ export class MemoryCondenser {
       candidates = candidates.filter((item) => !item.scope || item.scope === "main");
     }
     if (candidates.length < this.minGroupSize) {
-      return { groups: 0, principles: 0, duplicatesConsolidated: maintenance.removed.length, reason: "not enough items in scope" };
+      return { groups: 0, principles: 0, duplicatesConsolidated: maintenance.removed.length, weakNoiseRetired: weakNoise.removed.length, weakNoiseDeferred: weakNoise.deferred, reason: "not enough items in scope" };
     }
     const groups = clusterByTagOverlap(candidates, this.minGroupSize).slice(0, this.maxGroupsPerRun);
     const principles = [];
@@ -90,7 +96,7 @@ export class MemoryCondenser {
     }
 
     if (typeof this.runtime.memory.persist === "function") this.runtime.memory.persist("condense", { count: principles.length });
-    return { groups: groups.length, principles: principles.length, items: principles, duplicatesConsolidated: maintenance.removed.length };
+    return { groups: groups.length, principles: principles.length, items: principles, duplicatesConsolidated: maintenance.removed.length, weakNoiseRetired: weakNoise.removed.length, weakNoiseDeferred: weakNoise.deferred };
   }
 
   async distill(items) {

--- a/src/memory-system.js
+++ b/src/memory-system.js
@@ -467,6 +467,45 @@ export class MemorySystem {
     return { groups: retained.length, removed, retained };
   }
 
+  retireWeakAutomatedNoise({
+    maxRemovals = 100,
+    minAgeDays = 30,
+    maxStrength = 0.25,
+    archive = null,
+    now = new Date()
+  } = {}) {
+    const at = now instanceof Date ? now : new Date(now);
+    const cutoff = at.getTime() - Math.max(1, Number(minAgeDays) || 30) * 24 * 60 * 60 * 1000;
+    const cap = Math.max(0, Math.min(500, Number(maxRemovals) || 0));
+    const removed = [];
+    const candidates = [...this.items.values()]
+      .filter((item) => {
+        const lastEvidence = Date.parse(item.lastObservedAt ?? item.lastAccessedAt ?? item.createdAt ?? "");
+        return !isProtectedMemory(item)
+          && item.kind !== "principle"
+          && !item.metadata?.supersededBy
+          && Number(item.strength ?? 0) <= maxStrength
+          && Number(item.risk ?? 0) < 0.3
+          && Number(item.novelty ?? 0) < 0.3
+          && Number(item.repetition ?? 0) < 0.2
+          && Number.isFinite(lastEvidence)
+          && lastEvidence < cutoff;
+      })
+      .sort((a, b) => String(a.lastObservedAt ?? a.createdAt).localeCompare(String(b.lastObservedAt ?? b.createdAt)));
+
+    for (const item of candidates.slice(0, cap)) {
+      try {
+        archive?.({ at: at.toISOString(), item });
+      } catch {
+        continue;
+      }
+      this.items.delete(item.id);
+      this.dropPrincipleVector(item.id);
+      removed.push(item);
+    }
+    return { removed, deferred: Math.max(0, candidates.length - removed.length) };
+  }
+
   snapshot() {
     return {
       short: this.byTier("short"),

--- a/src/outcome-store.js
+++ b/src/outcome-store.js
@@ -118,11 +118,12 @@ export class OutcomeStore {
 
   aggregate(windowDays = 7, filter = null) {
     const cutoff = Date.now() - windowDays * 24 * 3600 * 1000;
-    const list = [...this.outcomes.values()].filter((o) => {
+    const inWindow = [...this.outcomes.values()].filter((o) => {
       if (new Date(o.at).getTime() < cutoff) return false;
       if (filter && !filter(o)) return false;
       return true;
     });
+    const list = inWindow.filter(isQualityEligibleOutcome);
     const resolved = list.filter((o) => o.resolved && typeof o.qualityScore === "number");
     const avgQuality = resolved.length === 0 ? null : resolved.reduce((a, b) => a + b.qualityScore, 0) / resolved.length;
     const byKind = {};
@@ -132,6 +133,7 @@ export class OutcomeStore {
       total: list.length,
       resolved: resolved.length,
       pending: list.length - resolved.length,
+      excludedHousekeeping: inWindow.length - list.length,
       avgQuality: avgQuality === null ? null : Number(avgQuality.toFixed(3)),
       byKind
     };
@@ -247,6 +249,19 @@ export class OutcomeStore {
       this.outcomes = new Map([...pending, ...resolved].map((o) => [o.id, o]));
     }
   }
+}
+
+// Historical versions recorded every autonomous pulse as an outcome, even
+// when it only asked the scheduler for the next item or did nothing. Those
+// rows are valid operational audit history, but treating them as successful
+// work makes the quality score measure cron frequency instead of usefulness.
+// Keep them in the store/recent feed and exclude only from quality aggregates.
+export function isQualityEligibleOutcome(outcome = {}) {
+  if (typeof outcome.metadata?.qualityEligible === "boolean") return outcome.metadata.qualityEligible;
+  if (outcome.kind !== "autopilot-fire") return true;
+  const calls = Array.isArray(outcome.toolCalls) ? outcome.toolCalls : [];
+  if (calls.length === 0) return false;
+  return !calls.every((call) => call?.name === "agent_pick_next");
 }
 
 /**

--- a/test/backlog-triage.test.js
+++ b/test/backlog-triage.test.js
@@ -934,7 +934,7 @@ test("summarizeTriagePass is small and carries the counts that matter", async ()
 
 // ─── wiring ──────────────────────────────────────────────────────────────
 
-test("the runtime registers daily deterministic triage while model review stays weekly", async () => {
+test("the runtime registers daily bounded triage", async () => {
   const { createDurableRuntime } = await import("../src/abi-runtime.js");
   const runtime = createDurableRuntime({ dataDir: tempDataDir(), autoConnectMcp: false });
   const job = runtime.cron.listJobs().find((j) => j.id === "backlog-triage");
@@ -963,14 +963,16 @@ test("backlog hygiene stays at 05:45 after a late catch-up and disabled migratio
   assert.equal(cron.listJobs().find((entry) => entry.id === job.id).nextRunAt, null);
 });
 
-test("model review cadence is weekly even when deterministic cleanup runs daily", () => {
+test("model review cadence can run daily while preserving an explicit weekly interval", () => {
   const previous = "2026-07-27T05:15:00.000Z";
+  assert.equal(llmReviewDue(previous, new Date("2026-07-27T20:15:00.000Z"), 1), false);
+  assert.equal(llmReviewDue(previous, new Date("2026-07-28T05:15:00.000Z"), 1), true);
   assert.equal(llmReviewDue(previous, new Date("2026-07-28T05:15:00.000Z"), 7), false);
   assert.equal(llmReviewDue(previous, new Date("2026-08-03T05:15:00.000Z"), 7), true);
   assert.equal(llmReviewDue(null, NOW, 7), true);
 });
 
-test("daily passes keep deterministic cleanup active without paying for daily model review", async () => {
+test("daily passes keep deterministic cleanup and bounded model review active", async () => {
   const dir = tempDataDir();
   writeSuggestion(dir, observer("prop_ambiguous", { title: "Review the vendor agreement" }));
   const provider = stubProvider((items) => items.map((item) => ({
@@ -992,8 +994,8 @@ test("daily passes keep deterministic cleanup active without paying for daily mo
     proposedAt: new Date(NOW.getTime() - 40 * DAY).toISOString()
   }));
   const second = await triage.run({ now: new Date(NOW.getTime() + DAY) });
-  assert.equal(second.llm.skipped, "cadence");
-  assert.equal(provider.calls.length, 0, "daily cleanup does not become a daily model bill");
+  assert.equal(second.llm.skipped, null);
+  assert.equal(provider.calls.length, 1, "the next bounded slice advances each day");
   assert.equal(second.applied.suggestions, 1, "safe deterministic retirement still runs daily");
 });
 

--- a/test/memory-maintenance.test.js
+++ b/test/memory-maintenance.test.js
@@ -223,3 +223,29 @@ test("daily condenser runs bounded duplicate maintenance before principle cluste
   assert.equal(memory.items.size, 1);
   assert.equal(result.principles, 0);
 });
+
+test("daily condenser retires only old weak automated noise with a content-free recovery receipt", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-memory-weak-noise-"));
+  const memory = new FileBackedMemorySystem({ dir, autoLoad: false });
+  const old = "2026-06-01T00:00:00.000Z";
+  memory.remember({ source: "agent-host", content: "low value internal runtime trace" }, {
+    id: "weak", tier: "medium", strength: 0.2, now: old
+  });
+  memory.remember({ source: "local", content: "explicit preference", tags: ["tool:remember"] }, {
+    id: "protected", tier: "medium", strength: 0.1, now: old
+  });
+  memory.remember({ source: "agent-host", content: "repeated useful evidence", repetition: 0.8 }, {
+    id: "repeated", tier: "medium", strength: 0.2, now: old
+  });
+
+  const condenser = new MemoryCondenser({ runtime: { memory }, minGroupSize: 99 });
+  const result = await condenser.condense({ now: new Date("2026-08-18T00:00:00.000Z") });
+  assert.equal(result.weakNoiseRetired, 1);
+  assert.equal(memory.items.has("weak"), false);
+  assert.equal(memory.items.has("protected"), true);
+  assert.equal(memory.items.has("repeated"), true);
+  const receipt = fs.readFileSync(memory.duplicateArchivePath, "utf8").trim().split("\n").map(JSON.parse)
+    .find((entry) => entry.op === "retire-weak-automated-memory");
+  assert.equal(receipt.removedId, "weak");
+  assert.doesNotMatch(JSON.stringify(receipt), /low value internal runtime trace/);
+});

--- a/test/outcome-quality.test.js
+++ b/test/outcome-quality.test.js
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { OutcomeStore, scoreFromToolCalls } from "../src/outcome-store.js";
+import { OutcomeStore, isQualityEligibleOutcome, scoreFromToolCalls } from "../src/outcome-store.js";
 import { SkillRegistry } from "../src/skills.js";
 
 test("scoreFromToolCalls grades runs by per-call ok flags", () => {
@@ -67,6 +67,21 @@ test("resolveSweep still scores a quiet old cron fire 0.5", () => {
   assert.equal(sweep[0].id, quiet.id);
   assert.equal(sweep[0].score, 0.5);
   assert.equal(sweep[0].source, "system-inferred");
+});
+
+test("quality aggregates exclude legacy no-op autopilot pulses without deleting audit history", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-outcome-housekeeping-"));
+  const store = new OutcomeStore({ dir });
+  store.record({ kind: "autopilot-fire", toolCalls: [] });
+  store.record({ kind: "autopilot-fire", toolCalls: [{ name: "agent_pick_next", ok: true }] });
+  store.record({ kind: "autopilot-fire", toolCalls: [{ name: "add_task", ok: true }] });
+  store.record({ kind: "agent-reply", toolCalls: [] });
+
+  const aggregate = store.aggregate(30);
+  assert.equal(store.recent(10).length, 4, "audit history stays intact");
+  assert.equal(aggregate.total, 2);
+  assert.equal(aggregate.excludedHousekeeping, 2);
+  assert.equal(isQualityEligibleOutcome({ kind: "autopilot-fire", metadata: { qualityEligible: false }, toolCalls: [{ name: "add_task" }] }), false);
 });
 
 test("skill run grades completion by tool-call results; tool-free run keeps 0.7", async () => {


### PR DESCRIPTION
## Summary
- keep legacy scheduler/no-op outcomes as audit history while excluding them from usefulness scores
- retire only old, weak, low-risk automated memory noise in bounded daily passes with content-free recovery receipts
- rotate the bounded, budget-aware review backlog through model relevance checks daily, with a seven-day backoff after provider failures

## Safety and privacy
- no installation-specific names, hosts, paths, credentials, or private content
- explicit user memories, corrections, principles, repeated evidence, and recent/strong memories are protected
- retirement is capped and archived before atomic snapshot persistence
- task records are not conflated with drafts or suggestions

## Verification
- bundled Node full suite: 999 passed, 0 failed
- focused cron/review/memory/outcome suite: 93 passed, 0 failed
- git diff --check
- staged public-repo secret/scope guard passed