### PR TITLE
[codex] make outcome feedback measurable and correctable

### DIFF
--- a/src/abi-runtime.js
+++ b/src/abi-runtime.js
@@ -170,6 +170,12 @@ export class AbiRuntime {
         this.propagation.recordOutcomeQuality?.(specialistId, outcome.qualityScore);
       }
     };
+    this.outcomes.onFeedback = (outcome, previous) => {
+      const specialistId = outcome.metadata?.specialistId;
+      if (specialistId && typeof outcome.qualityScore === "number") {
+        this.propagation.replaceOutcomeQuality?.(specialistId, previous?.previousQualityScore, outcome.qualityScore);
+      }
+    };
     this.embedder = options.embedder ?? createEmbedder({ budgetGuard: this.budget, ...(options.embedderOptions ?? {}) });
     this.vectorStore = options.vectorStore ?? new VectorStore({ embedder: this.embedder, ...(options.vectorStoreOptions ?? {}) });
     if (typeof this.propagation.bindVectorStore === "function") this.propagation.bindVectorStore(this.vectorStore);

--- a/src/file-backed-propagation-controller.js
+++ b/src/file-backed-propagation-controller.js
@@ -54,6 +54,12 @@ export class FileBackedPropagationController extends PropagationController {
     return sp;
   }
 
+  replaceOutcomeQuality(id, previousScore, score) {
+    const sp = super.replaceOutcomeQuality(id, previousScore, score);
+    if (sp) this.save();
+    return sp;
+  }
+
   retire(id, reason) {
     const sp = super.retire(id, reason);
     if (sp) this.save();

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -1571,6 +1571,30 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
         });
       }
 
+      const outcomeFeedbackMatch = pathname.match(/^\/outcomes\/([^/]+)\/feedback$/);
+      if (method === "POST" && outcomeFeedbackMatch) {
+        let outcomeId;
+        try { outcomeId = decodeURIComponent(outcomeFeedbackMatch[1]); }
+        catch { return sendJson(res, 400, { error: "invalid outcome id" }); }
+        const body = await readJsonLimited(req, 16 * 1024).catch(() => null);
+        if (!body) return sendJson(res, 400, { error: "invalid feedback body" });
+        const qualityScore = Number(body.qualityScore);
+        if (!Number.isFinite(qualityScore) || qualityScore < 0 || qualityScore > 1) {
+          return sendJson(res, 400, { error: "qualityScore must be between 0 and 1" });
+        }
+        const note = typeof body.note === "string" ? body.note.trim() : null;
+        if (note && note.length > 2000) return sendJson(res, 400, { error: "feedback note is too long" });
+        const result = runtime.outcomes?.rate?.(outcomeId, qualityScore, note || null);
+        if (!result) return sendJson(res, 404, { error: "outcome not found" });
+        return sendJson(res, 200, {
+          id: result.id,
+          resolved: result.resolved,
+          qualityScore: result.qualityScore,
+          source: result.source,
+          resolvedAt: result.resolvedAt
+        });
+      }
+
       if (method === "POST" && pathname === "/feedback") {
         const body = await readJson(req);
         const result = runtime.outcomes?.feedback(body.refId, body.qualityScore, body.note);
@@ -6782,8 +6806,11 @@ async function renderOutcomes() {
       <h2>Outcomes <span class="muted" style="font-size:14px;font-weight:400;">· last 7 days</span></h2>
       <div class="grid stats">
         <div class="card"><span class="desc">Avg quality</span><div class="stat-value">\${agg.avgQuality ?? "—"}</div></div>
-        <div class="card"><span class="desc">Resolved</span><div class="stat-value">\${agg.resolved ?? 0} <span class="muted" style="font-size:14px;">/ \${agg.total ?? 0}</span></div></div>
+        <div class="card"><span class="desc">Resolved</span><div class="stat-value">\${agg.resolved ?? 0} <span class="muted" style="font-size:14px;">/ \${agg.total ?? 0}</span></div><div class="muted" style="font-size:11px;">\${agg.scored ?? 0} scored · \${agg.timedOut ?? 0} timed out</div></div>
         <div class="card"><span class="desc">Pending</span><div class="stat-value">\${agg.pending ?? 0}</div></div>
+        <div class="card"><span class="desc">User-signal coverage</span><div class="stat-value">\${Math.round(Number(agg.userSignalCoverage ?? 0) * 100)}%</div><div class="muted" style="font-size:11px;">\${agg.explicitRatings ?? 0} ratings · \${agg.userFollowups ?? 0} follow-ups</div></div>
+        <div class="card"><span class="desc">Inferred scores</span><div class="stat-value">\${agg.inferredScores ?? 0}</div><div class="muted" style="font-size:11px;">avg \${agg.avgInferredQuality ?? "—"}</div></div>
+        <div class="card"><span class="desc">Explicit quality</span><div class="stat-value">\${agg.avgExplicitQuality ?? "—"}</div><div class="muted" style="font-size:11px;">direct ratings only</div></div>
       </div>
       \${byKindCards ? \`<h3>By kind</h3><div class="grid stats">\${byKindCards}</div>\` : ""}
       <h3>Recent</h3>
@@ -6797,29 +6824,29 @@ async function renderOutcomes() {
     const qBadge = typeof o.qualityScore === "number"
       ? \`<span class="badge \${o.qualityScore >= 0.7 ? "ok" : o.qualityScore >= 0.4 ? "warn" : "err"}">q=\${o.qualityScore.toFixed(2)}</span>\`
       : (o.resolved ? '<span class="badge">timeout</span>' : '<span class="badge warn">pending</span>');
+    const sourceBadge = \`<span class="badge">\${escapeHtml(o.source === "explicit-rating" ? "user rated" : o.source === "user-followup" ? "follow-up signal" : o.source ?? "unresolved")}</span>\`;
     el.innerHTML = \`
       <div class="row between">
         <span class="name">\${escapeHtml(o.kind)} · \${escapeHtml(o.scrutinyAction ?? "—")}</span>
-        \${qBadge}
+        <span>\${sourceBadge} \${qBadge}</span>
       </div>
       <div class="desc">\${escapeHtml(o.sessionId ?? "")} · \${escapeHtml(o.channel ?? "")} · \${escapeHtml(new Date(o.at).toLocaleString())}</div>
       <div class="row" style="gap:6px;margin-top:8px;">
-        <button class="secondary" data-feedback="\${escapeHtml(o.refId ?? "")}" data-score="0.95">👍 great</button>
-        <button class="secondary" data-feedback="\${escapeHtml(o.refId ?? "")}" data-score="0.5">😐 ok</button>
-        <button class="secondary" data-feedback="\${escapeHtml(o.refId ?? "")}" data-score="0.1">👎 bad</button>
+        <button class="secondary" data-outcome-feedback="\${escapeHtml(o.id)}" data-score="0.95">👍 great</button>
+        <button class="secondary" data-outcome-feedback="\${escapeHtml(o.id)}" data-score="0.5">😐 ok</button>
+        <button class="secondary" data-outcome-feedback="\${escapeHtml(o.id)}" data-score="0.1">👎 bad</button>
       </div>
     \`;
     list.appendChild(el);
   }
-  list.querySelectorAll("[data-feedback]").forEach((btn) => {
+  list.querySelectorAll("[data-outcome-feedback]").forEach((btn) => {
     btn.addEventListener("click", async () => {
-      const refId = btn.getAttribute("data-feedback");
+      const outcomeId = btn.getAttribute("data-outcome-feedback");
       const score = Number(btn.getAttribute("data-score"));
-      if (!refId) { btn.textContent = "no refId"; return; }
+      if (!outcomeId) { btn.textContent = "missing outcome"; return; }
       try {
-        await postJson("/feedback", { refId, qualityScore: score });
-        btn.textContent = "✓ rated";
-        btn.disabled = true;
+        await postJson(\`/outcomes/\${encodeURIComponent(outcomeId)}/feedback\`, { qualityScore: score });
+        await renderOutcomes();
       } catch (err) { btn.textContent = "[err] " + err.message; }
     });
   });

--- a/src/outcome-store.js
+++ b/src/outcome-store.js
@@ -59,6 +59,41 @@ export class OutcomeStore {
     return outcome;
   }
 
+  /**
+   * Record direct user feedback for one exact outcome. Unlike resolve(), this
+   * deliberately replaces an earlier heuristic score so the quality loop can
+   * be calibrated after the system has already inferred a result.
+   */
+  rate(id, qualityScore, note = null) {
+    const outcome = this.outcomes.get(id);
+    const score = clampScore(qualityScore);
+    if (!outcome || score === null) return null;
+    if (!outcome.resolved) return this.resolve(id, score, "explicit-rating", note);
+
+    const previousQualityScore = outcome.qualityScore;
+    const previousSource = outcome.source;
+    const { resolutionNote: _oldNote, ...metadata } = outcome.metadata ?? {};
+    outcome.qualityScore = score;
+    outcome.source = "explicit-rating";
+    outcome.resolvedAt = nowIso();
+    outcome.metadata = note ? { ...metadata, resolutionNote: note } : metadata;
+    appendJsonLine(this.eventsPath, {
+      op: "feedback",
+      id,
+      qualityScore: score,
+      previousQualityScore,
+      previousSource,
+      at: outcome.resolvedAt
+    });
+    if (typeof previousQualityScore === "number") {
+      if (this.onFeedback) this.onFeedback(outcome, { previousQualityScore, previousSource });
+    } else if (this.onResolve) {
+      this.onResolve(outcome);
+    }
+    this.persist();
+    return outcome;
+  }
+
   pending(maxAgeMs = null) {
     const cutoff = maxAgeMs ? Date.now() - maxAgeMs : null;
     const out = [];
@@ -102,14 +137,17 @@ export class OutcomeStore {
   aggregateBySuggestion(suggestionId) {
     const list = this.bySuggestion(suggestionId);
     if (list.length === 0) return null;
-    const resolved = list.filter((o) => o.resolved && typeof o.qualityScore === "number");
-    const avgQuality = resolved.length === 0 ? null : resolved.reduce((a, b) => a + b.qualityScore, 0) / resolved.length;
+    const terminal = list.filter((o) => o.resolved);
+    const scored = terminal.filter((o) => typeof o.qualityScore === "number");
+    const avgQuality = scored.length === 0 ? null : scored.reduce((a, b) => a + b.qualityScore, 0) / scored.length;
     const byKind = {};
     for (const o of list) byKind[o.kind] = (byKind[o.kind] || 0) + 1;
     return {
       total: list.length,
-      resolved: resolved.length,
-      pending: list.length - resolved.length,
+      resolved: terminal.length,
+      scored: scored.length,
+      pending: list.length - terminal.length,
+      timedOut: terminal.filter((o) => o.source === "timeout").length,
       avgQuality: avgQuality === null ? null : Number(avgQuality.toFixed(3)),
       byKind,
       lastAt: list[list.length - 1]?.at ?? null
@@ -124,18 +162,37 @@ export class OutcomeStore {
       return true;
     });
     const list = inWindow.filter(isQualityEligibleOutcome);
-    const resolved = list.filter((o) => o.resolved && typeof o.qualityScore === "number");
-    const avgQuality = resolved.length === 0 ? null : resolved.reduce((a, b) => a + b.qualityScore, 0) / resolved.length;
+    const terminal = list.filter((o) => o.resolved);
+    const scored = terminal.filter((o) => typeof o.qualityScore === "number");
+    const avgQuality = scored.length === 0 ? null : scored.reduce((a, b) => a + b.qualityScore, 0) / scored.length;
     const byKind = {};
+    const bySource = {};
     for (const o of list) byKind[o.kind] = (byKind[o.kind] || 0) + 1;
+    for (const o of list) bySource[o.source ?? "pending"] = (bySource[o.source ?? "pending"] || 0) + 1;
+    const explicit = scored.filter((o) => o.source === "explicit-rating");
+    const userFollowups = scored.filter((o) => o.source === "user-followup");
+    const inferred = scored.filter((o) => o.source !== "explicit-rating" && o.source !== "user-followup");
+    const avg = (items) => items.length === 0
+      ? null
+      : Number((items.reduce((sum, item) => sum + item.qualityScore, 0) / items.length).toFixed(3));
+    const userSignals = explicit.length + userFollowups.length;
     return {
       windowDays,
       total: list.length,
-      resolved: resolved.length,
-      pending: list.length - resolved.length,
+      resolved: terminal.length,
+      scored: scored.length,
+      pending: list.length - terminal.length,
       excludedHousekeeping: inWindow.length - list.length,
       avgQuality: avgQuality === null ? null : Number(avgQuality.toFixed(3)),
-      byKind
+      byKind,
+      bySource,
+      explicitRatings: explicit.length,
+      userFollowups: userFollowups.length,
+      inferredScores: inferred.length,
+      timedOut: terminal.filter((o) => o.source === "timeout").length,
+      userSignalCoverage: scored.length === 0 ? 0 : Number((userSignals / scored.length).toFixed(3)),
+      avgExplicitQuality: avg(explicit),
+      avgInferredQuality: avg(inferred)
     };
   }
 
@@ -219,7 +276,7 @@ export class OutcomeStore {
     const outcomes = this.byRef(refId);
     if (outcomes.length === 0) return null;
     const target = outcomes[outcomes.length - 1]; // latest
-    return this.resolve(target.id, qualityScore, "explicit-rating", note);
+    return this.rate(target.id, qualityScore, note);
   }
 
   /**

--- a/src/propagation-controller.js
+++ b/src/propagation-controller.js
@@ -137,6 +137,15 @@ export class PropagationController {
     return sp;
   }
 
+  replaceOutcomeQuality(specialistId, previousScore, qualityScore) {
+    if (typeof previousScore !== "number" || typeof qualityScore !== "number") return null;
+    const sp = [...this.specialists.values()].find((s) => s.id === specialistId);
+    const n = sp?.outcomeSamples ?? 0;
+    if (!sp || n < 1 || typeof sp.meanOutcomeQuality !== "number") return null;
+    sp.meanOutcomeQuality = Math.max(0, Math.min(1, ((sp.meanOutcomeQuality * n) - previousScore + qualityScore) / n));
+    return sp;
+  }
+
   retire(specialistId, reason = "manual") {
     const sp = [...this.specialists.values()].find((s) => s.id === specialistId);
     if (!sp || sp.status === "retired") return null;

--- a/test/abi-runtime.test.js
+++ b/test/abi-runtime.test.js
@@ -394,6 +394,47 @@ test("outcome store explicit feedback resolves an outcome", () => {
   assert.equal(result.source, "explicit-rating");
 });
 
+test("specialist quality replaces an inferred contribution when direct feedback arrives", () => {
+  const propagation = new PropagationController();
+  const signal = {
+    summary: "Repeated bounded workflow",
+    content: "The same bounded workflow recurs with stable inputs.",
+    domain: "general",
+    taskType: "specialist-feedback-test",
+    citations: ["one", "two", "three"],
+    impact: 0.9,
+    externalPressure: 0.8,
+    novelty: 0.7,
+    repetition: 0.9,
+    risk: 0.5,
+    specificity: 0.9,
+    requiresSpecialist: true
+  };
+  const created = propagation.propagate({ signal, scrutiny: { action: "propagate", reasons: [] } }).specialist;
+  propagation.recordOutcomeQuality(created.id, 0.7);
+  propagation.replaceOutcomeQuality(created.id, 0.7, 0.1);
+  assert.equal(created.outcomeSamples, 1, "feedback replaces rather than double-counting the sample");
+  assert.ok(Math.abs(created.meanOutcomeQuality - 0.1) < 1e-12);
+});
+
+test("file-backed specialist recalibration survives restart", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-specialist-rating-"));
+  const storePath = path.join(root, "specialists.json");
+  const first = new FileBackedPropagationController({ storePath });
+  const created = first.propagate({
+    signal: { summary: "Repeated release triage", taskType: "release-triage", requiresSpecialist: true },
+    scrutiny: { action: "propagate", reasons: [] }
+  }).specialist;
+  first.recordOutcomeQuality(created.id, 0.7);
+  first.replaceOutcomeQuality(created.id, 0.7, 0.2);
+
+  const second = new FileBackedPropagationController({ storePath });
+  const restored = second.list().find((specialist) => specialist.id === created.id);
+  assert.equal(restored.outcomeSamples, 1);
+  assert.ok(Math.abs(restored.meanOutcomeQuality - 0.2) < 1e-12);
+  fs.rmSync(root, { recursive: true });
+});
+
 test("agent turn writes an outcome record into runtime.outcomes", async () => {
   const runtime = createDefaultRuntime();
   await runtime.agentHost.handleMessage({ channel: "local", from: "test", text: "hi" });

--- a/test/outcome-feedback.test.js
+++ b/test/outcome-feedback.test.js
@@ -4,7 +4,7 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
 import fs from "node:fs";
-import { createDurableRuntime, DeterministicModelProvider, OutcomeStore } from "../src/index.js";
+import { createDurableRuntime, createHostedInterface, DeterministicModelProvider, OutcomeStore } from "../src/index.js";
 
 function tmpDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -33,6 +33,44 @@ test("negative followup tone scores low", async () => {
   const resolved = runtime.outcomes.recent(10).find((o) => o.id === first.id);
   assert.equal(resolved.source, "user-followup");
   assert.equal(resolved.qualityScore, 0.2);
+});
+
+test("authenticated outcome feedback targets exact rows and overrides inferred scores", async () => {
+  const runtime = createDurableRuntime({ dataDir: tmpDir("outcome-route-") });
+  const outcome = runtime.outcomes.record({ kind: "agent-reply", refId: null, sessionId: "private-session" });
+  runtime.outcomes.resolve(outcome.id, 0.7, "system-inferred", "heuristic score");
+  const app = createHostedInterface(runtime, { port: 0, authToken: "test-outcome-token" });
+  const address = await app.listen();
+  const submit = (id, body, authorized = true) => fetch(`${address.url}/outcomes/${encodeURIComponent(id)}/feedback`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(authorized ? { authorization: "Bearer test-outcome-token" } : {})
+    },
+    body: JSON.stringify(body)
+  });
+  try {
+    const denied = await submit(outcome.id, { qualityScore: 0.1 }, false);
+    assert.equal(denied.status, 401);
+    assert.equal(runtime.outcomes.outcomes.get(outcome.id).source, "system-inferred");
+
+    const accepted = await submit(outcome.id, { qualityScore: 0.1, note: "Direct correction" });
+    assert.equal(accepted.status, 200);
+    assert.deepEqual(await accepted.json(), {
+      id: outcome.id,
+      resolved: true,
+      qualityScore: 0.1,
+      source: "explicit-rating",
+      resolvedAt: runtime.outcomes.outcomes.get(outcome.id).resolvedAt
+    });
+    assert.equal(runtime.outcomes.outcomes.get(outcome.id).metadata.resolutionNote, "Direct correction");
+
+    assert.equal((await submit(outcome.id, { qualityScore: 2 })).status, 400);
+    assert.equal((await submit(outcome.id, { qualityScore: 0.5, note: "x".repeat(2001) })).status, 400);
+    assert.equal((await submit("missing-outcome", { qualityScore: 0.5 })).status, 404);
+  } finally {
+    await app.close();
+  }
 });
 
 test("synthetic autopilot housekeeping does not create a quality outcome", async () => {

--- a/test/outcome-quality.test.js
+++ b/test/outcome-quality.test.js
@@ -84,6 +84,54 @@ test("quality aggregates exclude legacy no-op autopilot pulses without deleting 
   assert.equal(isQualityEligibleOutcome({ kind: "autopilot-fire", metadata: { qualityEligible: false }, toolCalls: [{ name: "add_task" }] }), false);
 });
 
+test("explicit feedback replaces inferred scores and makes aggregate confidence measurable", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-outcome-rating-"));
+  const store = new OutcomeStore({ dir });
+  const inferred = store.record({ kind: "agent-reply", refId: "reply-1" });
+  const followedUp = store.record({ kind: "agent-reply", refId: "reply-2" });
+  store.resolve(inferred.id, 0.7, "system-inferred", "heuristic");
+  store.resolve(followedUp.id, 0.85, "user-followup", "positive follow-up");
+
+  const rated = store.rate(inferred.id, 0.1, "not useful");
+  assert.equal(rated.qualityScore, 0.1);
+  assert.equal(rated.source, "explicit-rating");
+  assert.equal(rated.metadata.resolutionNote, "not useful");
+
+  const aggregate = store.aggregate(30);
+  assert.equal(aggregate.explicitRatings, 1);
+  assert.equal(aggregate.userFollowups, 1);
+  assert.equal(aggregate.inferredScores, 0);
+  assert.equal(aggregate.userSignalCoverage, 1);
+  assert.equal(aggregate.avgExplicitQuality, 0.1);
+  assert.deepEqual(aggregate.bySource, { "explicit-rating": 1, "user-followup": 1 });
+
+  const events = fs.readFileSync(store.eventsPath, "utf8").trim().split("\n").map(JSON.parse);
+  const feedback = events.at(-1);
+  assert.equal(feedback.op, "feedback");
+  assert.equal(feedback.previousSource, "system-inferred");
+  assert.doesNotMatch(JSON.stringify(feedback), /not useful/, "feedback receipt excludes note text");
+
+  const restored = new OutcomeStore({ dir });
+  assert.equal(restored.outcomes.get(inferred.id).source, "explicit-rating");
+  assert.equal(restored.outcomes.get(inferred.id).qualityScore, 0.1);
+  fs.rmSync(dir, { recursive: true });
+});
+
+test("quality aggregates distinguish terminal timeouts from genuinely pending work", () => {
+  const store = new OutcomeStore({ dir: fs.mkdtempSync(path.join(os.tmpdir(), "openagi-outcome-terminal-")) });
+  const now = new Date();
+  const timedOut = store.record({ kind: "agent-reply", at: new Date(now.getTime() - 48 * 3600 * 1000).toISOString() });
+  store.record({ kind: "agent-reply" });
+  store.resolveSweep({ now, timeoutHours: 24 });
+  const aggregate = store.aggregate(30);
+  assert.equal(store.outcomes.get(timedOut.id).source, "timeout");
+  assert.equal(aggregate.total, 2);
+  assert.equal(aggregate.resolved, 1);
+  assert.equal(aggregate.scored, 0);
+  assert.equal(aggregate.timedOut, 1);
+  assert.equal(aggregate.pending, 1);
+});
+
 test("skill run grades completion by tool-call results; tool-free run keeps 0.7", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-skill-quality-"));
   const skillsRoot = path.join(root, "skills");

--- a/test/sec-dashboard-xss.test.js
+++ b/test/sec-dashboard-xss.test.js
@@ -122,6 +122,13 @@ test("SEC-4: memory correction controls encode ids and escape stored content", a
   assert.ok(!script.includes('${m.content}</textarea>'));
 });
 
+test("SEC-4: outcome feedback uses escaped row ids and URL encoding", async () => {
+  const { script } = await dashboard();
+  assert.ok(script.includes('data-outcome-feedback="${escapeHtml(o.id)}"'));
+  assert.ok(script.includes('/outcomes/${encodeURIComponent(outcomeId)}/feedback'));
+  assert.ok(!script.includes('data-feedback="${o.refId'));
+});
+
 test("SEC-4: renderMarkdown refuses non-http(s) link schemes", async () => {
   const { script } = await dashboard();
   const renderMarkdown = shippedRenderMarkdown(script);


### PR DESCRIPTION
## Problem

The Outcomes page appeared to offer feedback, but most rows had already been resolved by a heuristic. Clicking a rating on those rows called `resolve()` again, which rejected the update and surfaced a misleading not-found error. Rows without a `refId` could not be rated at all.

The scorecard also mixed direct user evidence, follow-up tone, inferred scores, timeouts, and truly pending work into a single average, making a high quality number look more certain than it was.

## Changes

- Add exact-outcome feedback that can replace an earlier inferred score.
- Target ratings by immutable outcome ID instead of optional message reference.
- Persist feedback overrides and privacy-safe receipts across restart.
- Recalculate specialist quality without double-counting the replaced sample, including file-backed persistence.
- Separate resolved, scored, timed-out, and pending outcomes.
- Report user-signal coverage, direct ratings, follow-up signals, inferred scores, and explicit/inferred averages.
- Label score provenance in the Outcomes UI and refresh immediately after rating.

## Security and privacy

- The new route inherits dashboard authentication and CSRF protections.
- Request bodies are capped at 16 KiB, scores are constrained to 0–1, and optional notes are capped at 2,000 characters.
- Outcome IDs are escaped in HTML attributes and URL-encoded in requests.
- Durable feedback receipts include IDs, numeric scores, source categories, and timestamps only; note text is not copied into the append-only receipt.
- No new credential, network destination, environment variable, data directory, or public route is introduced.

## Verification

- Focused outcome, auth, persistence, XSS, and data-directory coverage: 155/155 passed.
- Swift tests: 35/35 passed.
- ABI import and changed-source syntax checks passed.
- Fresh Developer ID-signed macOS app built and passed strict code-sign verification.
- Git safety guard passed for staged files and the commit range.
- The repository-wide JavaScript runner emitted hundreds of passing markers with no failures but did not terminate after repeated completion checks; it was stopped rather than reported as a pass.
