### PR TITLE
[codex] prepare v0.0.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagi",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "private": true,
   "type": "module",
   "description": "Generic ABI runtime scaffold for directional adaptive scrutiny, tiered memory, and propagation.",


### PR DESCRIPTION
## Release

Prepare OpenAGI v0.0.19 from `main` after the computer-history timeline and iMessage bridge observability changes merged.

## Included user-visible changes

- Adds OCR-backed, screenshot-oriented Computer History with retention and capture-health controls.
- Adds skill suggestions from computer-history context.
- Makes iMessage bridge trigger, allowlist, and disabled-response policy failures visible without exposing message content, account handles, trigger text, credentials, paths, or raw errors.
- Advertises iMessage bridge health as a status-only node capability with no remotely callable operations.

## Verification

The exact implementation merged into `main` passed 1,013 JavaScript tests, 35 Swift tests, focused iMessage/heartbeat coverage, a fresh signed macOS app build, code-sign validation, and the repository secret guard. This release commit changes only the package version from 0.0.18 to 0.0.19.
