### PR TITLE
Prepare v0.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagi",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "description": "Generic ABI runtime scaffold for directional adaptive scrutiny, tiered memory, and propagation.",


### PR DESCRIPTION
## Release contents
- signed-daemon iMessage bridge and scoped paired-node search/capture path (#62)
- bounded legacy review, memory, and outcome quality rehabilitation (#63)
- optional fail-closed Cua Driver Computer Use backend (#64)

## Verification
- feature full suite: 1003 passed, 0 failed
- Mac release workflow contract: 2 passed, 0 failed
- staged safety guard and diff check passed