### PR TITLE
[codex] make memory quality measurable and correctable

### DIFF
--- a/src/agent-host.js
+++ b/src/agent-host.js
@@ -177,6 +177,7 @@ export class AgentHost {
       try {
         const rawHits = await this.runtime.vectorStore.search("principle", text, { limit: 10, minScore: 0.1 });
         intuitions = filterPrincipleHits(rawHits, this.runtime.memory, { limit: 3 });
+        this.runtime.memory?.recordRecalls?.(intuitions.map((hit) => hit.id), { source: "principle-context" });
       } catch { /* best effort */ }
     }
 

--- a/src/file-backed-memory-system.js
+++ b/src/file-backed-memory-system.js
@@ -37,6 +37,23 @@ export class FileBackedMemorySystem extends MemorySystem {
     return item;
   }
 
+  recordRecalls(ids, options = {}) {
+    const updated = super.recordRecalls(ids, options);
+    if (updated.length > 0) {
+      // Deliberately omit the query and memory content. IDs plus bounded
+      // counters are enough to audit usefulness without duplicating private
+      // material into the append-only event log.
+      this.persist("recall", {
+        items: updated.map((item) => ({
+          id: item.id,
+          recallCount: item.metadata.recallCount,
+          lastRecalledAt: item.metadata.lastRecalledAt
+        }))
+      });
+    }
+    return updated;
+  }
+
   correct(input) {
     // super.correct() routes the new locked item through this.remember()
     // (already persisted); this extra event captures the supersede mutations

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -856,6 +856,35 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
         );
         return sendJson(res, 200, { id: item.id, tier: item.tier });
       }
+      if (method === "POST" && /^\/memory\/[^/]+\/correct$/.test(pathname)) {
+        const id = decodeURIComponent(pathname.slice("/memory/".length, -"/correct".length));
+        const body = await readJsonLimited(req, 16 * 1024).catch(() => null);
+        if (!body || typeof body !== "object" || Array.isArray(body)) {
+          return sendJson(res, 400, { error: "invalid correction request" });
+        }
+        const correction = String(body?.correction ?? "").trim();
+        if (!correction) return sendJson(res, 400, { error: "correction required" });
+        if (correction.length > 10_000) return sendJson(res, 400, { error: "correction too long" });
+        // Re-read after the only await in this branch. From here through
+        // correct() execution is synchronous, so concurrent submissions
+        // cannot both pass the active-row check and create conflicting fixes.
+        const current = runtime.memory?.items?.get?.(id);
+        if (!current) return sendJson(res, 404, { error: "unknown memory" });
+        if (current.metadata?.supersededBy) return sendJson(res, 409, { error: "memory already superseded" });
+        const result = runtime.memory.correct({
+          id,
+          content: correction,
+          scope: current.scope ?? "main",
+          source: "dashboard-correction",
+          metadata: { userAuthored: true, channel: "dashboard" }
+        });
+        return sendJson(res, 200, {
+          id: result.item.id,
+          tier: result.item.tier,
+          locked: result.item.locked,
+          supersededCount: result.superseded.length
+        });
+      }
       if (method === "GET" && pathname === "/agents") return sendJson(res, 200, runtime.agentHost?.store.listAgents() ?? runtime.propagation.list());
       if (method === "GET" && pathname === "/specialists") {
         const includeRetired = url.searchParams.get("retired") === "1";
@@ -3773,6 +3802,13 @@ function renderApp() {
     .mem-content { font-size: 13px; line-height: 1.5; max-height: 8.4em; overflow: hidden; position: relative; word-break: break-word; }
     .mem-content::after { content: ""; position: absolute; bottom: 0; left: 0; right: 0; height: 1.6em; background: linear-gradient(transparent, var(--panel)); pointer-events: none; }
     .mem-tags { display: flex; gap: 4px; flex-wrap: wrap; }
+    .mem-actions { display: flex; gap: 8px; align-items: center; margin-top: auto; }
+    .mem-actions button { background: transparent; color: var(--accent); border: 1px solid var(--line); border-radius: 6px; padding: 5px 9px; cursor: pointer; font: inherit; font-size: 11px; }
+    .mem-actions button:hover { border-color: var(--accent); }
+    .mem-correction { display: grid; gap: 7px; border-top: 1px solid var(--line); padding-top: 8px; }
+    .mem-correction[hidden] { display: none; }
+    .mem-correction textarea { min-height: 74px; resize: vertical; font-size: 12px; line-height: 1.4; }
+    .mem-correction .row button { font-size: 11px; padding: 5px 9px; }
     .chip { background: var(--bg); color: var(--muted); padding: 2px 8px; border-radius: 10px; font-size: 11px; border: 1px solid var(--line); white-space: nowrap; }
 
     /* OAuth banner */
@@ -6177,16 +6213,26 @@ async function renderMemory() {
 function renderMemoryView() {
   const snap = state.memorySnap || { short: [], medium: [], long: [] };
   const f = state.memoryFilter;
-  const counts = { short: snap.short.length, medium: snap.medium.length, long: snap.long.length };
+  const active = (items) => (items ?? []).filter((m) => !m.metadata?.supersededBy);
+  const counts = { short: active(snap.short).length, medium: active(snap.medium).length, long: active(snap.long).length };
   const total = counts.short + counts.medium + counts.long;
-  const principles = snap.long.filter((m) => m.kind === "principle").length;
+  const allActive = [...active(snap.short), ...active(snap.medium), ...active(snap.long)];
+  const principles = allActive.filter((m) => m.kind === "principle").length;
+  const corrections = allActive.filter((m) => m.kind === "correction" || m.locked).length;
+  const recalled = allActive.filter((m) => (m.metadata?.recallCount ?? 0) > 0 || (m.lastAccessedAt || "") > (m.lastObservedAt || "")).length;
+  const recallCoverage = total > 0 ? Math.round((recalled / total) * 100) : 0;
 
   main.innerHTML = \`
     <div class="pane">
       <div class="row between" style="margin-bottom:14px;align-items:center;flex-wrap:wrap;gap:10px;">
-        <h2 style="margin:0;">Memory <span class="muted" style="font-weight:400;font-size:14px;">· \${total} total · \${principles} principle\${principles===1?"":"s"}\${uiHelp("Principles are durable rules promoted from repeated raw memories. They live in long-tier and resist decay.")}</span></h2>
+        <h2 style="margin:0;">Memory <span class="muted" style="font-weight:400;font-size:14px;">· \${total} active · \${principles} principle\${principles===1?"":"s"} · \${corrections} correction\${corrections===1?"":"s"}\${uiHelp("Principles are durable rules promoted from repeated raw memories. Corrections are locked and replace stale facts.")}</span></h2>
       </div>
       <div id="memoryPageChat"></div>
+      <div class="grid stats" style="margin-bottom:14px;">
+        <div class="card"><span class="desc">Recall coverage</span><div class="stat-value">\${recallCoverage}%</div><div class="desc">\${recalled} of \${total} active memories have been used</div></div>
+        <div class="card"><span class="desc">Corrections locked</span><div class="stat-value">\${corrections}</div><div class="desc">Superseded facts stay hidden from recall</div></div>
+        <div class="card"><span class="desc">Durable principles</span><div class="stat-value">\${principles}</div><div class="desc">Long-term distilled guidance</div></div>
+      </div>
       <div class="row" style="gap:10px;align-items:center;margin-bottom:14px;flex-wrap:wrap;">
         <div class="tier-pills">
           <button data-tier="all" class="\${f.tier==='all'?'active':''}">All <span class="count">\${total}</span></button>
@@ -6231,6 +6277,7 @@ function fillMemoryGrid() {
   if (f.tier === "all" || f.tier === "short") items = items.concat((snap.short ?? []).map((m) => ({ ...m, _tier: "short" })));
   if (f.tier === "all" || f.tier === "medium") items = items.concat((snap.medium ?? []).map((m) => ({ ...m, _tier: "medium" })));
   if (f.tier === "all" || f.tier === "long") items = items.concat((snap.long ?? []).map((m) => ({ ...m, _tier: "long" })));
+  items = items.filter((m) => !m.metadata?.supersededBy);
 
   if (f.query) {
     const q = f.query.toLowerCase();
@@ -6252,20 +6299,60 @@ function fillMemoryGrid() {
     const kindBadge = m.kind === "principle" ? '<span class="badge ok">principle</span>' : "";
     const dangerBadge = (m.dangerLevel || 0) > 0.7 ? '<span class="badge err">⚠ danger</span>' : "";
     const scopeBadge = m.scope && m.scope !== "main" ? \`<span class="badge">\${escapeHtml(m.scope)}</span>\` : "";
+    const correctionBadge = m.kind === "correction" || m.locked ? '<span class="badge ok">corrected</span>' : "";
+    const recallCount = Math.max(0, Number(m.metadata?.recallCount) || 0);
+    const recallBadge = recallCount > 0 ? \`<span class="badge">recalled \${recallCount}×</span>\` : '<span class="badge muted">not recalled yet</span>';
     const age = m.createdAt ? timeAgo(m.createdAt) : "";
     return \`
-      <div class="mem-card tier-\${m._tier}">
+      <div class="mem-card tier-\${m._tier}" data-memory-id="\${escapeHtml(m.id)}">
         <div class="mem-head">
           <span class="badge tier-\${m._tier}">\${m._tier}</span>
-          \${kindBadge}\${dangerBadge}\${scopeBadge}
+          \${kindBadge}\${correctionBadge}\${dangerBadge}\${scopeBadge}\${recallBadge}
           <span class="badge">str \${(m.strength ?? 0).toFixed(2)}</span>
           <span class="mem-age">\${escapeHtml(age)}</span>
         </div>
         <div class="mem-content">\${escapeHtml(m.content || "")}</div>
         \${tags ? \`<div class="mem-tags">\${tags}</div>\` : ""}
+        <div class="mem-actions"><button type="button" data-memory-correct="\${escapeHtml(m.id)}">Correct this memory</button><span class="muted" data-memory-status></span></div>
+        <form class="mem-correction" data-memory-form="\${escapeHtml(m.id)}" hidden>
+          <label class="desc" for="memory-correction-\${escapeHtml(m.id)}">Replace it with the complete corrected fact</label>
+          <textarea id="memory-correction-\${escapeHtml(m.id)}" name="correction" required>\${escapeHtml(m.content || "")}</textarea>
+          <div class="row"><button type="submit">Save correction</button><button type="button" class="secondary" data-memory-cancel>Cancel</button></div>
+        </form>
       </div>
     \`;
   }).join("");
+
+  list.querySelectorAll("[data-memory-correct]").forEach((button) => button.addEventListener("click", () => {
+    const card = button.closest("[data-memory-id]");
+    const form = card?.querySelector("[data-memory-form]");
+    if (!form) return;
+    form.hidden = false;
+    form.querySelector("textarea")?.focus();
+  }));
+  list.querySelectorAll("[data-memory-cancel]").forEach((button) => button.addEventListener("click", () => {
+    const form = button.closest("[data-memory-form]");
+    if (form) form.hidden = true;
+  }));
+  list.querySelectorAll("[data-memory-form]").forEach((form) => form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const id = form.getAttribute("data-memory-form");
+    const correction = String(new FormData(form).get("correction") ?? "").trim();
+    const card = form.closest("[data-memory-id]");
+    const status = card?.querySelector("[data-memory-status]");
+    const submit = form.querySelector('button[type="submit"]');
+    if (!correction || !id) return;
+    submit.disabled = true;
+    if (status) status.textContent = "Saving…";
+    try {
+      await postJson(\`/memory/\${encodeURIComponent(id)}/correct\`, { correction });
+      state.memorySnap = await fetchJson("/memory");
+      renderMemoryView();
+    } catch (error) {
+      submit.disabled = false;
+      if (status) status.textContent = error.message || "Correction failed";
+    }
+  }));
 }
 
 function timeAgo(iso) {
@@ -6848,6 +6935,11 @@ async function renderHealth() {
         <div class="card"><span class="desc">Medium tier</span><div class="stat-value">\${mem.counts.medium ?? 0}</div><div class="desc">\${((mem.saturation.medium ?? 0) * 100).toFixed(0)}% saturated</div></div>
         <div class="card"><span class="desc">Long tier</span><div class="stat-value">\${mem.counts.long ?? 0}</div><div class="desc">\${((mem.saturation.long ?? 0) * 100).toFixed(0)}% saturated</div></div>
         <div class="card"><span class="desc">Principles</span><div class="stat-value">\${mem.principles ?? 0}</div></div>
+        <div class="card"><span class="desc">Recall coverage</span><div class="stat-value">\${Math.round((mem.quality?.recallCoverage ?? 0) * 100)}%</div><div class="desc">\${mem.quality?.recalled ?? 0} of \${mem.quality?.active ?? 0} active</div></div>
+        <div class="card"><span class="desc">Total recalls</span><div class="stat-value">\${mem.quality?.totalRecalls ?? 0}</div><div class="desc">Persisted across restarts</div></div>
+        <div class="card"><span class="desc">Corrections</span><div class="stat-value">\${mem.quality?.corrections ?? 0}</div><div class="desc">Locked user fixes</div></div>
+        <div class="card"><span class="desc">Weak memories</span><div class="stat-value">\${mem.quality?.weak ?? 0}</div><div class="desc">Strength below 0.30</div></div>
+        <div class="card"><span class="desc">Exact duplicates</span><div class="stat-value">\${mem.quality?.duplicateRows ?? 0}</div></div>
       </div>
 
       <h3>Outcomes</h3>

--- a/src/introspector.js
+++ b/src/introspector.js
@@ -28,6 +28,7 @@ export class Introspector {
       medium: memSnap.medium.length / memLimits.medium,
       long: memSnap.long.length / memLimits.long
     };
+    const memQuality = r.memory.qualityStats?.() ?? null;
 
     const cron = r.cron?.listJobs?.() ?? [];
     const enabledCron = cron.filter((j) => j.enabled);
@@ -47,6 +48,12 @@ export class Introspector {
     const findings = [];
     if (memSaturation.short > 0.85) findings.push({ severity: "warn", area: "memory", note: "short tier > 85% — older items will start dropping." });
     if (memSaturation.long > 0.85) findings.push({ severity: "warn", area: "memory", note: "long tier > 85% — consider raising limit or curating principles." });
+    if (memQuality?.active >= 50 && memQuality.recallCoverage < 0.2) {
+      findings.push({ severity: "info", area: "memory", note: `Only ${Math.round(memQuality.recallCoverage * 100)}% of active memories have been recalled — improve retrieval or retire low-value rows.` });
+    }
+    if (memQuality?.duplicateRows > 0) {
+      findings.push({ severity: "warn", area: "memory", note: `${memQuality.duplicateRows} exact duplicate memory row(s) remain active.` });
+    }
     if (dormant.length > 0) findings.push({ severity: "info", area: "specialists", note: `${dormant.length} specialist(s) dormant >14d — retirement-sweep will handle at 30d.` });
     if (lowQuality.length > 0) findings.push({ severity: "warn", area: "specialists", note: `${lowQuality.length} specialist(s) under-performing (<0.4 mean quality).` });
     if (budget && budget.spentUsd / Math.max(budget.dailyUsdLimit, 0.0001) > 0.7) findings.push({ severity: "warn", area: "budget", note: `today's spend > 70% of daily cap.` });
@@ -80,7 +87,8 @@ export class Introspector {
       memory: {
         counts: { short: memSnap.short.length, medium: memSnap.medium.length, long: memSnap.long.length },
         saturation: memSaturation,
-        principles: memSnap.long.filter((m) => m.kind === "principle").length
+        principles: memSnap.long.filter((m) => m.kind === "principle" && !m.metadata?.supersededBy).length,
+        quality: memQuality
       },
       cron: { total: cron.length, enabled: enabledCron.length, upcoming },
       budget,

--- a/src/memory-system.js
+++ b/src/memory-system.js
@@ -219,11 +219,43 @@ export class MemorySystem {
 
     scored.sort((a, b) => b.score - a.score);
     const now = options.now ?? nowIso();
-    for (const entry of scored.slice(0, limit)) {
-      entry.item.lastAccessedAt = now;
-      entry.item.strength = clamp(entry.item.strength + 0.03);
+    const selected = scored.slice(0, limit);
+    this.recordRecalls(selected.map((entry) => entry.item.id), {
+      now,
+      source: options.source ?? "retrieve"
+    });
+    return selected;
+  }
+
+  /**
+   * Record that stored memories were actually placed into a retrieval result.
+   * The base implementation updates only aggregate metadata on the item; the
+   * file-backed subclass persists the same mutation with a content-free
+   * receipt. Keeping this separate also lets vector-backed principle recall
+   * use the same accounting without copying private text into telemetry.
+   */
+  recordRecalls(ids, { now = nowIso(), source = "retrieve" } = {}) {
+    const recalledAt = now instanceof Date ? now.toISOString() : String(now);
+    const safeSource = ["retrieve", "principle-context"].includes(source) ? source : "retrieve";
+    const updated = [];
+    for (const id of new Set(Array.isArray(ids) ? ids : [])) {
+      const item = this.items.get(id);
+      if (!item || item.metadata?.supersededBy) continue;
+      const priorSources = item.metadata?.recallSources ?? {};
+      item.lastAccessedAt = recalledAt;
+      item.strength = clamp((item.strength ?? 0) + 0.03);
+      item.metadata = {
+        ...(item.metadata ?? {}),
+        recallCount: Math.max(0, Number(item.metadata?.recallCount) || 0) + 1,
+        lastRecalledAt: recalledAt,
+        recallSources: {
+          ...priorSources,
+          [safeSource]: Math.max(0, Number(priorSources[safeSource]) || 0) + 1
+        }
+      };
+      updated.push(item);
     }
-    return scored.slice(0, limit);
+    return updated;
   }
 
   reinforce(id, amount = 0.1) {
@@ -530,6 +562,56 @@ export class MemorySystem {
       short: this.byTier("short"),
       medium: this.byTier("medium"),
       long: this.byTier("long")
+    };
+  }
+
+  /**
+   * Content-free quality signals for health/audit surfaces. These are derived
+   * from active rows only: superseded facts remain in the local audit trail
+   * until retention removes them, but must not make recall coverage or memory
+   * pressure look healthier than the brain the agent can actually use.
+   */
+  qualityStats() {
+    const active = [...this.items.values()].filter((item) => !item.metadata?.supersededBy);
+    const recalled = active.filter((item) => (
+      Math.max(0, Number(item.metadata?.recallCount) || 0) > 0 ||
+      String(item.lastAccessedAt ?? "") > String(item.lastObservedAt ?? "")
+    ));
+    const weakByTier = { short: 0, medium: 0, long: 0 };
+    for (const item of active) {
+      if ((item.strength ?? 0) < 0.3 && Object.hasOwn(weakByTier, item.tier)) weakByTier[item.tier] += 1;
+    }
+
+    const duplicateGroups = new Map();
+    for (const item of active) {
+      if (isProtectedMemory(item) || !item.rawContentHash) continue;
+      const key = [
+        item.tier,
+        item.scope ?? "main",
+        item.kind ?? "raw",
+        item.source ?? "runtime",
+        [...(item.tags ?? [])].map(String).sort().join("\u0001"),
+        item.rawContentHash
+      ].join("\u0000");
+      duplicateGroups.set(key, (duplicateGroups.get(key) ?? 0) + 1);
+    }
+    const duplicateSizes = [...duplicateGroups.values()].filter((size) => size > 1);
+    const totalRecalls = active.reduce((sum, item) => sum + Math.max(0, Number(item.metadata?.recallCount) || 0), 0);
+    const principles = active.filter((item) => item.kind === "principle");
+
+    return {
+      active: active.length,
+      recalled: recalled.length,
+      neverRecalled: Math.max(0, active.length - recalled.length),
+      recallCoverage: active.length > 0 ? recalled.length / active.length : 0,
+      totalRecalls,
+      corrections: active.filter((item) => item.kind === "correction" || item.locked).length,
+      principles: principles.length,
+      specificPrinciples: principles.filter((item) => (item.specificity ?? 0) >= 0.6).length,
+      weak: Object.values(weakByTier).reduce((sum, count) => sum + count, 0),
+      weakByTier,
+      duplicateGroups: duplicateSizes.length,
+      duplicateRows: duplicateSizes.reduce((sum, size) => sum + size - 1, 0)
     };
   }
 

--- a/test/abi-runtime.test.js
+++ b/test/abi-runtime.test.js
@@ -824,9 +824,14 @@ test("propagation enforces max depth and breadth for sub-specialists", () => {
 
 test("introspector audit returns structural findings", () => {
   const runtime = createDefaultRuntime();
+  const recalled = runtime.memory.remember({ content: "Audit recall fixture" }, { tier: "medium" });
+  runtime.memory.recordRecalls([recalled.id]);
   const audit = runtime.introspector.audit();
   assert.ok(audit.specialists);
   assert.ok(audit.memory);
+  assert.equal(audit.memory.quality.active, 1);
+  assert.equal(audit.memory.quality.recallCoverage, 1);
+  assert.equal(audit.memory.quality.totalRecalls, 1);
   assert.ok(audit.cron);
   assert.ok(Array.isArray(audit.findings));
 });

--- a/test/memory-corrections.test.js
+++ b/test/memory-corrections.test.js
@@ -139,6 +139,52 @@ test("corrections persist and restore through the file-backed store", () => {
   fs.rmSync(dir, { recursive: true });
 });
 
+test("file-backed recall telemetry survives restart without copying queries or content into the receipt", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-mem-recall-"));
+  const memory = new FileBackedMemorySystem({ dir });
+  const item = memory.remember(
+    { source: "test", content: "Private customer preference used only for this recall test", tags: ["preference"] },
+    { tier: "medium", now: "2026-08-21T08:00:00.000Z" }
+  );
+
+  const hits = memory.retrieve("private customer preference", { now: "2026-08-21T09:00:00.000Z" });
+  assert.equal(hits[0].item.id, item.id);
+  assert.equal(item.metadata.recallCount, 1);
+  assert.equal(item.metadata.lastRecalledAt, "2026-08-21T09:00:00.000Z");
+  assert.deepEqual(item.metadata.recallSources, { retrieve: 1 });
+
+  const events = fs.readFileSync(memory.eventsPath, "utf8").trim().split("\n").map(JSON.parse);
+  const receipt = events.at(-1);
+  assert.equal(receipt.op, "recall");
+  assert.deepEqual(receipt.payload.items.map((entry) => entry.id), [item.id]);
+  assert.doesNotMatch(JSON.stringify(receipt), /private customer preference/i);
+  assert.doesNotMatch(JSON.stringify(receipt), /Private customer preference used only/i);
+
+  const reloaded = new FileBackedMemorySystem({ dir });
+  assert.equal(reloaded.items.get(item.id).metadata.recallCount, 1);
+  assert.equal(reloaded.qualityStats().recallCoverage, 1);
+  fs.rmSync(dir, { recursive: true });
+});
+
+test("qualityStats excludes superseded rows and reports weak, correction, recall, and duplicate pressure", () => {
+  const memory = new MemorySystem();
+  const recalled = memory.remember({ source: "agent-host", content: "recallable automated fact", tags: ["fact"] }, { tier: "medium", strength: 0.4 });
+  const duplicate = { ...recalled, id: "duplicate-row", metadata: {} };
+  memory.items.set(duplicate.id, duplicate);
+  const stale = memory.remember({ source: "test", content: "meeting is at three", tags: ["meeting"] }, { tier: "medium", strength: 0.2 });
+  memory.recordRecalls([recalled.id], { now: "2026-08-21T10:00:00.000Z" });
+  memory.correct({ id: stale.id, content: "Meeting is at four" });
+
+  const quality = memory.qualityStats();
+  assert.equal(quality.active, 3, "the superseded source row is not active");
+  assert.equal(quality.recalled, 1);
+  assert.equal(quality.totalRecalls, 1);
+  assert.equal(quality.corrections, 1);
+  assert.equal(quality.duplicateGroups, 1);
+  assert.equal(quality.duplicateRows, 1);
+  assert.equal(quality.weak, 0, "the only weak row was superseded by its correction");
+});
+
 test("correct_memory tool wires through with scope + recall exposes confidence fields", async () => {
   const memory = new MemorySystem();
   const runtime = { memory };

--- a/test/memory-import.test.js
+++ b/test/memory-import.test.js
@@ -37,3 +37,90 @@ test("POST /memory/remember rejects empty content", async () => {
     await app.close();
   }
 });
+
+test("POST /memory/:id/correct locks a user correction and refuses stale or empty writes", async () => {
+  const runtime = createDefaultRuntime();
+  const stale = runtime.memory.remember({ source: "test", content: "The review starts at three", tags: ["review"] });
+  const app = createHostedInterface(runtime, { port: 0 });
+  const address = await app.listen();
+  try {
+    const corrected = await fetch(`${address.url}/memory/${encodeURIComponent(stale.id)}/correct`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ correction: "The review starts at four" })
+    });
+    assert.equal(corrected.status, 200);
+    const body = await corrected.json();
+    assert.equal(body.locked, true);
+    assert.equal(body.supersededCount, 1);
+    assert.equal(runtime.memory.items.get(stale.id).metadata.supersededBy, body.id);
+    assert.equal(runtime.memory.items.get(body.id).metadata.userAuthored, true);
+    assert.equal(runtime.memory.retrieve("review starts")[0].item.id, body.id);
+
+    const repeat = await fetch(`${address.url}/memory/${encodeURIComponent(stale.id)}/correct`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ correction: "Try to overwrite the stale row again" })
+    });
+    assert.equal(repeat.status, 409);
+
+    const activeId = body.id;
+    const empty = await fetch(`${address.url}/memory/${encodeURIComponent(activeId)}/correct`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ correction: "   " })
+    });
+    assert.equal(empty.status, 400);
+
+    const oversized = await fetch(`${address.url}/memory/${encodeURIComponent(activeId)}/correct`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ correction: "x".repeat(10_001) })
+    });
+    assert.equal(oversized.status, 400);
+
+    const raced = runtime.memory.remember({ source: "test", content: "The launch is Monday", tags: ["launch"] });
+    const submitRace = (correction) => fetch(`${address.url}/memory/${encodeURIComponent(raced.id)}/correct`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ correction })
+    });
+    const raceResponses = await Promise.all([
+      submitRace("The launch is Tuesday"),
+      submitRace("The launch is Wednesday")
+    ]);
+    assert.deepEqual(raceResponses.map((response) => response.status).sort(), [200, 409]);
+    assert.equal(
+      [...runtime.memory.items.values()].filter((item) => item.metadata?.corrects?.includes(raced.id)).length,
+      1,
+      "concurrent submissions create one correction for the stale row"
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("memory correction route inherits dashboard authentication", async () => {
+  const runtime = createDefaultRuntime();
+  const stale = runtime.memory.remember({ source: "test", content: "A private stored fact" });
+  const app = createHostedInterface(runtime, { port: 0, authToken: "test-dashboard-token" });
+  const address = await app.listen();
+  try {
+    const denied = await fetch(`${address.url}/memory/${encodeURIComponent(stale.id)}/correct`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ correction: "An unauthorized replacement" })
+    });
+    assert.equal(denied.status, 401);
+    assert.equal(stale.metadata.supersededBy, undefined);
+
+    const allowed = await fetch(`${address.url}/memory/${encodeURIComponent(stale.id)}/correct`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer test-dashboard-token" },
+      body: JSON.stringify({ correction: "The authorized corrected fact" })
+    });
+    assert.equal(allowed.status, 200);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/principle-vector-gc.test.js
+++ b/test/principle-vector-gc.test.js
@@ -185,4 +185,7 @@ test("handleMessage injects live principles but never quarantined ones", async (
   assert.match(captured.turnContext, /block prep time before standup meetings/, "live principle injected as intuition");
   assert.doesNotMatch(captured.turnContext, /Quarantined hunch/, "quarantined principle NOT injected");
   assert.doesNotMatch(captured.instructions, /block prep time/, "static instructions stay principle-free (byte-stable for the prompt cache)");
+  assert.equal(live.metadata.recallCount, 1, "placing a principle in turn context records a recall");
+  assert.deepEqual(live.metadata.recallSources, { "principle-context": 1 });
+  assert.equal(quarantined.metadata.recallCount, undefined, "filtered principles are never credited as recalled");
 });

--- a/test/sec-dashboard-xss.test.js
+++ b/test/sec-dashboard-xss.test.js
@@ -115,6 +115,13 @@ test("SEC-4: a markdown link URL cannot splice extra attributes into the anchor"
   assert.ok(!/onmouseover\s*=\s*["']/i.test(encoded), `handler survived on a parseable URL: ${encoded}`);
 });
 
+test("SEC-4: memory correction controls encode ids and escape stored content", async () => {
+  const { script } = await dashboard();
+  assert.ok(script.includes('/memory/${encodeURIComponent(id)}/correct'));
+  assert.ok(script.includes('${escapeHtml(m.content || "")}</textarea>'));
+  assert.ok(!script.includes('${m.content}</textarea>'));
+});
+
 test("SEC-4: renderMarkdown refuses non-http(s) link schemes", async () => {
   const { script } = await dashboard();
   const renderMarkdown = shippedRenderMarkdown(script);


### PR DESCRIPTION
## Problem

Memory quality was difficult to measure or repair from the product:

- successful recalls updated only in memory, so restart erased the evidence
- vector-selected principles bypassed recall tracking entirely
- the dashboard showed inventory counts but not recall coverage, duplicates, weak memories, or corrections
- stale or incorrect memories could not be corrected directly from the Memory UI

## Changes

- Persist privacy-safe recall telemetry for normal retrieval and principle-context injection.
- Add aggregate memory-quality statistics for recall coverage, weak tiers, corrections, principles, and exact duplicate groups.
- Surface those aggregates in Health and Memory without exposing private memory content.
- Add an authenticated, CSRF-protected memory-correction route and inline correction flow.
- Hide superseded memories from active inventory while retaining correction history.
- Add diagnostics for low recall coverage and duplicate rows.

## Security and privacy

- The correction request body is capped at 16 KiB and corrected content at 10,000 characters.
- Concurrent corrections are race-safe: one succeeds and stale attempts receive `409`.
- Memory content and identifiers are escaped before dashboard rendering; route identifiers are URL encoded.
- Recall receipts store only IDs, counts, timestamps, and an allowlisted source category—never query text or memory content.
- No new data directory, environment variable, credential, network destination, or callable node operation is introduced.

## Verification

- Focused memory/security coverage: 7/7 passed.
- Full JavaScript test suite passed with the bundled Node runtime.
- Swift tests: 35/35 passed.
- Data-directory contract tests and ABI import check passed.
- Fresh Developer ID-signed macOS app built and passed strict code-sign verification.
- Git safety guard passed for the staged files and commit range.
