### PR TITLE
[codex] surface iMessage bridge policy failures

### DIFF
--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -38,7 +38,11 @@ import { summarizeRegisterMcpServer } from "./tool-registry.js";
 import { logAgentFailure, publicAgentFailure } from "./agent-failure.js";
 import { NodeControlBroker, createNodeControlWorker, sanitizeNodeCapabilities, pinnedRemoteOrigin } from "./node-control.js";
 import { createConfiguredComputerExecutor } from "./integrations/cua-computer-executor.js";
-import { createImessageBridgeRuntime } from "./integrations/imessage-bridge-runtime.js";
+import {
+  createImessageBridgeRuntime,
+  imessageBridgeCapability,
+  imessageBridgeConfig
+} from "./integrations/imessage-bridge-runtime.js";
 import {
   createImessageNodeCapability,
   isImessageSearchEnabled
@@ -530,6 +534,23 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
       imessageNodeCapability ??= options.imessageNodeCapability
         ?? createImessageNodeCapability({ env: serviceEnv });
       providers.set(imessageNodeCapability.id, imessageNodeCapability);
+    }
+    if (imessageBridgeConfig(serviceEnv).enabled) {
+      providers.set("imessage-bridge", {
+        async health() {
+          const status = imessageBridgeRuntime?.status?.() ?? {
+            enabled: true,
+            running: false,
+            detailCode: "not-started",
+            lastDecisionCode: null
+          };
+          const capability = imessageBridgeCapability(status);
+          return { ok: capability.ready, service: "imessage", capability };
+        },
+        async invoke() {
+          throw new Error("iMessage bridge status has no remote operations");
+        }
+      });
     }
     return providers;
   };
@@ -2118,6 +2139,14 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
                     ? "Disabled. Set OPENAGI_IMESSAGE_BRIDGE=1; the safe default requires a self-handle/allowlist plus the ‘openagi’ trigger and captures no ambient messages."
                     : s.detailCode === "full-disk-access-required"
                       ? "Full Disk Access is required for the signed OpenAGI app; restart OpenAGI after granting it."
+                      : s.detailCode === "ready" && s.lastDecisionCode === "trigger-mismatch"
+                        ? "Running, but the most recent eligible message did not contain the configured trigger word."
+                      : s.detailCode === "ready" && s.lastDecisionCode === "not-allowed"
+                        ? "Running, but the most recent message was not in the configured sender or chat allowlist."
+                      : s.detailCode === "ready" && s.lastDecisionCode === "responses-disabled"
+                        ? "Running in capture-only mode; automatic replies are disabled."
+                      : s.detailCode === "ready" && s.lastDecisionCode === "reply-error"
+                        ? "Running, but the most recent attempted reply failed. Check main/provider health and Messages Automation permission."
                       : s.detailCode === "ready"
                         ? "Running under the signed OpenAGI daemon identity with scoped node authentication."
                         : `Bridge ${s.running ? "is running" : "is stopped"}; status: ${s.detailCode}.`
@@ -6403,7 +6432,11 @@ async function renderNodesOnce({ showLoading = true } = {}) {
     const revoke = !isNode && !n.self
       ? \`<div style="margin-top:6px;"><button class="ui-btn ui-btn-destructive ui-btn-sm" data-revoke-node="\${escapeHtml(n.nodeId)}">Remove node</button></div>\`
       : "";
-    const capabilityLabels = { "computer-use": "Computer use", "imessage-search": "iMessage search" };
+    const capabilityLabels = {
+      "computer-use": "Computer use",
+      "imessage-search": "iMessage search",
+      "imessage-bridge": "iMessage replies"
+    };
     const capabilities = (Array.isArray(n.capabilities) ? n.capabilities : []).map((capability) => {
       const label = capabilityLabels[capability.id] ?? String(capability.id ?? "capability").replaceAll("-", " ");
       const stateLabel = capability.ready === true ? "ready" : "not ready";

--- a/src/integrations/imessage-bridge-runtime.js
+++ b/src/integrations/imessage-bridge-runtime.js
@@ -30,6 +30,34 @@ export function imessageBridgeConfig(env = process.env) {
   };
 }
 
+// A paired main needs to distinguish "the Messages database is searchable"
+// from "this Mac is actively polling and allowed to reply." Advertise that as
+// a status-only capability over the existing authenticated outbound relay.
+// No handles, trigger text, message text, paths, or raw errors cross machines.
+export function imessageBridgeCapability(status, now = () => Date.now()) {
+  const enabled = status?.enabled === true;
+  const running = status?.running === true;
+  const ready = enabled && running && status?.detailCode === "ready";
+  const decision = [
+    "trigger-mismatch",
+    "not-allowed",
+    "responses-disabled",
+    "reply-error"
+  ].includes(status?.lastDecisionCode)
+    ? status.lastDecisionCode
+    : null;
+  const detail = ready
+    ? (decision ? `ready:${decision}` : "ready")
+    : String(status?.detailCode ?? (enabled ? "not-started" : "disabled")).slice(0, 80);
+  return {
+    id: "imessage-bridge",
+    ready,
+    operations: [],
+    detail,
+    checkedAt: new Date(now()).toISOString()
+  };
+}
+
 export function createImessageBridgeRuntime(options = {}) {
   const dataDir = options.dataDir ?? resolveDataDir();
   const env = options.env ?? process.env;

--- a/src/integrations/imessage-bridge.js
+++ b/src/integrations/imessage-bridge.js
@@ -113,7 +113,20 @@ export class IMessageBridge {
       lastSuccessAt: null,
       lastErrorAt: null,
       detailCode: "stopped",
-      totals: { processed: 0, replied: 0, captured: 0, skipped: 0, errors: 0 }
+      // Operational counters are deliberately metadata-only. They make a
+      // silent policy skip diagnosable without exposing handles or message
+      // content through status, logs, heartbeats, or the dashboard.
+      lastDecisionCode: null,
+      totals: {
+        processed: 0,
+        replied: 0,
+        captured: 0,
+        skipped: 0,
+        triggerMisses: 0,
+        notAllowed: 0,
+        responsesDisabled: 0,
+        errors: 0
+      }
     };
     // Texts the bridge itself just sent — so reading the self-thread doesn't
     // echo our own replies back into capture/reply (would otherwise loop).
@@ -176,6 +189,19 @@ export class IMessageBridge {
       for (const key of Object.keys(this._status.totals)) {
         this._status.totals[key] += Number(summary?.[key] ?? 0);
       }
+      this._status.lastDecisionCode = Number(summary?.replied ?? 0) > 0
+        ? "replied"
+        : Number(summary?.errors ?? 0) > 0
+          ? "reply-error"
+          : Number(summary?.triggerMisses ?? 0) > 0
+            ? "trigger-mismatch"
+            : Number(summary?.notAllowed ?? 0) > 0
+              ? "not-allowed"
+              : Number(summary?.responsesDisabled ?? 0) > 0
+                ? "responses-disabled"
+                : Number(summary?.processed ?? 0) > 0
+                  ? "no-reply"
+                  : "idle";
     } else if (kind.endsWith("error")) {
       this._status.lastPollAt = at;
       this._status.lastErrorAt = at;
@@ -201,21 +227,26 @@ export class IMessageBridge {
     const allowed = noAllowlist
       || this.allowFrom.has(String(handle).toLowerCase())
       || (chatId != null && this.allowChats.has(String(chatId).toLowerCase()));
-    if (this.respondMode === "none") return { respond: false };
+    if (this.respondMode === "none") return { respond: false, reason: "responses-disabled" };
     if (this.respondMode === "all") return { respond: true, forward: text };
-    if (this.respondMode === "allow") return { respond: allowed, forward: text };
+    if (this.respondMode === "allow") {
+      return allowed
+        ? { respond: true, forward: text }
+        : { respond: false, reason: "not-allowed" };
+    }
     if (this.respondMode === "trigger") {
-      if (!allowed || !this.trigger) return { respond: false };
+      if (!allowed) return { respond: false, reason: "not-allowed" };
+      if (!this.trigger) return { respond: false, reason: "responses-disabled" };
       // Match the trigger as a whole word so "Peri, what's up?" fires but
       // "perimeter" / "period" don't.
       const wordRe = new RegExp(`\\b${escapeRe(this.trigger)}\\b`, "i");
-      if (!wordRe.test(text)) return { respond: false };
+      if (!wordRe.test(text)) return { respond: false, reason: "trigger-mismatch" };
       // Strip a leading "<trigger>" mention so it isn't echoed back into the
       // prompt ("Peri what's up" → "what's up"); a bare "Peri" forwards as-is.
       const stripped = text.replace(new RegExp(`^\\s*${escapeRe(this.trigger)}\\b[\\s,:!.?]*`, "i"), "").trim();
       return { respond: true, forward: stripped || text };
     }
-    return { respond: false };
+    return { respond: false, reason: "responses-disabled" };
   }
 
   shouldCapture(handle) {
@@ -240,6 +271,7 @@ export class IMessageBridge {
 
     const rows = await this.readMessages(state.lastDate);
     let processed = 0, replied = 0, captured = 0, skipped = 0, errors = 0;
+    let triggerMisses = 0, notAllowed = 0, responsesDisabled = 0;
     let highest = state.lastDate;
     for (const row of rows) {
       if (row.appleDate && BigInt(row.appleDate) > BigInt(highest || 0)) highest = row.appleDate;
@@ -269,7 +301,13 @@ export class IMessageBridge {
 
       // 2. Reply per the response policy.
       const decision = this.responseFor(row.handle, text, row.chatId);
-      if (!decision.respond) { skipped++; continue; }
+      if (!decision.respond) {
+        skipped++;
+        if (decision.reason === "trigger-mismatch") triggerMisses++;
+        else if (decision.reason === "not-allowed") notAllowed++;
+        else responsesDisabled++;
+        continue;
+      }
       try {
         // Session keys off the conversation so a group has one shared thread.
         const sessionKey = row.isGroup ? row.chatId : row.handle;
@@ -294,7 +332,16 @@ export class IMessageBridge {
       }
     }
     this._saveState({ ...state, lastDate: highest });
-    return { processed, replied, captured, skipped, errors };
+    return {
+      processed,
+      replied,
+      captured,
+      skipped,
+      triggerMisses,
+      notAllowed,
+      responsesDisabled,
+      errors
+    };
   }
 
   // Run the poll loop until stop() is called. Default 10s: a read-only reader is

--- a/test/imessage-bridge-runtime.test.js
+++ b/test/imessage-bridge-runtime.test.js
@@ -3,7 +3,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { createImessageBridgeRuntime, imessageBridgeConfig } from "../src/integrations/imessage-bridge-runtime.js";
+import {
+  createImessageBridgeRuntime,
+  imessageBridgeCapability,
+  imessageBridgeConfig
+} from "../src/integrations/imessage-bridge-runtime.js";
 import { writeNodeConfig } from "../src/cli-client.js";
 
 test("integrated bridge is opt-in and cannot answer anyone without an allowlist", () => {
@@ -35,7 +39,17 @@ test("daemon-owned bridge starts and stops once with bounded public status", () 
         lastSuccessAt: null,
         lastErrorAt: null,
         detailCode: "starting",
-        totals: { processed: 0, replied: 0, captured: 0, skipped: 0, errors: 0 }
+        lastDecisionCode: null,
+        totals: {
+          processed: 0,
+          replied: 0,
+          captured: 0,
+          skipped: 0,
+          triggerMisses: 0,
+          notAllowed: 0,
+          responsesDisabled: 0,
+          errors: 0
+        }
       };
     }
   };
@@ -59,11 +73,31 @@ test("daemon-owned bridge starts and stops once with bounded public status", () 
   assert.deepEqual(received.allowFrom, ["first@example.test", "second@example.test"]);
   assert.equal(received.start.intervalMs, 2_000, "poll interval is clamped to the safe minimum");
   assert.deepEqual(Object.keys(runtime.status()).sort(), [
-    "capture", "detailCode", "enabled", "lastErrorAt", "lastEvent", "lastPollAt",
-    "lastSuccessAt", "mode", "running", "startedAt", "totals"
+    "capture", "detailCode", "enabled", "lastDecisionCode", "lastErrorAt", "lastEvent",
+    "lastPollAt", "lastSuccessAt", "mode", "running", "startedAt", "totals"
   ]);
   runtime.stop();
   assert.equal(stops, 1);
+});
+
+test("bridge capability advertises only bounded categorical health", () => {
+  const capability = imessageBridgeCapability({
+    enabled: true,
+    running: true,
+    detailCode: "ready",
+    lastDecisionCode: "trigger-mismatch",
+    trigger: "private-trigger",
+    allowFrom: ["private@example.test"]
+  }, () => Date.parse("2026-08-20T12:00:00.000Z"));
+
+  assert.deepEqual(capability, {
+    id: "imessage-bridge",
+    ready: true,
+    operations: [],
+    detail: "ready:trigger-mismatch",
+    checkedAt: "2026-08-20T12:00:00.000Z"
+  });
+  assert.doesNotMatch(JSON.stringify(capability), /private-trigger|private@example/);
 });
 
 test("paired bridge refuses the broad enrollment credential until scoped enrollment is confirmed", () => {

--- a/test/imessage-bridge.test.js
+++ b/test/imessage-bridge.test.js
@@ -81,6 +81,7 @@ test("allowlist drops messages from non-allowed senders", async () => {
   bridge.client.chat = async () => ({ ok: true, json: { reply: "ok" } });
   const r = await bridge.poll();
   assert.equal(r.skipped, 1, "non-allowed sender skipped");
+  assert.equal(r.notAllowed, 1, "skip reason is counted without exposing the sender");
   assert.equal(r.replied, 1, "allowed sender answered");
   assert.equal(sent.length, 1);
   assert.equal(sent[0].handle, "+15551112222");
@@ -181,6 +182,7 @@ test("respond=all replies to everyone; respond=none never replies", async () => 
   b.bridge.readMessages = async () => [{ rowid: 1, handle: "+1999", text: "hi" }];
   const r = await b.bridge.poll();
   assert.equal(r.replied, 0);
+  assert.equal(r.responsesDisabled, 1);
   assert.equal(b.sent.length, 0);
 });
 
@@ -192,8 +194,30 @@ test("respond=trigger only replies on the trigger word, stripped before forwardi
   ];
   const r = await b.bridge.poll();
   assert.equal(r.replied, 1, "only the triggered message");
+  assert.equal(r.triggerMisses, 1, "a trigger miss is visible as metadata-only diagnostics");
   assert.equal(b.forwarded.length, 1);
   assert.equal(b.forwarded[0].text, "what's the weather?", "trigger prefix stripped");
+});
+
+test("bridge status records the latest policy decision without private message data", async () => {
+  const b = policyBridge({
+    respondMode: "trigger",
+    trigger: "peri",
+    allowFrom: ["private@example.test"]
+  });
+  b.bridge.readMessages = async () => [{
+    rowid: 1,
+    appleDate: "1",
+    handle: "private@example.test",
+    text: "private body without the trigger"
+  }];
+  const result = await b.bridge.poll();
+  b.bridge._recordEvent("poll-success", null, result);
+
+  const status = b.bridge.status();
+  assert.equal(status.lastDecisionCode, "trigger-mismatch");
+  assert.equal(status.totals.triggerMisses, 1);
+  assert.doesNotMatch(JSON.stringify(status), /private@example|private body|peri/);
 });
 
 test("respond=trigger matches the keyword as a whole word, not a substring", async () => {

--- a/test/node-heartbeat-sender.test.js
+++ b/test/node-heartbeat-sender.test.js
@@ -63,6 +63,63 @@ test("a paired instance heartbeats immediately on listen instead of waiting for 
   }
 });
 
+test("paired nodes advertise privacy-safe iMessage bridge reply health", async () => {
+  const mainDir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-hb-imessage-main-"));
+  const credential = "test-only-imessage-pairing";
+  const mainRuntime = createDurableRuntime({ dataDir: mainDir });
+  const mainApp = createHostedInterface(mainRuntime, {
+    host: "127.0.0.1", port: 0, tickerMs: 0, dataDir: mainDir, authToken: credential
+  });
+  const mainBase = (await mainApp.listen()).url;
+
+  const nodeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-hb-imessage-node-"));
+  writeNodeConfig({ remote: mainBase, token: credential }, nodeDir);
+  const nodeRuntime = createDurableRuntime({ dataDir: nodeDir });
+  const bridgeStatus = {
+    enabled: true,
+    running: true,
+    detailCode: "ready",
+    lastDecisionCode: "not-allowed"
+  };
+  const nodeApp = createHostedInterface(nodeRuntime, {
+    host: "127.0.0.1",
+    port: 0,
+    tickerMs: 0,
+    dataDir: nodeDir,
+    heartbeatIntervalMs: 20,
+    serviceEnv: {
+      OPENAGI_IMESSAGE_BRIDGE: "1",
+      IMESSAGE_TRIGGER: "private-trigger",
+      IMESSAGE_ALLOW: "private@example.test"
+    },
+    imessageBridgeRuntime: {
+      start() {},
+      stop() {},
+      status: () => bridgeStatus
+    }
+  });
+  await nodeApp.listen();
+
+  try {
+    let capability = null;
+    for (let attempt = 0; attempt < 40 && !capability; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      const roster = await (await fetch(`${mainBase}/nodes`, {
+        headers: { authorization: `Bearer ${credential}` }
+      })).json();
+      capability = roster.nodes
+        .find((node) => !node.self)?.capabilities
+        ?.find((entry) => entry.id === "imessage-bridge" && entry.ready) ?? null;
+    }
+    assert.deepEqual(capability?.operations, []);
+    assert.equal(capability?.detail, "ready:not-allowed");
+    assert.doesNotMatch(JSON.stringify(capability), /private-trigger|private@example/);
+  } finally {
+    await nodeApp.close();
+    await mainApp.close();
+  }
+});
+
 test("a failed heartbeat POST does not crash the sender or the process", async () => {
   const nodeDir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-hb-fail-"));
   writeNodeConfig({ remote: "http://127.0.0.1:1", token: null }, nodeDir); // nothing listens on port 1


### PR DESCRIPTION
## Problem

An iMessage can be present in the paired Mac's Messages database while OpenAGI remains silent because the message missed the configured trigger or sender/chat allowlist. The bridge currently reports only that polling is healthy, so the main dashboard cannot distinguish a policy skip from a broken bridge.

## Root cause

Policy decisions were collapsed into one `skipped` counter, and paired-node heartbeats advertised history-search readiness but not conversation-bridge readiness. This made a healthy bridge with a mismatched iMessage identity or trigger look indistinguishable from a disconnected installation.

## Changes

- Track metadata-only trigger-mismatch, not-allowlisted, and replies-disabled counters.
- Record a bounded categorical last decision without storing handles or message text.
- Advertise `imessage-bridge` as a status-only paired-node capability with zero remote operations.
- Show readable iMessage reply health in Integrations and Nodes.
- Add a real main/node heartbeat test proving the capability crosses the authenticated outbound relay without leaking configured handles or trigger text.

## Security and privacy

No message text, sender handle, trigger text, path, token, URL, or raw error is added to status or heartbeat payloads. Capability data remains sanitized and HTML-escaped, and the new status capability exposes no callable operations.

## Verification

- `build/OpenAGI.app/Contents/Resources/node/bin/node --test` — 1,013 passed
- `swift test` — 35 passed
- Focused iMessage/heartbeat tests — 33 passed
- Fresh signed macOS app build and code-sign validation passed
- Git safety guard passed for staged files and the complete commit range
