### PR TITLE
Release v0.0.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagi",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "private": true,
   "type": "module",
   "description": "Generic ABI runtime scaffold for directional adaptive scrutiny, tiered memory, and propagation.",


### PR DESCRIPTION
Prepare v0.0.16 with the encrypted-relay timeout fix from #68.

Verification:
- `test/mac-release-workflow.test.js` (2/2)
- staged secret/large-file safety guard
- `git diff --check`