### PR TITLE
Prepare v0.0.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagi",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "private": true,
   "type": "module",
   "description": "Generic ABI runtime scaffold for directional adaptive scrutiny, tiered memory, and propagation.",


### PR DESCRIPTION
Follow-up Mac migration release: safely retires repository-owned legacy iMessage LaunchAgents and supports persisted encrypted-tunnel relay assertions.

Verification: Swift 28/28; focused Node 28/28; Mac release contract 2/2; staged safety guard passed.