### PR TITLE
Surface macOS permission controls

### DIFF
--- a/mac/Sources/OpenAGI/Capture/CapturePermissions.swift
+++ b/mac/Sources/OpenAGI/Capture/CapturePermissions.swift
@@ -387,6 +387,22 @@ final class CapturePermissions: ObservableObject {
          watchForGrant: false)
   }
 
+  /// Accessibility has its own explicit prompt API. Keep it behind a literal
+  /// user action just like Screen Recording so ordinary status refreshes never
+  /// produce recurring system prompts.
+  func requestAccessibilityFromPermissionButton() {
+    let key = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
+    let options = [key: true] as CFDictionary
+    accessibilityGranted = AXIsProcessTrustedWithOptions(options)
+  }
+
+  /// macOS exposes no request API for Full Disk Access. The only honest
+  /// recovery path is the system pane where the user can enable the signed app.
+  func openFullDiskAccessSettings() {
+    open("x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
+         watchForGrant: false)
+  }
+
   private func open(_ urlString: String, watchForGrant: Bool = true) {
     guard let url = URL(string: urlString) else { return }
     NSWorkspace.shared.open(url)

--- a/mac/Sources/OpenAGI/PrivacyPanel.swift
+++ b/mac/Sources/OpenAGI/PrivacyPanel.swift
@@ -186,7 +186,12 @@ struct PrivacyPanel: View {
         detail: permissions.screenRecordingGranted
           ? "Screen frames + OCR are running."
           : "Screen capture is OFF. Turn it on in System Settings, then switch back here. If it still says OFF, use Request Permission from the tray's Capture menu or quit and reopen OpenAGI.",
-        action: { permissions.openScreenRecordingSettings() })
+        requestLabel: "Request Permission",
+        requestAction: {
+          permissions.requestScreenRecordingFromPermissionButton()
+          permissions.beginWatchingForGrant()
+        },
+        settingsAction: { permissions.openScreenRecordingSettings() })
 
       permissionRow(
         name: "Accessibility",
@@ -199,7 +204,14 @@ struct PrivacyPanel: View {
         detail: permissions.accessibilityGranted
           ? "Window titles are recorded alongside app names."
           : "Optional. Without it, activity is recorded with app names but no window titles. Window-title exclusions still apply during capture — those titles come from the window list, not Accessibility.",
-        action: { permissions.openAccessibilitySettings() })
+        requestLabel: "Request Permission",
+        requestAction: { permissions.requestAccessibilityFromPermissionButton() },
+        settingsAction: { permissions.openAccessibilitySettings() })
+
+      permissionLinkRow(
+        name: "Full Disk Access",
+        detail: "Required for iMessage history search and the paired-node conversation bridge. macOS does not provide a permission prompt for this access; enable OpenAGI in System Settings, then quit and reopen it.",
+        action: { permissions.openFullDiskAccessSettings() })
 
       if let failure = permissions.lastCaptureFailure {
         Text("⚠ \(failure)")
@@ -210,7 +222,14 @@ struct PrivacyPanel: View {
     }
   }
 
-  private func permissionRow(name: String, granted: Bool, detail: String, action: @escaping () -> Void) -> some View {
+  private func permissionRow(
+    name: String,
+    granted: Bool,
+    detail: String,
+    requestLabel: String,
+    requestAction: @escaping () -> Void,
+    settingsAction: @escaping () -> Void
+  ) -> some View {
     VStack(alignment: .leading, spacing: 4) {
       HStack {
         Image(systemName: granted ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
@@ -220,7 +239,27 @@ struct PrivacyPanel: View {
           .font(.caption)
           .foregroundColor(granted ? .secondary : .orange)
         Spacer()
-        Button("Open System Settings…", action: action)
+        if !granted { Button(requestLabel, action: requestAction) }
+        Button("Open Settings…", action: settingsAction)
+      }
+      Text(detail)
+        .font(.caption)
+        .foregroundColor(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+  }
+
+  private func permissionLinkRow(name: String, detail: String, action: @escaping () -> Void) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack {
+        Image(systemName: "externaldrive.badge.questionmark")
+          .foregroundColor(.secondary)
+        Text(name).bold()
+        Text("Check in System Settings")
+          .font(.caption)
+          .foregroundColor(.secondary)
+        Spacer()
+        Button("Open Settings…", action: action)
       }
       Text(detail)
         .font(.caption)

--- a/mac/Sources/OpenAGI/TrayController.swift
+++ b/mac/Sources/OpenAGI/TrayController.swift
@@ -222,6 +222,7 @@ struct TrayMenu: View {
       Button("Open health audit…") { state.openDashboard(path: "/?tab=health") }
       Button("Open activity log…") { state.openDashboard(path: "/?tab=activity") }
       Button("Settings…") { state.openDashboard(path: "/setup") }
+      Button("Permissions & privacy…") { PrivacyWindowController.shared.show() }
       Button("Copy auth token") { copyAuthToken() }
 
       Divider()


### PR DESCRIPTION
Make required macOS permissions discoverable from the OpenAGI menu.

- Add top-level Permissions & privacy entry.
- Add deliberate Request Permission actions for Screen Recording and Accessibility.
- Add a Full Disk Access row linking to the only settings pane macOS provides.
- Keep status refreshes non-prompting; permission dialogs only follow explicit user clicks.

Verification: `cd mac && swift test` (28/28), `git diff --check`, staged secret/large-file guard.