### PR TITLE
Release v0.0.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagi",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "private": true,
   "type": "module",
   "description": "Generic ABI runtime scaffold for directional adaptive scrutiny, tiered memory, and propagation.",


### PR DESCRIPTION
Prepare v0.0.18 with the explicit macOS permission controls from #72.

Verification:
- `test/mac-release-workflow.test.js` (2/2)
- staged secret/large-file guard
- `git diff --check`