### PR TITLE
Retire inactive automated knowledge safely

### DIFF
--- a/src/backlog-triage.js
+++ b/src/backlog-triage.js
@@ -91,6 +91,10 @@ const DEFAULTS = {
   freshDays: 7,
   // Below this age nothing is ever auto-retired by the weak-evidence rule.
   staleDays: 30,
+  // A mined workflow is evidence-backed only while it continues to occur.
+  // Once its own occurrence ledger has been quiet for this long, retirement
+  // is based on measured non-recurrence rather than proposal age alone.
+  staleRecurrenceDays: 30,
   // Title-token Jaccard at which two observer suggestions are treated as the
   // same ask. Tuned against the real queue: 0.65 collapses "Run the agent
   // autopilot pulse" into "Run the next agent autopilot pulse" and leaves
@@ -191,6 +195,7 @@ export class BacklogTriage {
     this.options = {
       freshDays: envNumber("OPENAGI_BACKLOG_TRIAGE_FRESH_DAYS", DEFAULTS.freshDays),
       staleDays: envNumber("OPENAGI_BACKLOG_TRIAGE_STALE_DAYS", DEFAULTS.staleDays),
+      staleRecurrenceDays: envNumber("OPENAGI_BACKLOG_TRIAGE_STALE_RECURRENCE_DAYS", DEFAULTS.staleRecurrenceDays),
       duplicateThreshold: DEFAULTS.duplicateThreshold,
       maxLlmItems: envNumber("OPENAGI_BACKLOG_TRIAGE_MAX_LLM", DEFAULTS.maxLlmItems),
       batchSize: envNumber("OPENAGI_BACKLOG_TRIAGE_BATCH", DEFAULTS.batchSize),
@@ -253,6 +258,7 @@ export class BacklogTriage {
       now: startedAt,
       freshDays: this.options.freshDays,
       staleDays: this.options.staleDays,
+      staleRecurrenceDays: this.options.staleRecurrenceDays,
       duplicateThreshold: this.options.duplicateThreshold
     });
 
@@ -669,6 +675,7 @@ export class BacklogTriage {
 export function classifyDeterministic({
   suggestions = [], drafts = [], taskIndex = new Map(), now = new Date(),
   freshDays = DEFAULTS.freshDays, staleDays = DEFAULTS.staleDays,
+  staleRecurrenceDays = DEFAULTS.staleRecurrenceDays,
   duplicateThreshold = DEFAULTS.duplicateThreshold
 } = {}) {
   const nowMs = now instanceof Date ? now.getTime() : new Date(now).getTime();
@@ -768,6 +775,27 @@ export function classifyDeterministic({
       resolved.push(makeResolution(s, nowMs, "weak-mined-evidence",
         `Mined pattern never recurred: seen ${seq.count ?? 0}× across ${seq.distinctDays ?? 0} day(s), confidence ${fmt(seq.confidence)}.`,
         { count: seq.count ?? null, distinctDays: seq.distinctDays ?? null, confidence: seq.confidence ?? null, ageDays: round1(ageDays) }));
+      continue;
+    }
+    const lastOccurrenceAt = latestOccurrenceAt(seq?.occurrences);
+    const daysSinceLastOccurrence = Number.isFinite(lastOccurrenceAt)
+      ? (nowMs - lastOccurrenceAt) / DAY_MS
+      : null;
+    if (
+      seq
+      && ageDays >= staleDays
+      && daysSinceLastOccurrence !== null
+      && daysSinceLastOccurrence >= staleRecurrenceDays
+    ) {
+      resolved.push(makeResolution(s, nowMs, "stale-mined-nonrecurrence",
+        `Mined pattern has not recurred for ${Math.floor(daysSinceLastOccurrence)} days, despite a ${seq.count ?? 0}-occurrence history.`,
+        {
+          count: seq.count ?? null,
+          distinctDays: seq.distinctDays ?? null,
+          lastOccurrenceAt: new Date(lastOccurrenceAt).toISOString(),
+          daysSinceLastOccurrence: round1(daysSinceLastOccurrence),
+          ageDays: round1(ageDays)
+        }));
       continue;
     }
     ambiguous.push(toCandidate(s, ageDays));
@@ -881,6 +909,16 @@ function weakEvidence(seq) {
   return (Number.isFinite(confidence) && confidence < 0.5)
     || (Number.isFinite(count) && count < 3)
     || (Number.isFinite(days) && days < 2);
+}
+
+function latestOccurrenceAt(occurrences) {
+  if (!Array.isArray(occurrences)) return Number.NaN;
+  let latest = Number.NEGATIVE_INFINITY;
+  for (const occurrence of occurrences) {
+    const at = Date.parse(occurrence ?? "");
+    if (Number.isFinite(at) && at > latest) latest = at;
+  }
+  return latest;
 }
 
 // ─── ranking the survivors ───────────────────────────────────────────────

--- a/src/memory-system.js
+++ b/src/memory-system.js
@@ -13,6 +13,9 @@ const DEFAULT_TTL_MS = {
 };
 
 const DECAY_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const AUTOMATED_MEMORY_SOURCES = new Set([
+  "agent-host", "ambient-digest", "autopilot", "condenser", "daily-plan", "daily-recap", "runtime"
+]);
 
 // These memories exist because the user explicitly asked OpenAGI to retain
 // them (or approved a knowledge suggestion). They are never admission-deduped
@@ -471,6 +474,7 @@ export class MemorySystem {
     maxRemovals = 100,
     minAgeDays = 30,
     maxStrength = 0.25,
+    maxInactiveStrength = 0.4,
     archive = null,
     now = new Date()
   } = {}) {
@@ -481,15 +485,30 @@ export class MemorySystem {
     const candidates = [...this.items.values()]
       .filter((item) => {
         const lastEvidence = Date.parse(item.lastObservedAt ?? item.lastAccessedAt ?? item.createdAt ?? "");
-        return !isProtectedMemory(item)
-          && item.kind !== "principle"
-          && !item.metadata?.supersededBy
+        const lastRecall = Date.parse(item.lastAccessedAt ?? item.createdAt ?? "");
+        const strictlyLowSignal = item.kind !== "principle"
           && Number(item.strength ?? 0) <= maxStrength
           && Number(item.risk ?? 0) < 0.3
           && Number(item.novelty ?? 0) < 0.3
-          && Number(item.repetition ?? 0) < 0.2
+          && Number(item.repetition ?? 0) < 0.2;
+        const source = String(item.source ?? "");
+        const syntheticCondenserPrinciple = source === "condenser" && item.kind === "principle";
+        const inactiveAutomated = AUTOMATED_MEMORY_SOURCES.has(source)
+          && Number(item.strength ?? 0) < maxInactiveStrength
+          && Number(item.dangerLevel ?? 0) < 0.75
+          // Strong recurrence remains evidence even when recall is quiet. The
+          // legacy low-signal path above already requires <0.2. Condenser
+          // principles are the exception: the condenser assigns 0.8 to every
+          // output as a construction default, so that value is not independent
+          // evidence that this particular principle kept recurring.
+          && (syntheticCondenserPrinciple || Number(item.repetition ?? 0) < 0.8)
+          && Number.isFinite(lastRecall)
+          && lastRecall < cutoff;
+        return !isProtectedMemory(item)
+          && !item.metadata?.supersededBy
           && Number.isFinite(lastEvidence)
-          && lastEvidence < cutoff;
+          && lastEvidence < cutoff
+          && (strictlyLowSignal || inactiveAutomated);
       })
       .sort((a, b) => String(a.lastObservedAt ?? a.createdAt).localeCompare(String(b.lastObservedAt ?? b.createdAt)));
 

--- a/test/backlog-triage.test.js
+++ b/test/backlog-triage.test.js
@@ -310,6 +310,36 @@ test("a weak mined pattern younger than the stale window is never retired by rul
   assert.deepEqual(ambiguous.map((a) => a.id), ["sug_weak"]);
 });
 
+test("a strong mined pattern retires only when its own occurrence ledger stopped recurring", () => {
+  const proposedAt = new Date(NOW.getTime() - 60 * DAY).toISOString();
+  const recentOccurrence = new Date(NOW.getTime() - 5 * DAY).toISOString();
+  const staleOccurrence = new Date(NOW.getTime() - 45 * DAY).toISOString();
+  const { resolved, ambiguous } = classifyDeterministic({
+    suggestions: [
+      mined("sug_stale", {
+        fingerprint: "a→b",
+        proposedAt,
+        sequence: { count: 30, distinctDays: 9, confidence: 0.99, occurrences: [staleOccurrence] }
+      }),
+      mined("sug_recurring", {
+        fingerprint: "c→d",
+        proposedAt,
+        sequence: { count: 30, distinctDays: 9, confidence: 0.99, occurrences: [staleOccurrence, recentOccurrence] }
+      }),
+      mined("sug_no_ledger", {
+        fingerprint: "e→f",
+        proposedAt,
+        sequence: { count: 30, distinctDays: 9, confidence: 0.99 }
+      })
+    ],
+    now: NOW
+  });
+  assert.deepEqual(resolved.map((item) => item.id), ["sug_stale"]);
+  assert.equal(resolved[0].rule, "stale-mined-nonrecurrence");
+  assert.equal(resolved[0].evidence.daysSinceLastOccurrence, 45);
+  assert.deepEqual(ambiguous.map((item) => item.id).sort(), ["sug_no_ledger", "sug_recurring"]);
+});
+
 test("only superseded re-drafts are retired — a completed parent task never justifies it", () => {
   // The trap this guards: for a draft-only task, "completed" means the AGENT
   // finished the draft, not that the user acted on it. Pending drafts can

--- a/test/memory-maintenance.test.js
+++ b/test/memory-maintenance.test.js
@@ -249,3 +249,25 @@ test("daily condenser retires only old weak automated noise with a content-free 
   assert.equal(receipt.removedId, "weak");
   assert.doesNotMatch(JSON.stringify(receipt), /low value internal runtime trace/);
 });
+
+test("daily condenser retires inactive weak automated principles but preserves danger and user evidence", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-memory-inactive-noise-"));
+  const memory = new FileBackedMemorySystem({ dir, autoLoad: false });
+  const old = "2026-06-01T00:00:00.000Z";
+  memory.remember({ source: "condenser", kind: "principle", content: "old automated principle", repetition: 0.8 }, {
+    id: "inactive-principle", tier: "long", strength: 0.35, now: old
+  });
+  memory.remember({ source: "condenser", kind: "principle", content: "dangerous specific principle", risk: 1, specificity: 1 }, {
+    id: "danger-principle", tier: "long", strength: 0.35, now: old
+  });
+  memory.remember({ source: "local", content: "explicit preference", tags: ["tool:remember"] }, {
+    id: "protected", tier: "medium", strength: 0.1, now: old
+  });
+
+  const condenser = new MemoryCondenser({ runtime: { memory }, minGroupSize: 99 });
+  const result = await condenser.condense({ now: new Date("2026-08-18T00:00:00.000Z") });
+  assert.equal(result.weakNoiseRetired, 1);
+  assert.equal(memory.items.has("inactive-principle"), false);
+  assert.equal(memory.items.has("danger-principle"), true);
+  assert.equal(memory.items.has("protected"), true);
+});


### PR DESCRIPTION
Improve maintenance effectiveness without using age alone or deleting user-authored data.

- Retire mined workflow suggestions only when their own occurrence ledger has been quiet for 30 days.
- Retire weak automated memories only after 30 days without observation or recall.
- Preserve explicit memories, corrections, imports, high-danger evidence, recent recurrence, and genuine high-repetition evidence.
- Keep existing recoverable statuses and content-free archive receipts.

Live read-only dry run: 44 stale mined suggestions and 29 inactive condenser principles eligible; zero user tasks are touched.

Verification: 220/220 maintenance, memory, cron, and runtime tests; `git diff --check`; staged secret/large-file guard.