### PR TITLE
Computer History: add an OCR-backed day and hour timeline

### DIFF
--- a/mac/Sources/OpenAGI/AppDelegate.swift
+++ b/mac/Sources/OpenAGI/AppDelegate.swift
@@ -36,6 +36,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
       HotkeyManager.shared.onHotkey = { OverlayController.shared.toggle() }
       HotkeyManager.shared.register()
 
+      // Support and automated verification need a deterministic way to open
+      // the native permission/retention surface in this dockless menu-bar app.
+      // `open OpenAGI.app --args --show-permissions` does not change a setting;
+      // it only reveals the same panel as the tray-menu item.
+      if ProcessInfo.processInfo.arguments.contains("--show-permissions") {
+        PrivacyWindowController.shared.show()
+      }
+
       // Start the durable outreach consumer if a remote main is configured.
       // Backfills from the persisted cursor so nothing queued while the app was
       // closed is lost.

--- a/mac/Sources/OpenAGI/Capture/CaptureHealth.swift
+++ b/mac/Sources/OpenAGI/Capture/CaptureHealth.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+enum CaptureHealthState: Equatable {
+  case disabled
+  case paused(until: Date)
+  case permissionRequired
+  case waitingForFirstFrame
+  case healthy(latestFrameAt: Date)
+  case stale(latestFrameAt: Date)
+}
+
+/// A permission grant and an enabled toggle are prerequisites, not proof that
+/// screenshots are being persisted. This pure evaluator keeps the UI honest by
+/// requiring a recent saved frame before it calls capture healthy.
+enum CaptureHealth {
+  nonisolated static func evaluate(
+    enabled: Bool,
+    pausedUntil: Date?,
+    screenRecordingGranted: Bool,
+    latestFrameAt: Date?,
+    captureIntervalSeconds: Double,
+    now: Date = Date()
+  ) -> CaptureHealthState {
+    guard enabled else { return .disabled }
+    if let pausedUntil, pausedUntil > now { return .paused(until: pausedUntil) }
+    guard screenRecordingGranted else { return .permissionRequired }
+    guard let latestFrameAt else { return .waitingForFirstFrame }
+
+    // Allow several capture intervals plus OCR/storage time before declaring a
+    // failure. A hard 60-second floor avoids noisy state changes at the default
+    // five-second interval while still detecting a dead timer promptly.
+    let freshnessBudget = max(60, captureIntervalSeconds * 6)
+    if now.timeIntervalSince(latestFrameAt) <= freshnessBudget {
+      return .healthy(latestFrameAt: latestFrameAt)
+    }
+    return .stale(latestFrameAt: latestFrameAt)
+  }
+}

--- a/mac/Sources/OpenAGI/Capture/CaptureSettings.swift
+++ b/mac/Sources/OpenAGI/Capture/CaptureSettings.swift
@@ -49,6 +49,13 @@ enum CaptureDecision: Equatable {
 final class CaptureSettings: ObservableObject {
   static let shared = CaptureSettings()
 
+  /// Screenshots are the most sensitive and storage-heavy capture artifact.
+  /// Keep a short, useful default while letting the user opt into a longer
+  /// local history from Capture Privacy. Existing persisted choices are never
+  /// overwritten by this default.
+  nonisolated static let defaultFrameRetentionDays = 1
+  nonisolated static let frameRetentionPresets = [1, 3, 7, 30, 90]
+
   @Published var enabled: Bool {
     didSet { persist() }
   }
@@ -230,7 +237,9 @@ final class CaptureSettings: ObservableObject {
     self.appliedDefaultBundleIds = Self.defaultExcludedBundleIds
     self.appliedDefaultWindowPatterns = Self.defaultExcludedWindowPatterns
 
-    self.frameRetentionDays = (loaded["frameRetentionDays"] as? Int) ?? 7
+    self.frameRetentionDays = max(
+      1,
+      (loaded["frameRetentionDays"] as? Int) ?? Self.defaultFrameRetentionDays)
     self.textRetentionDays = (loaded["textRetentionDays"] as? Int) ?? 90
     self.maxDiskBytes = (loaded["maxDiskBytes"] as? Int) ?? (5 * 1024 * 1024 * 1024)
 

--- a/mac/Sources/OpenAGI/Capture/CaptureStorage.swift
+++ b/mac/Sources/OpenAGI/Capture/CaptureStorage.swift
@@ -1,6 +1,23 @@
 import Foundation
 import SQLite3
 
+struct CaptureStats: Equatable {
+  let frames: Int
+  let activity: Int
+  let storedThumbnails: Int
+  let diskBytes: Int
+  let latestFrameAt: Date?
+  let latestActivityAt: Date?
+
+  static let empty = CaptureStats(
+    frames: 0,
+    activity: 0,
+    storedThumbnails: 0,
+    diskBytes: 0,
+    latestFrameAt: nil,
+    latestActivityAt: nil)
+}
+
 // Local SQLite store for captured frames + activity. The OCR text and
 // activity events get pushed to the daemon via Bridge for cross-machine
 // recall; this local store is the source of truth for thumbnails and
@@ -159,12 +176,20 @@ final class CaptureStorage {
     }
   }
 
-  func stats() -> (frames: Int, activity: Int, diskBytes: Int) {
+  func stats() -> CaptureStats {
     queue.sync {
       let f = scalarInt("SELECT COUNT(*) FROM frames")
       let a = scalarInt("SELECT COUNT(*) FROM activity")
+      let thumbnails = scalarInt(
+        "SELECT COUNT(*) FROM frames WHERE thumbnail_path IS NOT NULL AND length(trim(thumbnail_path)) > 0")
       let bytes = directorySize(at: CaptureSettings.captureDir)
-      return (f, a, bytes)
+      return CaptureStats(
+        frames: f,
+        activity: a,
+        storedThumbnails: thumbnails,
+        diskBytes: bytes,
+        latestFrameAt: latestStoredThumbnailDate(),
+        latestActivityAt: scalarDate("SELECT MAX(at) FROM activity"))
     }
   }
 
@@ -199,6 +224,28 @@ final class CaptureStorage {
 
       let delT = "DELETE FROM texts WHERE frame_uid NOT IN (SELECT frame_uid FROM frames)"
       sqlite3_exec(db, delT, nil, nil, nil)
+
+      // A crash between writing a JPEG and recording its row can leave an
+      // orphan that SQL retention will never see. Sweep only files older than
+      // the same cutoff; a just-written image is never touched even if its row
+      // is still waiting on OCR.
+      _ = Self.removeExpiredThumbnails(
+        in: CaptureSettings.captureDir.appendingPathComponent("thumbnails"),
+        olderThan: framesOlderThan)
+
+      // DELETE releases SQLite pages for reuse but does not shrink the file or
+      // erase free pages. Compact only after enough space has accumulated to
+      // justify the I/O; this keeps retention truthful without vacuuming every
+      // six-hour maintenance tick.
+      let pageCount = scalarInt("PRAGMA page_count")
+      let freePages = scalarInt("PRAGMA freelist_count")
+      let pageSize = scalarInt("PRAGMA page_size")
+      if Self.shouldCompactDatabase(
+        pageCount: pageCount,
+        freePages: freePages,
+        pageSize: pageSize) {
+        sqlite3_exec(db, "VACUUM", nil, nil, nil)
+      }
     }
   }
 
@@ -217,6 +264,68 @@ final class CaptureStorage {
     guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return 0 }
     if sqlite3_step(stmt) == SQLITE_ROW { return Int(sqlite3_column_int64(stmt, 0)) }
     return 0
+  }
+
+  private func scalarDate(_ sql: String) -> Date? {
+    var stmt: OpaquePointer?
+    defer { sqlite3_finalize(stmt) }
+    guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK,
+          sqlite3_step(stmt) == SQLITE_ROW,
+          let raw = columnText(stmt, 0) else { return nil }
+    return ISO8601DateFormatter().date(from: raw)
+  }
+
+  /// The database path is not enough: older builds recorded the intended path
+  /// even when JPEG encoding or the write failed. Check a bounded set of the
+  /// newest candidates so the UI only calls capture healthy when an image can
+  /// actually be opened from disk.
+  private func latestStoredThumbnailDate() -> Date? {
+    let sql = """
+      SELECT captured_at, thumbnail_path FROM frames
+      WHERE thumbnail_path IS NOT NULL AND length(trim(thumbnail_path)) > 0
+      ORDER BY captured_at DESC LIMIT 100
+      """
+    var stmt: OpaquePointer?
+    defer { sqlite3_finalize(stmt) }
+    guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return nil }
+    while sqlite3_step(stmt) == SQLITE_ROW {
+      guard let rawDate = columnText(stmt, 0),
+            let path = columnText(stmt, 1),
+            FileManager.default.isReadableFile(atPath: path),
+            let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+            let size = attrs[.size] as? NSNumber,
+            size.int64Value > 0 else { continue }
+      if let date = ISO8601DateFormatter().date(from: rawDate) { return date }
+    }
+    return nil
+  }
+
+  @discardableResult
+  nonisolated static func removeExpiredThumbnails(in directory: URL, olderThan cutoff: Date) -> Int {
+    let keys: Set<URLResourceKey> = [.isRegularFileKey, .contentModificationDateKey]
+    guard let files = try? FileManager.default.contentsOfDirectory(
+      at: directory,
+      includingPropertiesForKeys: Array(keys),
+      options: [.skipsHiddenFiles]) else { return 0 }
+    var removed = 0
+    for file in files where file.pathExtension.lowercased() == "jpg" {
+      guard let values = try? file.resourceValues(forKeys: keys),
+            values.isRegularFile == true,
+            let modified = values.contentModificationDate,
+            modified < cutoff else { continue }
+      if (try? FileManager.default.removeItem(at: file)) != nil { removed += 1 }
+    }
+    return removed
+  }
+
+  nonisolated static func shouldCompactDatabase(
+    pageCount: Int,
+    freePages: Int,
+    pageSize: Int
+  ) -> Bool {
+    guard pageCount > 0, freePages > 0, pageSize > 0 else { return false }
+    let freeBytes = Int64(freePages) * Int64(pageSize)
+    return freeBytes >= 16 * 1024 * 1024 && freePages * 4 >= pageCount
   }
 }
 

--- a/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
+++ b/mac/Sources/OpenAGI/Capture/ScreenCapturer.swift
@@ -152,7 +152,11 @@ final class ScreenCapturer {
 
       // Thumbnail (640px wide max, JPEG 50%) — best-effort.
       let thumbPath = thumbnailsDir.appendingPathComponent("\(uid).jpg").path
-      _ = saveThumbnail(image: nsImage, to: thumbPath, maxWidth: 640, quality: 0.5)
+      let savedThumbnailPath = saveThumbnail(
+        image: nsImage,
+        to: thumbPath,
+        maxWidth: 640,
+        quality: 0.5) ? thumbPath : nil
 
       // OCR off the main thread.
       ocrQueue.async {
@@ -162,7 +166,10 @@ final class ScreenCapturer {
             capturedAt: Date(),
             app: appName,
             window: windowTitle,
-            thumbnailPath: thumbPath,
+            // Never persist a path to an image that was not actually written.
+            // Capture health and history use this field as evidence that a
+            // recoverable screenshot exists, not merely that OCR ran.
+            thumbnailPath: savedThumbnailPath,
             ocrText: text,
             confidence: confidence
           )

--- a/mac/Sources/OpenAGI/PrivacyPanel.swift
+++ b/mac/Sources/OpenAGI/PrivacyPanel.swift
@@ -33,7 +33,7 @@ final class PrivacyWindowController {
 struct PrivacyPanel: View {
   @ObservedObject private var settings = CaptureSettings.shared
   @ObservedObject private var permissions = CapturePermissions.shared
-  @State private var stats: (frames: Int, activity: Int, diskBytes: Int) = (0, 0, 0)
+  @State private var stats = CaptureStats.empty
   @State private var newBundleId: String = ""
   @State private var newPattern: String = ""
   @State private var statsTimer: Timer?
@@ -65,6 +65,7 @@ struct PrivacyPanel: View {
             }
             Spacer()
           }
+          captureHealthRow
         }
 
         section(title: "Frequency") {
@@ -129,11 +130,19 @@ struct PrivacyPanel: View {
 
         section(title: "Retention") {
           HStack {
-            Text("Frames + thumbnails kept for")
-            Stepper(value: $settings.frameRetentionDays, in: 1...90) {
-              Text("\(settings.frameRetentionDays) days").monospacedDigit()
+            Text("Screenshot history")
+            Spacer()
+            Picker("Screenshot history", selection: $settings.frameRetentionDays) {
+              ForEach(frameRetentionOptions, id: \.self) { days in
+                Text(frameRetentionLabel(days)).tag(days)
+              }
             }
+            .labelsHidden()
+            .pickerStyle(.menu)
           }
+          Text("JPEG thumbnails stay only on this Mac. The default is 24 hours; longer options trade privacy and disk space for more visual recall.")
+            .font(.caption).foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
           HStack {
             Text("OCR text + activity kept for")
             Stepper(value: $settings.textRetentionDays, in: 7...365) {
@@ -144,9 +153,16 @@ struct PrivacyPanel: View {
 
         section(title: "Storage") {
           HStack {
-            stat("Frames", "\(stats.frames)")
+            stat("Screenshots", "\(stats.storedThumbnails)")
             stat("Activity events", "\(stats.activity)")
             stat("Disk usage", formatBytes(stats.diskBytes))
+          }
+          HStack {
+            Text("Last screenshot")
+              .font(.caption).foregroundColor(.secondary)
+            Spacer()
+            Text(relativeDate(stats.latestFrameAt, empty: "Never"))
+              .font(.caption).monospacedDigit()
           }
           HStack {
             Button(role: .destructive) {
@@ -184,7 +200,7 @@ struct PrivacyPanel: View {
         // it "resumes automatically" and then leaving capture off is exactly the
         // kind of confident-but-wrong claim this panel exists to eliminate.
         detail: permissions.screenRecordingGranted
-          ? "Screen frames + OCR are running."
+          ? "Screen Recording is available. The live capture status below confirms whether screenshots are actually being saved."
           : "Screen capture is OFF. Turn it on in System Settings, then switch back here. If it still says OFF, use Request Permission from the tray's Capture menu or quit and reopen OpenAGI.",
         requestLabel: "Request Permission",
         requestAction: {
@@ -220,6 +236,77 @@ struct PrivacyPanel: View {
           .fixedSize(horizontal: false, vertical: true)
       }
     }
+  }
+
+  private var captureHealthRow: some View {
+    let health = CaptureHealth.evaluate(
+      enabled: settings.enabled,
+      pausedUntil: settings.pausedUntil,
+      screenRecordingGranted: permissions.screenRecordingGranted,
+      latestFrameAt: stats.latestFrameAt,
+      captureIntervalSeconds: settings.captureIntervalSeconds)
+    return HStack(alignment: .top, spacing: 8) {
+      Image(systemName: captureHealthIsHealthy(health)
+        ? "checkmark.circle.fill"
+        : "exclamationmark.triangle.fill")
+        .foregroundColor(captureHealthIsHealthy(health) ? .green : .orange)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(captureHealthTitle(health)).bold()
+        Text(captureHealthDetail(health))
+          .font(.caption).foregroundColor(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      Spacer()
+    }
+  }
+
+  private var frameRetentionOptions: [Int] {
+    let presets = CaptureSettings.frameRetentionPresets
+    return presets.contains(settings.frameRetentionDays)
+      ? presets
+      : (presets + [settings.frameRetentionDays]).sorted()
+  }
+
+  private func frameRetentionLabel(_ days: Int) -> String {
+    days == 1 ? "24 hours" : "\(days) days"
+  }
+
+  private func captureHealthIsHealthy(_ state: CaptureHealthState) -> Bool {
+    if case .healthy = state { return true }
+    return false
+  }
+
+  private func captureHealthTitle(_ state: CaptureHealthState) -> String {
+    switch state {
+    case .disabled: return "Screenshot capture is off"
+    case .paused: return "Screenshot capture is paused"
+    case .permissionRequired: return "Screen Recording permission required"
+    case .waitingForFirstFrame: return "Waiting for the first screenshot"
+    case .healthy: return "Screenshots are being saved"
+    case .stale: return "Screenshot capture has stopped"
+    }
+  }
+
+  private func captureHealthDetail(_ state: CaptureHealthState) -> String {
+    switch state {
+    case .disabled:
+      return "Turn on Capture enabled to begin a private local history."
+    case .paused(let until):
+      return "Paused until \(until.formatted(date: .abbreviated, time: .shortened))."
+    case .permissionRequired:
+      return "Activity may still list app names, but no screenshots or OCR are being recorded."
+    case .waitingForFirstFrame:
+      return "Permission is granted and capture is enabled, but no image has been persisted yet."
+    case .healthy(let latest):
+      return "Last screenshot saved \(relativeDate(latest, empty: "just now"))."
+    case .stale(let latest):
+      return "The last screenshot was saved \(relativeDate(latest, empty: "at an unknown time")); app-focus activity can continue even while images are unavailable."
+    }
+  }
+
+  private func relativeDate(_ date: Date?, empty: String) -> String {
+    guard let date else { return empty }
+    return date.formatted(.relative(presentation: .named))
   }
 
   private func permissionRow(

--- a/mac/Tests/OpenAGITests/CaptureHealthTests.swift
+++ b/mac/Tests/OpenAGITests/CaptureHealthTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import XCTest
+@testable import OpenAGI
+
+final class CaptureHealthTests: XCTestCase {
+  private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+  func testFreshInstallDefaultsToOneDayOfScreenshots() {
+    XCTAssertEqual(CaptureSettings.defaultFrameRetentionDays, 1)
+    XCTAssertEqual(CaptureSettings.frameRetentionPresets, [1, 3, 7, 30, 90])
+  }
+
+  func testPermissionIsNotReportedAsHealthyWithoutSavedFrame() {
+    XCTAssertEqual(
+      CaptureHealth.evaluate(
+        enabled: true,
+        pausedUntil: nil,
+        screenRecordingGranted: true,
+        latestFrameAt: nil,
+        captureIntervalSeconds: 5,
+        now: now),
+      .waitingForFirstFrame)
+  }
+
+  func testFreshSavedFrameIsHealthy() {
+    let frame = now.addingTimeInterval(-30)
+    XCTAssertEqual(
+      CaptureHealth.evaluate(
+        enabled: true,
+        pausedUntil: nil,
+        screenRecordingGranted: true,
+        latestFrameAt: frame,
+        captureIntervalSeconds: 5,
+        now: now),
+      .healthy(latestFrameAt: frame))
+  }
+
+  func testStaleFrameIsReportedEvenWhileCaptureIsEnabled() {
+    let frame = now.addingTimeInterval(-61)
+    XCTAssertEqual(
+      CaptureHealth.evaluate(
+        enabled: true,
+        pausedUntil: nil,
+        screenRecordingGranted: true,
+        latestFrameAt: frame,
+        captureIntervalSeconds: 5,
+        now: now),
+      .stale(latestFrameAt: frame))
+  }
+
+  func testPermissionFailureWinsOverHistoricalFrame() {
+    XCTAssertEqual(
+      CaptureHealth.evaluate(
+        enabled: true,
+        pausedUntil: nil,
+        screenRecordingGranted: false,
+        latestFrameAt: now,
+        captureIntervalSeconds: 5,
+        now: now),
+      .permissionRequired)
+  }
+
+  func testExpiredOrphanedThumbnailsAreRemovedWithoutTouchingFreshFiles() throws {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("openagi-capture-retention-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let expired = dir.appendingPathComponent("expired.jpg")
+    let fresh = dir.appendingPathComponent("fresh.jpg")
+    let unrelated = dir.appendingPathComponent("notes.txt")
+    try Data([1]).write(to: expired)
+    try Data([2]).write(to: fresh)
+    try Data([3]).write(to: unrelated)
+    try FileManager.default.setAttributes(
+      [.modificationDate: now.addingTimeInterval(-2 * 86_400)],
+      ofItemAtPath: expired.path)
+    try FileManager.default.setAttributes(
+      [.modificationDate: now],
+      ofItemAtPath: fresh.path)
+
+    XCTAssertEqual(
+      CaptureStorage.removeExpiredThumbnails(
+        in: dir,
+        olderThan: now.addingTimeInterval(-86_400)),
+      1)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: expired.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: fresh.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: unrelated.path))
+  }
+
+  func testDatabaseCompactionRequiresMaterialFreeSpaceAndRatio() {
+    XCTAssertFalse(CaptureStorage.shouldCompactDatabase(
+      pageCount: 10_000, freePages: 2_499, pageSize: 4096))
+    XCTAssertFalse(CaptureStorage.shouldCompactDatabase(
+      pageCount: 10_000, freePages: 2_500, pageSize: 4096))
+    XCTAssertTrue(CaptureStorage.shouldCompactDatabase(
+      pageCount: 20_000, freePages: 5_000, pageSize: 4096))
+  }
+}

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -2371,10 +2371,38 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
         const { listAllSuggestions } = await import("./suggestion-feed.js");
         const status = url.searchParams.get("status");
         const id = url.searchParams.get("id");
-        const suggestions = listAllSuggestions(runtime, {
+        const category = url.searchParams.get("category");
+        const view = url.searchParams.get("view");
+        const requestedLimit = Number.parseInt(url.searchParams.get("limit") ?? "", 10);
+        let suggestions = listAllSuggestions(runtime, {
           status: status === "null" ? null : (status ?? "pending")
         });
-        return sendJson(res, 200, id ? suggestions.filter((item) => item.id === id) : suggestions);
+        if (id) suggestions = suggestions.filter((item) => item.id === id);
+        if (category) suggestions = suggestions.filter((item) => item.category === category);
+        if (Number.isFinite(requestedLimit)) {
+          suggestions = suggestions.slice(0, Math.max(1, Math.min(500, requestedLimit)));
+        }
+        if (view === "summary") {
+          const summarizeApps = (values) => (Array.isArray(values) ? values : [])
+            .slice(0, 32)
+            .map((item) => typeof item === "string"
+              ? item.slice(0, 200)
+              : (typeof item?.app === "string" ? { app: item.app.slice(0, 200) } : null))
+            .filter(Boolean);
+          suggestions = suggestions.map((item) => ({
+            id: item.id,
+            proposedAt: item.proposedAt ?? null,
+            category: item.category ?? null,
+            title: String(item.title ?? "").slice(0, 240),
+            rationale: String(item.rationale ?? "").slice(0, 1_000),
+            status: item.status ?? null,
+            source: item.source ?? null,
+            context: { apps: summarizeApps(item.context?.apps) },
+            sequence: { apps: summarizeApps(item.sequence?.apps) },
+            proposal: { description: String(item.proposal?.description ?? "").slice(0, 1_000) }
+          }));
+        }
+        return sendJson(res, 200, suggestions);
       }
       if (method === "POST" && pathname === "/proactive/observe") {
         if (!runtime.proactiveObserver?.observe) return sendJson(res, 503, { error: "no observer" });
@@ -3896,20 +3924,44 @@ function renderApp() {
     .history-apps {
       display: flex; flex-wrap: wrap; gap: 6px; margin-top: var(--space-2);
     }
-    .history-app-label {
-      display: inline-flex; align-items: center; min-width: 0;
-      padding: 2px 8px; border-radius: 999px;
-      border: 1px solid var(--border); background: var(--background);
-      color: var(--muted-foreground); font-size: var(--font-size-xs);
-      white-space: nowrap; max-width: 260px; overflow: hidden;
-      text-overflow: ellipsis;
+    .history-app-icon {
+      display: inline-grid; place-items: center; width: 28px; height: 28px;
+      border-radius: 7px; border: 1px solid rgba(255,255,255,.12);
+      color: #fff; background: linear-gradient(145deg, #50545c, #25272b);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.12), 0 1px 2px rgba(0,0,0,.2);
+      font-size: 10px; font-weight: 750; letter-spacing: -.02em;
     }
-    .history-app-mark {
-      display: inline-grid; place-items: center; width: 16px; height: 16px;
-      margin-right: 5px; border-radius: 4px; color: var(--foreground);
-      background: var(--muted-bg); font-size: 9px; font-weight: 700;
-      flex: 0 0 auto;
+    .history-app-icon.tone-blue { background: linear-gradient(145deg, #5b9cff, #315ccf); }
+    .history-app-icon.tone-purple { background: linear-gradient(145deg, #9b7cff, #5d3fb4); }
+    .history-app-icon.tone-green { background: linear-gradient(145deg, #59ce8f, #188151); }
+    .history-app-icon.tone-orange { background: linear-gradient(145deg, #ffac5c, #c35c24); }
+    .history-app-icon.tone-dark { background: linear-gradient(145deg, #474b54, #17181b); }
+    .history-app-more {
+      display: inline-grid; place-items: center; min-width: 28px; height: 28px;
+      padding: 0 7px; border-radius: 7px; border: 1px solid var(--border);
+      color: var(--muted-foreground); background: var(--background);
+      font-size: 10px; font-weight: 650;
     }
+    .history-skill-card {
+      margin-top: var(--space-4); padding: var(--space-4);
+      border: 1px solid var(--border); border-radius: var(--radius-lg);
+      background: linear-gradient(145deg, rgba(255,255,255,.035), rgba(255,255,255,.015));
+    }
+    .history-skill-kicker {
+      margin: 0; color: var(--foreground); font-size: var(--font-size-sm);
+      font-weight: 650;
+    }
+    .history-skill-description {
+      margin: var(--space-2) 0 0; color: var(--muted-foreground);
+      font-size: var(--font-size-sm); line-height: 1.5;
+    }
+    .history-skill-create {
+      margin-top: var(--space-2); padding: 0; border: 0; background: transparent;
+      color: var(--accent); font: inherit; font-size: var(--font-size-sm);
+      font-weight: 600; text-align: left; cursor: pointer;
+    }
+    .history-skill-create:hover { text-decoration: underline; }
+    .history-skill-create:disabled { opacity: .6; cursor: wait; text-decoration: none; }
     .history-evidence {
       display: inline-flex; align-items: center; gap: 5px;
       margin-top: var(--space-2); color: var(--muted-foreground);
@@ -8177,18 +8229,26 @@ async function renderActivity() {
     }
     loadWrap.hidden = true;
     try {
-      const results = await fetchJson("/observations/search?" + new URLSearchParams({
-        ...(q ? { q } : {}),
-        ...(since ? { since } : {}),
-        kinds: "activity,frame",
-        limit: String(requestedLimit + 1)
-      }).toString());
+      const [results, suggestions] = await Promise.all([
+        fetchJson("/observations/search?" + new URLSearchParams({
+          ...(q ? { q } : {}),
+          ...(since ? { since } : {}),
+          kinds: "activity,frame",
+          limit: String(requestedLimit + 1)
+        }).toString()),
+        // Skill cards enrich history but must never become a dependency for
+        // reading it: a damaged suggestion store degrades to no cards.
+        fetchJson("/proactive/suggestions?status=pending&category=skill&limit=200&view=summary").catch(() => [])
+      ]);
       if (requestId !== listRequest || state.tab !== "activity") return;
       const rows = (Array.isArray(results) ? results : [])
         .slice(0, requestedLimit)
         .filter((row) => row?.kind !== "transcript");
       const hasMore = Array.isArray(results) && results.length > requestedLimit;
-      renderActivityResults(rows, { query: q, hasMore });
+      const skillSuggestions = (Array.isArray(suggestions) ? suggestions : [])
+        .filter((suggestion) => suggestion?.category === "skill" && suggestion?.status === "pending");
+      renderActivityResults(rows, { query: q, hasMore, suggestions: skillSuggestions });
+      bindHistorySkillButtons(() => reload());
     } catch (error) {
       if (requestId !== listRequest || state.tab !== "activity") return;
       renderActivityError(error, () => reload({ resetLimit: true }));
@@ -8279,6 +8339,11 @@ function historyAppLabel(value) {
     "com.microsoft.edgemac": "Microsoft Edge",
     "com.openai.chat": "ChatGPT",
     "com.openai.codex": "Codex",
+    "com.tinyspeck.slackmacgap": "Slack",
+    "us.zoom.xos": "Zoom",
+    "com.apple.mobilesms": "Messages",
+    "com.apple.calendar": "Calendar",
+    "com.github.githubclient": "GitHub",
     "com.blizzard.worldofwarcraft": "World of Warcraft",
     "worldofwarcraft": "World of Warcraft",
     "com.wispr.wispr-flow": "Wispr Flow",
@@ -8340,7 +8405,85 @@ function historyPeriodCopy(rows) {
   return { apps, title, summary, screenCount, sourceCount: rows.length };
 }
 
-function historyPeriods(results) {
+function historyAppVisual(value) {
+  const label = historyAppLabel(value);
+  const key = label.toLocaleLowerCase();
+  const known = {
+    "finder": ["F", "blue"], "chrome": ["◉", "orange"], "safari": ["↗", "blue"],
+    "slack": ["S", "purple"], "codex": ["⌘", "dark"], "chatgpt": ["✦", "green"],
+    "github": ["GH", "dark"], "zoom": ["▣", "blue"], "messages": ["●", "green"],
+    "calendar": ["31", "orange"], "conductor": ["C", "dark"], "rize": ["R", "purple"],
+    "system settings": ["⚙", "dark"]
+  };
+  const match = known[key];
+  return {
+    label,
+    glyph: match?.[0] ?? (label.slice(0, 2).toLocaleUpperCase() || "APP"),
+    tone: match?.[1] ?? "dark"
+  };
+}
+
+function historyAppIconHtml(value) {
+  const visual = historyAppVisual(value);
+  return \`<span class="history-app-icon tone-\${visual.tone}" aria-label="Application: \${escapeHtml(visual.label)}" title="\${escapeHtml(visual.label)}"><span aria-hidden="true">\${escapeHtml(visual.glyph)}</span></span>\`;
+}
+
+function historySuggestionApps(suggestion) {
+  const values = [];
+  for (const item of suggestion?.context?.apps ?? []) {
+    const value = typeof item === "string" ? item : item?.app;
+    if (value) values.push(historyAppLabel(value).toLocaleLowerCase());
+  }
+  for (const value of suggestion?.sequence?.apps ?? []) {
+    if (value) values.push(historyAppLabel(value).toLocaleLowerCase());
+  }
+  return new Set(values.filter(Boolean));
+}
+
+function historyAttachSkillSuggestions(periods, suggestions) {
+  const attached = periods.map((period) => ({ ...period, skillSuggestions: [] }));
+  for (const suggestion of suggestions ?? []) {
+    const proposedAt = historyDate(suggestion?.proposedAt);
+    if (!proposedAt) continue;
+    const suggestionApps = historySuggestionApps(suggestion);
+    let best = null;
+    for (const period of attached) {
+      if (period.skillSuggestions.length > 0) continue;
+      const periodAt = historyDate(period?.at);
+      if (!periodAt) continue;
+      const distanceHours = Math.abs(proposedAt.getTime() - periodAt.getTime()) / 3_600_000;
+      const periodApps = new Set(period.apps.map((app) => app.toLocaleLowerCase()));
+      const overlap = [...suggestionApps].filter((app) => periodApps.has(app)).length;
+      // Evidence-bearing suggestions may attach to a matching work period on
+      // the same half-day. Suggestions without app evidence must be nearly
+      // contemporaneous, so unrelated cards do not drift into history.
+      if (suggestionApps.size > 0 ? (overlap === 0 || distanceHours > 12) : distanceHours > 0.5) continue;
+      const score = overlap * 100 - distanceHours;
+      if (!best || score > best.score) best = { period, score };
+    }
+    if (best) best.period.skillSuggestions.push(suggestion);
+  }
+  return attached;
+}
+
+function historySkillName(value) {
+  const raw = historyCleanText(value).replace(/[-_]+/g, " ");
+  return raw.replace(/\\b[a-z]/g, (letter) => letter.toLocaleUpperCase()) || "Suggested";
+}
+
+function historySkillCardHtml(suggestion) {
+  const name = historySkillName(suggestion?.title);
+  const description = historyTruncate(
+    suggestion?.proposal?.description || suggestion?.rationale || "Turn this repeated workflow into a reusable skill.",
+    280);
+  return \`<aside class="history-skill-card" aria-label="Suggested skill: \${escapeHtml(name)}">
+    <p class="history-skill-kicker">Suggested skill</p>
+    <p class="history-skill-description">\${escapeHtml(description)}</p>
+    <button class="history-skill-create" type="button" data-history-skill="\${escapeHtml(suggestion?.id ?? "")}" data-history-skill-name="\${escapeHtml(name)}">Create \${escapeHtml(name)} skill</button>
+  </aside>\`;
+}
+
+function historyPeriods(results, suggestions = []) {
   const periods = [];
   const byBucket = new Map();
   for (const row of results) {
@@ -8353,7 +8496,9 @@ function historyPeriods(results) {
     }
     period.rows.push(row);
   }
-  return periods.map((period) => ({ ...period, ...historyPeriodCopy(period.rows) }));
+  return historyAttachSkillSuggestions(
+    periods.map((period) => ({ ...period, ...historyPeriodCopy(period.rows) })),
+    suggestions);
 }
 
 function historyGroupPeriods(periods) {
@@ -8400,7 +8545,7 @@ function historySnippetHtml(value) {
   return escapeHtml(historyTruncate(value, 360));
 }
 
-function renderActivityResults(results, { query = "", hasMore = false } = {}) {
+function renderActivityResults(results, { query = "", hasMore = false, suggestions = [] } = {}) {
   const list = $("actResults");
   if (!list) return;
   list.setAttribute("aria-busy", "false");
@@ -8414,7 +8559,7 @@ function renderActivityResults(results, { query = "", hasMore = false } = {}) {
     if (loadWrap) loadWrap.hidden = true;
     return;
   }
-  const periods = historyPeriods(results);
+  const periods = historyPeriods(results, suggestions);
   const days = historyGroupPeriods(periods);
   const renderPeriod = (period) => {
     const timestamp = historyDate(period?.at)?.toISOString() ?? "";
@@ -8424,7 +8569,8 @@ function renderActivityResults(results, { query = "", hasMore = false } = {}) {
         <h5 class="history-entry-title">\${escapeHtml(period.title)}</h5>
         <p class="history-entry-summary">\${historySnippetHtml(period.summary)}</p>
         \${period.screenCount ? \`<div class="history-evidence">\${period.screenCount} OCR-backed screen capture\${period.screenCount === 1 ? "" : "s"}</div>\` : ""}
-        \${period.apps.length ? \`<div class="history-apps">\${period.apps.slice(0, 6).map((app) => \`<span class="history-app-label" aria-label="Application: \${escapeHtml(app)}"><span class="history-app-mark" aria-hidden="true">\${escapeHtml(app.slice(0, 1).toLocaleUpperCase())}</span>\${escapeHtml(app)}</span>\`).join("")}\${period.apps.length > 6 ? \`<span class="history-app-label" aria-label="\${period.apps.length - 6} additional applications">+\${period.apps.length - 6} more</span>\` : ""}</div>\` : ""}
+        \${period.apps.length ? \`<div class="history-apps" aria-label="Applications used">\${period.apps.slice(0, 12).map(historyAppIconHtml).join("")}\${period.apps.length > 12 ? \`<span class="history-app-more" aria-label="\${period.apps.length - 12} additional applications">+\${period.apps.length - 12}</span>\` : ""}</div>\` : ""}
+        \${period.skillSuggestions.map(historySkillCardHtml).join("")}
       </div>
     </article>\`;
   };
@@ -8449,6 +8595,31 @@ function renderActivityResults(results, { query = "", hasMore = false } = {}) {
     + " from " + results.length + " observation" + (results.length === 1 ? "" : "s")
     + (hasMore ? " · more available" : "");
   if (loadWrap) loadWrap.hidden = !hasMore;
+}
+
+function bindHistorySkillButtons(reload) {
+  document.querySelectorAll("[data-history-skill]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const id = button.dataset.historySkill;
+      const name = button.dataset.historySkillName || "suggested";
+      if (!id) return;
+      button.disabled = true;
+      button.textContent = "Creating…";
+      try {
+        const result = await postJson(\`/proactive/suggestions/\${encodeURIComponent(id)}/accept\`, {});
+        // Accept deliberately returns HTTP 200 for materialization failures so
+        // the pending suggestion remains retryable. Handle that envelope here
+        // instead of falsely celebrating a skill that was never written.
+        if (result.skillCreateError) throw new Error(result.skillCreateError);
+        showToast("✓ " + name + " skill created", true);
+        await reload();
+      } catch (error) {
+        showToast("Couldn’t create skill: " + error.message, false);
+        button.disabled = false;
+        button.textContent = "Create " + name + " skill";
+      }
+    });
+  });
 }
 
 function renderActivityError(error, retry) {

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -1414,7 +1414,11 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
         const app = url.searchParams.get("app") ?? null;
         const machine = url.searchParams.get("machine") ?? null;
         const kinds = url.searchParams.get("kinds")?.split(",").map((kind) => kind.trim()).filter(Boolean) ?? null;
-        const limit = Number.parseInt(url.searchParams.get("limit") ?? "25", 10);
+        const parsedLimit = Number.parseInt(url.searchParams.get("limit") ?? "25", 10);
+        // Search includes private OCR rows and may merge two large source
+        // tables for Computer History. Keep an authenticated-but-compromised
+        // client from turning an arbitrary limit into an unbounded allocation.
+        const limit = Math.max(1, Math.min(5_000, Number.isFinite(parsedLimit) ? parsedLimit : 25));
         const results = await runtime.observations.search({ query, since, until, app, machine, kinds, limit });
         return sendJson(res, 200, results);
       }
@@ -3820,12 +3824,50 @@ function renderApp() {
       background: var(--card); border: 1px solid var(--border);
       border-radius: var(--radius-lg); overflow: hidden;
     }
-    .history-day { padding: var(--space-4) var(--space-5) 0; }
+    .history-day { padding: var(--space-4) var(--space-5); }
     .history-day + .history-day { border-top: 1px solid var(--border); }
-    .history-day-title {
-      margin: 0; padding-bottom: var(--space-3); color: var(--foreground);
-      font-size: var(--font-size-base); font-weight: 650;
+    .history-day > summary, .history-hour > summary {
+      list-style: none; cursor: pointer; user-select: none;
     }
+    .history-day > summary::-webkit-details-marker,
+    .history-hour > summary::-webkit-details-marker { display: none; }
+    .history-day-summary {
+      display: flex; align-items: center; justify-content: space-between;
+      gap: var(--space-3); color: var(--foreground);
+    }
+    .history-day-title {
+      margin: 0; font-size: var(--font-size-base); font-weight: 650;
+    }
+    .history-day-meta, .history-hour-meta {
+      color: var(--muted-foreground); font-size: var(--font-size-xs);
+      font-weight: 500;
+    }
+    .history-disclosure::before {
+      content: "›"; display: inline-block; margin-right: 8px;
+      color: var(--muted-foreground); transform: rotate(0deg);
+      transition: transform .14s ease;
+    }
+    details[open] > summary .history-disclosure::before { transform: rotate(90deg); }
+    .history-hours { margin-top: var(--space-4); }
+    .history-hour {
+      position: relative; margin-left: 88px; padding-left: var(--space-4);
+      border-left: 1px solid var(--border);
+    }
+    .history-hour + .history-hour { padding-top: var(--space-4); }
+    .history-hour-summary {
+      position: relative; display: flex; align-items: baseline;
+      justify-content: space-between; gap: var(--space-3);
+      padding: 0 0 var(--space-3);
+    }
+    .history-hour-summary::before {
+      content: ""; position: absolute; left: calc(-1 * var(--space-4) - 4px);
+      top: 7px; width: 7px; height: 7px; border-radius: 50%;
+      background: var(--muted-foreground); box-shadow: 0 0 0 4px var(--card);
+    }
+    .history-hour-title {
+      color: var(--foreground); font-size: var(--font-size-sm); font-weight: 650;
+    }
+    .history-hour-entries { margin-left: calc(-88px - var(--space-4)); }
     .history-entry {
       display: grid; grid-template-columns: 88px minmax(0, 1fr);
       gap: var(--space-4);
@@ -3835,8 +3877,13 @@ function renderApp() {
       font-size: var(--font-size-xs); text-align: right; white-space: nowrap;
     }
     .history-entry-body {
-      min-width: 0; border-left: 1px solid var(--border);
+      position: relative; min-width: 0; border-left: 1px solid var(--border);
       padding: 0 0 var(--space-5) var(--space-4);
+    }
+    .history-entry-body::before {
+      content: ""; position: absolute; left: -4px; top: 7px;
+      width: 7px; height: 7px; border-radius: 50%;
+      background: var(--border-strong); box-shadow: 0 0 0 4px var(--card);
     }
     .history-entry-title {
       margin: 0; color: var(--foreground); font-size: var(--font-size-base);
@@ -3857,6 +3904,18 @@ function renderApp() {
       white-space: nowrap; max-width: 260px; overflow: hidden;
       text-overflow: ellipsis;
     }
+    .history-app-mark {
+      display: inline-grid; place-items: center; width: 16px; height: 16px;
+      margin-right: 5px; border-radius: 4px; color: var(--foreground);
+      background: var(--muted-bg); font-size: 9px; font-weight: 700;
+      flex: 0 0 auto;
+    }
+    .history-evidence {
+      display: inline-flex; align-items: center; gap: 5px;
+      margin-top: var(--space-2); color: var(--muted-foreground);
+      font-size: var(--font-size-xs);
+    }
+    .history-evidence::before { content: "▣"; color: var(--accent); }
     .history-state {
       padding: 56px var(--space-5); text-align: center;
       color: var(--muted-foreground); font-size: var(--font-size-sm);
@@ -3878,6 +3937,9 @@ function renderApp() {
       .history-section-header .ui-btn { width: 100%; }
       .history-filters { grid-template-columns: 1fr; }
       .history-day { padding-left: var(--space-4); padding-right: var(--space-4); }
+      .history-day-summary { align-items: flex-start; flex-direction: column; gap: 2px; }
+      .history-hour { margin-left: 66px; padding-left: var(--space-3); }
+      .history-hour-entries { margin-left: calc(-66px - var(--space-3)); }
       .history-entry { grid-template-columns: 66px minmax(0, 1fr); gap: var(--space-2); }
       .history-entry-body { padding-left: var(--space-3); }
     }
@@ -8035,7 +8097,7 @@ async function renderActivity() {
     <div class="pane history-page">
       <div class="history-page-header">
         <h2>Computer history</h2>
-        <p class="history-page-subtitle">A timeline of activity OpenAGI has received from your capture Mac. Search it when you need to remember where you left off.</p>
+        <p class="history-page-subtitle">A day-by-day log distilled from app activity and privacy-filtered screen OCR. Live screenshots stay in approved Computer Use sessions; history keeps searchable text and source references.</p>
       </div>
 
       <section id="historyStatusCard" class="history-status-card" aria-label="Computer history capture status" aria-live="polite" aria-busy="true">
@@ -8196,6 +8258,17 @@ function historyTimeLabel(value) {
   return date ? date.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" }) : "Time unavailable";
 }
 
+function historyHourKey(value) {
+  const date = historyDate(value);
+  if (!date) return "unknown";
+  return historyDayKey(value) + ":" + String(date.getHours()).padStart(2, "0");
+}
+
+function historyHourLabel(value) {
+  const date = historyDate(value);
+  return date ? date.toLocaleTimeString(undefined, { hour: "numeric" }) : "Time unavailable";
+}
+
 function historyAppLabel(value) {
   const raw = historyCleanText(value);
   if (!raw) return "";
@@ -8232,6 +8305,7 @@ function historyBucketKey(row) {
 
 function historyPeriodCopy(rows) {
   const apps = [...new Set(rows.map((row) => historyAppLabel(row?.app)).filter(Boolean))];
+  const screenCount = rows.filter((row) => row?.kind === "frame" || row?.kind === "frame-summary").length;
   const details = [];
   for (const row of rows) {
     const windowTitle = historyCleanText(row?.window);
@@ -8263,7 +8337,7 @@ function historyPeriodCopy(rows) {
       : apps.length > 1
         ? "You moved between " + appSummary + " during this period."
         : "OpenAGI received activity during this period, but no app or window detail was available.";
-  return { apps, title, summary };
+  return { apps, title, summary, screenCount, sourceCount: rows.length };
 }
 
 function historyPeriods(results) {
@@ -8280,6 +8354,31 @@ function historyPeriods(results) {
     period.rows.push(row);
   }
   return periods.map((period) => ({ ...period, ...historyPeriodCopy(period.rows) }));
+}
+
+function historyGroupPeriods(periods) {
+  const days = new Map();
+  for (const period of periods) {
+    const dayKey = historyDayKey(period?.at);
+    if (!days.has(dayKey)) days.set(dayKey, { at: period?.at, hours: new Map(), periods: [] });
+    const day = days.get(dayKey);
+    const hourKey = historyHourKey(period?.at);
+    if (!day.hours.has(hourKey)) day.hours.set(hourKey, { at: period?.at, periods: [] });
+    day.hours.get(hourKey).periods.push(period);
+    day.periods.push(period);
+  }
+  return [...days.values()].map((day) => ({ ...day, hours: [...day.hours.values()] }));
+}
+
+function historyGroupMeta(periods) {
+  const apps = [...new Set(periods.flatMap((period) => period.apps))];
+  const sourceCount = periods.reduce((sum, period) => sum + period.sourceCount, 0);
+  const screenCount = periods.reduce((sum, period) => sum + period.screenCount, 0);
+  const pieces = [periods.length + " period" + (periods.length === 1 ? "" : "s")];
+  if (apps.length) pieces.push(apps.slice(0, 2).join(", ") + (apps.length > 2 ? " +" + (apps.length - 2) : ""));
+  if (screenCount) pieces.push(screenCount + " screen capture" + (screenCount === 1 ? "" : "s"));
+  else if (sourceCount) pieces.push(sourceCount + " event" + (sourceCount === 1 ? "" : "s"));
+  return pieces.join(" · ");
 }
 
 function historyRelativeTime(value) {
@@ -8316,27 +8415,35 @@ function renderActivityResults(results, { query = "", hasMore = false } = {}) {
     return;
   }
   const periods = historyPeriods(results);
-  const days = new Map();
-  for (const period of periods) {
-    const key = historyDayKey(period?.at);
-    if (!days.has(key)) days.set(key, { at: period?.at, periods: [] });
-    days.get(key).periods.push(period);
-  }
-  list.innerHTML = [...days.values()].map((day) => \`
-    <section class="history-day">
-      <h4 class="history-day-title">\${escapeHtml(historyDayLabel(day.at))}</h4>
-      \${day.periods.map((period) => {
-        const timestamp = historyDate(period?.at)?.toISOString() ?? "";
-        return \`<article class="history-entry">
-          <time class="history-entry-time"\${timestamp ? \` datetime="\${escapeHtml(timestamp)}"\` : ""}>\${escapeHtml(historyTimeLabel(period?.at))}</time>
-          <div class="history-entry-body">
-            <h5 class="history-entry-title">\${escapeHtml(period.title)}</h5>
-            <p class="history-entry-summary">\${historySnippetHtml(period.summary)}</p>
-            \${period.apps.length ? \`<div class="history-apps">\${period.apps.slice(0, 6).map((app) => \`<span class="history-app-label" aria-label="Application: \${escapeHtml(app)}">\${escapeHtml(app)}</span>\`).join("")}\${period.apps.length > 6 ? \`<span class="history-app-label" aria-label="\${period.apps.length - 6} additional applications">+\${period.apps.length - 6} more</span>\` : ""}</div>\` : ""}
-          </div>
-        </article>\`;
-      }).join("")}
-    </section>
+  const days = historyGroupPeriods(periods);
+  const renderPeriod = (period) => {
+    const timestamp = historyDate(period?.at)?.toISOString() ?? "";
+    return \`<article class="history-entry" data-source-count="\${period.sourceCount}">
+      <time class="history-entry-time"\${timestamp ? \` datetime="\${escapeHtml(timestamp)}"\` : ""}>\${escapeHtml(historyTimeLabel(period?.at))}</time>
+      <div class="history-entry-body">
+        <h5 class="history-entry-title">\${escapeHtml(period.title)}</h5>
+        <p class="history-entry-summary">\${historySnippetHtml(period.summary)}</p>
+        \${period.screenCount ? \`<div class="history-evidence">\${period.screenCount} OCR-backed screen capture\${period.screenCount === 1 ? "" : "s"}</div>\` : ""}
+        \${period.apps.length ? \`<div class="history-apps">\${period.apps.slice(0, 6).map((app) => \`<span class="history-app-label" aria-label="Application: \${escapeHtml(app)}"><span class="history-app-mark" aria-hidden="true">\${escapeHtml(app.slice(0, 1).toLocaleUpperCase())}</span>\${escapeHtml(app)}</span>\`).join("")}\${period.apps.length > 6 ? \`<span class="history-app-label" aria-label="\${period.apps.length - 6} additional applications">+\${period.apps.length - 6} more</span>\` : ""}</div>\` : ""}
+      </div>
+    </article>\`;
+  };
+  list.innerHTML = days.map((day) => \`
+    <details class="history-day" open>
+      <summary class="history-day-summary">
+        <h4 class="history-day-title history-disclosure">\${escapeHtml(historyDayLabel(day.at))}</h4>
+        <span class="history-day-meta">\${escapeHtml(historyGroupMeta(day.periods))}</span>
+      </summary>
+      <div class="history-hours">
+        \${day.hours.map((hour) => \`<details class="history-hour" open>
+          <summary class="history-hour-summary">
+            <span class="history-hour-title history-disclosure">\${escapeHtml(historyHourLabel(hour.at))}</span>
+            <span class="history-hour-meta">\${escapeHtml(historyGroupMeta(hour.periods))}</span>
+          </summary>
+          <div class="history-hour-entries">\${hour.periods.map(renderPeriod).join("")}</div>
+        </details>\`).join("")}
+      </div>
+    </details>
   \`).join("");
   if (meta) meta.textContent = "Showing " + periods.length + " work period" + (periods.length === 1 ? "" : "s")
     + " from " + results.length + " observation" + (results.length === 1 ? "" : "s")

--- a/src/observation-store.js
+++ b/src/observation-store.js
@@ -272,7 +272,7 @@ export class ObservationStore {
       }
       sources.push(`SELECT 'frame' AS kind, f.frame_uid AS ref, f.captured_at AS at,
         f.app, f.window, 'screen' AS event, f.source_machine_id AS sourceMachineId,
-        (SELECT text FROM texts WHERE kind = 'frame' AND ref = f.frame_uid LIMIT 1) AS text
+        NULL AS text
         FROM frames f`);
       const params = [];
       const clauses = ["1=1"];

--- a/src/observation-store.js
+++ b/src/observation-store.js
@@ -215,7 +215,13 @@ export class ObservationStore {
       if (machine) out = out.filter((o) => o.sourceMachineId === machine);
       if (since) out = out.filter((o) => (o.at ?? "") >= since);
       if (until) out = out.filter((o) => (o.at ?? "") <= until);
-      return out.sort((a, b) => (b.at ?? "").localeCompare(a.at ?? "")).slice(0, limit).map(capTranscriptText);
+      return out.sort((a, b) => (b.at ?? "").localeCompare(a.at ?? "")).slice(0, limit).map((row) => capTranscriptText({
+        ...row,
+        kind: row.kind === "frame-summary" ? "frame" : row.kind,
+        ...(row.kind === "frame" || row.kind === "frame-summary"
+          ? { text: row.text ?? row.ocrText ?? null, ref: row.ref ?? row.frameId ?? null }
+          : {})
+      }));
     }
 
     if (query) {
@@ -253,7 +259,35 @@ export class ObservationStore {
       params.push(limit);
       return rows.all(...params).map(capTranscriptText);
     }
-    // No query → return recent activity by default.
+    // No query normally returns recent focus activity for backward
+    // compatibility. Computer History explicitly asks for activity + frame,
+    // so merge both source streams there; otherwise OCR-backed screen events
+    // disappeared from the timeline until the user typed a search.
+    if (normalizedKinds?.includes("frame")) {
+      const sources = [];
+      if (normalizedKinds.includes("activity")) {
+        sources.push(`SELECT 'activity' AS kind, CAST(id AS TEXT) AS ref, at,
+          app, window, event, source_machine_id AS sourceMachineId, NULL AS text
+          FROM activity`);
+      }
+      sources.push(`SELECT 'frame' AS kind, f.frame_uid AS ref, f.captured_at AS at,
+        f.app, f.window, 'screen' AS event, f.source_machine_id AS sourceMachineId,
+        (SELECT text FROM texts WHERE kind = 'frame' AND ref = f.frame_uid LIMIT 1) AS text
+        FROM frames f`);
+      const params = [];
+      const clauses = ["1=1"];
+      if (app) { clauses.push("app = ?"); params.push(app); }
+      if (since) { clauses.push("at >= ?"); params.push(since); }
+      if (until) { clauses.push("at <= ?"); params.push(until); }
+      if (machine) { clauses.push("sourceMachineId = ?"); params.push(machine); }
+      params.push(limit);
+      return this.db.prepare(
+        `SELECT kind, ref, at, app, window, event, sourceMachineId, text
+         FROM (${sources.join(" UNION ALL ")})
+         WHERE ${clauses.join(" AND ")}
+         ORDER BY at DESC LIMIT ?`
+      ).all(...params).map(capWindowText);
+    }
     if (normalizedKinds && !normalizedKinds.includes("activity")) return [];
     const params = [];
     let where = "1=1";

--- a/test/computer-history-dashboard.test.js
+++ b/test/computer-history-dashboard.test.js
@@ -11,6 +11,7 @@ let dataDir;
 let dashboardHtml;
 let dashboardScript;
 let previousProviderKey;
+const hostedSource = fs.readFileSync(new URL("../src/hosted-interface.js", import.meta.url), "utf8");
 
 test.before(async () => {
   previousProviderKey = process.env.OPENAI_API_KEY;
@@ -60,11 +61,14 @@ test("Computer History uses measured capture status and a day-grouped, paginated
 
   assert.match(renderer, /historyBucketKey\(row\)/, "raw focus events must be distilled into bounded work periods");
   assert.match(renderer, /historyDayKey\(period\?\.at\)/, "work periods must be grouped by local day");
+  assert.match(renderer, /historyHourKey\(period\?\.at\)/, "work periods must be grouped into expandable hours");
   assert.match(renderer, /kinds: "activity,frame"/, "transcripts must be excluded before server-side pagination");
   assert.match(renderer, /history-entry-time/, "each history row must keep a readable time");
   assert.match(renderer, /history-app-label/, "each history row must identify its source app with text");
   assert.match(renderer, /state\.activityFilter\.limit \+= HISTORY_PAGE_SIZE/, "Load more must expand the bounded query");
   assert.match(renderer, /results\.length > requestedLimit/, "pagination must be based on a one-row lookahead");
+  assert.match(hostedSource, /Math\.min\(5_000, Number\.isFinite\(parsedLimit\)/,
+    "private OCR search responses must remain server-bounded");
 
   assert.match(renderer, /This dashboard cannot tell whether capture is paused, disabled, or the capture Mac is offline/);
   assert.match(renderer, /How to pause/);
@@ -107,7 +111,8 @@ test("history rows escape observation content and expose empty/load-more states"
   }], { query: "needle", hasMore: true });
 
   const rendered = elements.actResults.innerHTML;
-  assert.match(rendered, /<section class="history-day">/);
+  assert.match(rendered, /<details class="history-day" open>/);
+  assert.match(rendered, /<details class="history-hour" open>/);
   assert.match(rendered, /<time class="history-entry-time"/);
   assert.match(rendered, /class="history-app-label"/);
   assert.doesNotMatch(rendered, /<script>|<img\s/, "private observation text must never become executable markup");
@@ -154,6 +159,39 @@ test("history coalesces repeated focus events into ten-minute work periods and h
   assert.match(rendered, />Finder</);
   assert.doesNotMatch(rendered, /com\.google\.Chrome|com\.openai\.codex|com\.apple\.finder/);
   assert.match(elements.historyResultMeta.textContent, /2 work periods from 3 observations/);
+});
+
+test("history exposes OCR-backed screen evidence inside day and hour groups", () => {
+  const helpers = between(dashboardScript, "function historyCleanText", "function renderActivityError");
+  const elements = {
+    actResults: { innerHTML: "", setAttribute() {} },
+    historyResultMeta: { textContent: "" },
+    historyLoadMoreWrap: { hidden: true }
+  };
+  const context = vm.createContext({
+    Map,
+    Date,
+    Intl,
+    Number,
+    String,
+    $: (id) => elements[id] ?? null,
+    escapeHtml: (value) => String(value ?? "").replace(/[&<>"']/g, (character) => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+    })[character])
+  });
+  vm.runInContext(`${helpers}\nthis.renderActivityResults = renderActivityResults;`, context);
+
+  context.renderActivityResults([
+    { kind: "frame", ref: "safe-frame", at: "2026-08-19T17:08:00.000Z", app: "com.openai.codex", window: "History UI", text: "OCR source" },
+    { kind: "activity", ref: "42", at: "2026-08-19T17:04:00.000Z", app: "com.openai.codex", window: "History UI" },
+    { kind: "activity", ref: "41", at: "2026-08-19T16:54:00.000Z", app: "com.apple.finder", window: "Files" }
+  ]);
+
+  const rendered = elements.actResults.innerHTML;
+  assert.equal((rendered.match(/class="history-hour"/g) ?? []).length, 2);
+  assert.match(rendered, /1 OCR-backed screen capture/);
+  assert.match(rendered, /data-source-count="2"/);
+  assert.match(rendered, /class="history-app-mark"/);
 });
 
 test("history keeps long multi-app periods readable", () => {

--- a/test/computer-history-dashboard.test.js
+++ b/test/computer-history-dashboard.test.js
@@ -10,6 +10,7 @@ let app;
 let dataDir;
 let dashboardHtml;
 let dashboardScript;
+let base;
 let previousProviderKey;
 const hostedSource = fs.readFileSync(new URL("../src/hosted-interface.js", import.meta.url), "utf8");
 
@@ -17,7 +18,7 @@ test.before(async () => {
   previousProviderKey = process.env.OPENAI_API_KEY;
   process.env.OPENAI_API_KEY = "test-only";
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-computer-history-dashboard-"));
-  app = createHostedInterface({}, {
+  app = createHostedInterface({ dataDir }, {
     host: "127.0.0.1",
     port: 0,
     tickerMs: 0,
@@ -25,7 +26,7 @@ test.before(async () => {
     authToken: ""
   });
   const listened = await app.listen();
-  const base = listened.url ?? `http://127.0.0.1:${listened.port}`;
+  base = listened.url ?? `http://127.0.0.1:${listened.port}`;
   const response = await fetch(`${base}/`, { headers: { accept: "text/html" } });
   assert.equal(response.status, 200);
   dashboardHtml = await response.text();
@@ -64,7 +65,11 @@ test("Computer History uses measured capture status and a day-grouped, paginated
   assert.match(renderer, /historyHourKey\(period\?\.at\)/, "work periods must be grouped into expandable hours");
   assert.match(renderer, /kinds: "activity,frame"/, "transcripts must be excluded before server-side pagination");
   assert.match(renderer, /history-entry-time/, "each history row must keep a readable time");
-  assert.match(renderer, /history-app-label/, "each history row must identify its source app with text");
+  assert.match(renderer, /history-app-icon/, "each history row must identify its source app with an accessible icon");
+  assert.match(renderer, /proactive\/suggestions\?status=pending&category=skill&limit=200&view=summary/,
+    "history should load a bounded summary of pending skill suggestions without a second surface");
+  assert.match(renderer, /encodeURIComponent\(id\)/, "skill suggestion ids must be encoded before reaching the accept route");
+  assert.match(renderer, /result\.skillCreateError/, "retryable skill creation failures must not be reported as success");
   assert.match(renderer, /state\.activityFilter\.limit \+= HISTORY_PAGE_SIZE/, "Load more must expand the bounded query");
   assert.match(renderer, /results\.length > requestedLimit/, "pagination must be based on a one-row lookahead");
   assert.match(hostedSource, /Math\.min\(5_000, Number\.isFinite\(parsedLimit\)/,
@@ -76,6 +81,35 @@ test("Computer History uses measured capture status and a day-grouped, paginated
   assert.match(renderer, /aria-controls="historyControlHelp"/);
   assert.doesNotMatch(renderer, /Capture enabled/, "received observations must not be misreported as the capture toggle state");
   assert.doesNotMatch(renderer, /Clear history|Delete history|observations\/prune/, "the usability redesign must not add destructive history actions");
+});
+
+test("history suggestion feed is category-filtered, bounded, and summary-only", async () => {
+  const suggestedDir = path.join(dataDir, "skills-suggested");
+  fs.mkdirSync(suggestedDir, { recursive: true });
+  for (const [index, proposedAt] of [[1, "2026-08-19T17:00:00.000Z"], [2, "2026-08-19T18:00:00.000Z"]]) {
+    fs.writeFileSync(path.join(suggestedDir, `sug_summary_${index}.json`), JSON.stringify({
+      id: `sug_summary_${index}`,
+      proposedAt,
+      status: "pending",
+      sequence: { apps: ["com.openai.codex"], occurrences: [{ private: "must not leave compact view" }] },
+      proposal: {
+        name: `release-triage-${index}`,
+        description: "A reusable release workflow",
+        body: "private full skill body"
+      }
+    }));
+  }
+
+  const response = await fetch(`${base}/proactive/suggestions?status=pending&category=skill&limit=1&view=summary`);
+  assert.equal(response.status, 200);
+  const suggestions = await response.json();
+  assert.equal(suggestions.length, 1);
+  assert.equal(suggestions[0].id, "sug_summary_2", "the newest matching suggestion wins the bounded view");
+  assert.deepEqual(suggestions[0].sequence.apps, ["com.openai.codex"]);
+  assert.equal(suggestions[0].proposal.description, "A reusable release workflow");
+  assert.equal("body" in suggestions[0].proposal, false);
+  assert.equal("draftBody" in suggestions[0], false);
+  assert.equal("occurrences" in suggestions[0].sequence, false);
 });
 
 test("history rows escape observation content and expose empty/load-more states", () => {
@@ -114,7 +148,7 @@ test("history rows escape observation content and expose empty/load-more states"
   assert.match(rendered, /<details class="history-day" open>/);
   assert.match(rendered, /<details class="history-hour" open>/);
   assert.match(rendered, /<time class="history-entry-time"/);
-  assert.match(rendered, /class="history-app-label"/);
+  assert.match(rendered, /class="history-app-icon/);
   assert.doesNotMatch(rendered, /<script>|<img\s/, "private observation text must never become executable markup");
   assert.match(rendered, /&lt;script&gt;/, "untrusted window titles stay visible as escaped text");
   assert.doesNotMatch(rendered, /<mark>/, "search markup is stripped before rendering private text");
@@ -154,9 +188,9 @@ test("history coalesces repeated focus events into ten-minute work periods and h
 
   const rendered = elements.actResults.innerHTML;
   assert.equal((rendered.match(/class="history-entry"/g) ?? []).length, 2);
-  assert.match(rendered, />Chrome</);
-  assert.match(rendered, />Codex</);
-  assert.match(rendered, />Finder</);
+  assert.match(rendered, /title="Chrome"/);
+  assert.match(rendered, /title="Codex"/);
+  assert.match(rendered, /title="Finder"/);
   assert.doesNotMatch(rendered, /com\.google\.Chrome|com\.openai\.codex|com\.apple\.finder/);
   assert.match(elements.historyResultMeta.textContent, /2 work periods from 3 observations/);
 });
@@ -191,7 +225,7 @@ test("history exposes OCR-backed screen evidence inside day and hour groups", ()
   assert.equal((rendered.match(/class="history-hour"/g) ?? []).length, 2);
   assert.match(rendered, /1 OCR-backed screen capture/);
   assert.match(rendered, /data-source-count="2"/);
-  assert.match(rendered, /class="history-app-mark"/);
+  assert.match(rendered, /class="history-app-icon/);
 });
 
 test("history keeps long multi-app periods readable", () => {
@@ -222,16 +256,75 @@ test("history keeps long multi-app periods readable", () => {
     "com.google.Chrome",
     "com.apple.finder",
     "wine preloader",
-    "com.apple.UserNotificationCenter"
+    "com.apple.UserNotificationCenter",
+    "com.tinyspeck.slackmacgap",
+    "us.zoom.xos",
+    "com.apple.MobileSMS",
+    "com.apple.Calendar",
+    "com.github.GitHubClient",
+    "com.example.thirteenth"
   ].map((app) => ({ kind: "activity", at, app, event: "focus" })));
 
   const rendered = elements.actResults.innerHTML;
-  assert.match(rendered, /Activity across World of Warcraft, Wispr Flow, and 5 more apps/);
-  assert.match(rendered, />World of Warcraft</);
-  assert.match(rendered, />Wispr Flow</);
-  assert.match(rendered, />\+1 more</);
-  assert.equal((rendered.match(/class="history-app-label"/g) ?? []).length, 7,
-    "six named apps plus one overflow chip keeps a long period scannable");
+  assert.match(rendered, /Activity across World of Warcraft, Wispr Flow, and 11 more apps/);
+  assert.match(rendered, /title="World of Warcraft"/);
+  assert.match(rendered, /title="Wispr Flow"/);
+  assert.match(rendered, />\+1</);
+  assert.equal((rendered.match(/class="history-app-icon/g) ?? []).length, 12,
+    "twelve icon tiles plus one overflow chip keeps a long period scannable");
+});
+
+test("history attaches an escaped skill suggestion to matching app evidence", () => {
+  const helpers = between(dashboardScript, "function historyCleanText", "function renderActivityError");
+  const elements = {
+    actResults: { innerHTML: "", setAttribute() {} },
+    historyResultMeta: { textContent: "" },
+    historyLoadMoreWrap: { hidden: true }
+  };
+  const context = vm.createContext({
+    Map,
+    Date,
+    Intl,
+    Math,
+    Number,
+    Set,
+    String,
+    $: (id) => elements[id] ?? null,
+    escapeHtml: (value) => String(value ?? "").replace(/[&<>"']/g, (character) => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+    })[character])
+  });
+  vm.runInContext(`${helpers}\nthis.renderActivityResults = renderActivityResults;`, context);
+
+  context.renderActivityResults([{
+    kind: "activity",
+    at: "2026-08-19T16:50:00.000Z",
+    app: "com.openai.codex",
+    window: "Release coordination"
+  }], { suggestions: [{
+    id: 'sug_"><img src=x onerror=alert(1)>',
+    status: "pending",
+    category: "skill",
+    title: "release triage",
+    rationale: "Turn staging, pull request, and rollout checks into a reusable <script>workflow</script>.",
+    proposedAt: "2026-08-19T16:55:00.000Z",
+    sequence: { apps: ["com.openai.codex"] }
+  }, {
+    id: "sug_unrelated",
+    status: "pending",
+    category: "skill",
+    title: "unrelated",
+    proposedAt: "2026-08-19T16:55:00.000Z",
+    sequence: { apps: ["com.apple.finder"] }
+  }] });
+
+  const rendered = elements.actResults.innerHTML;
+  assert.match(rendered, /class="history-skill-card"/);
+  assert.match(rendered, /Create Release Triage skill/);
+  assert.match(rendered, /&lt;script&gt;workflow&lt;\/script&gt;/);
+  assert.doesNotMatch(rendered, /<script>|<img\s|unrelated/);
+  assert.match(rendered, /data-history-skill="sug_&quot;&gt;&lt;img/,
+    "suggestion ids remain inert when copied into the action data attribute");
 });
 
 test("Ask about your history deep-links to Chat with an editable starter prompt", async () => {

--- a/test/observation-history.test.js
+++ b/test/observation-history.test.js
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { ObservationStore } from "../src/observation-store.js";
+
+test("unfiltered Computer History merges focus activity with OCR-backed frames", async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-observation-history-"));
+  const store = new ObservationStore({ dir });
+  await store.ready;
+  t.after(() => {
+    store.db?.close?.();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  await store.record([
+    {
+      kind: "activity",
+      at: "2026-08-19T20:00:00.000Z",
+      app: "com.openai.codex",
+      window: "Review the timeline",
+      event: "focus",
+      sourceMachineId: "node-a"
+    },
+    {
+      kind: "frame-summary",
+      frameId: "frame-safe-example",
+      at: "2026-08-19T20:01:00.000Z",
+      app: "com.openai.codex",
+      window: "Review the timeline",
+      ocrText: "screen text available to history",
+      sourceMachineId: "node-a"
+    },
+    {
+      kind: "frame-summary",
+      frameId: "frame-other-node",
+      at: "2026-08-19T20:02:00.000Z",
+      app: "com.apple.finder",
+      window: "Files",
+      ocrText: "other machine",
+      sourceMachineId: "node-b"
+    }
+  ]);
+
+  const merged = await store.search({
+    kinds: ["activity", "frame"],
+    machine: "node-a",
+    limit: 10
+  });
+  assert.deepEqual(merged.map((row) => row.kind), ["frame", "activity"]);
+  assert.equal(merged[0].ref, "frame-safe-example");
+  assert.equal(merged[0].text, "screen text available to history");
+  assert.ok(merged.every((row) => row.sourceMachineId === "node-a"));
+
+  const framesOnly = await store.search({ kinds: ["frame"], app: "com.apple.finder", limit: 10 });
+  assert.equal(framesOnly.length, 1);
+  assert.equal(framesOnly[0].ref, "frame-other-node");
+
+  const legacyDefault = await store.search({ limit: 10 });
+  assert.deepEqual(legacyDefault.map((row) => row.kind), ["activity"],
+    "callers that omit kinds keep the existing activity-only contract");
+});

--- a/test/observation-history.test.js
+++ b/test/observation-history.test.js
@@ -50,8 +50,13 @@ test("unfiltered Computer History merges focus activity with OCR-backed frames",
   });
   assert.deepEqual(merged.map((row) => row.kind), ["frame", "activity"]);
   assert.equal(merged[0].ref, "frame-safe-example");
-  assert.equal(merged[0].text, "screen text available to history");
+  assert.equal(merged[0].text, null,
+    "unfiltered history must not rescan the full OCR index once per recent frame");
   assert.ok(merged.every((row) => row.sourceMachineId === "node-a"));
+
+  const searched = await store.search({ query: "screen text available", kinds: ["frame"], limit: 10 });
+  assert.equal(searched[0].text, "screen text available to history",
+    "an explicit search still returns the bounded matching OCR text");
 
   const framesOnly = await store.search({ kinds: ["frame"], app: "com.apple.finder", limit: 10 });
   assert.equal(framesOnly.length, 1);


### PR DESCRIPTION
## What changed

- restructures Computer History into expandable day → hour → work-period groups inspired by OpenHistory’s scan-first timeline
- restores OCR-backed frame events to the normal unfiltered history feed (they previously appeared only after a text search)
- shows app markers, source counts, and explicit OCR-backed screen evidence without persisting or exposing raw screenshots
- caps authenticated observation search output to keep private OCR queries bounded
- keeps legacy activity-only callers unchanged when they do not request frame rows

## Architecture and privacy

OpenHistory’s hierarchy is a useful UX reference, but its recorder intentionally excludes screenshots and OCR. This implementation uses OpenAGI’s existing activity + privacy-filtered OCR store and preserves the existing contract: Computer Use may use live screenshots during an approved session, while Computer History renders searchable OCR/reference data rather than raw image files. No environment-specific node names, hosts, credentials, or setup assumptions are included.

## Verification

- full bundled-Node test suite passes
- focused Computer History / observation / OCR suite passes (24 tests)
- focused SQLite tests pass twice against isolated temporary data directories
- desktop visual pass completed with synthetic observations
- XSS/privacy review: all observation-derived strings remain escaped; no raw paths/images are exposed; response limit is bounded
- `git diff --check` and Node syntax checks pass