### PR TITLE
[codex] retry safe computer-use continuations

### DIFF
--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -408,7 +408,7 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
       return;
     }
     const goal = String(action.args?.goal ?? action.summary ?? "the approved computer-use goal").slice(0, 500);
-    let toolAttempted = false;
+    let mutatingToolAttempted = false;
     try {
       await channels.handleLocalMessage({
         channel: action.context.channel ?? "local",
@@ -425,17 +425,21 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
           continuationAttempt: continuation.attempts
         }
       }, {
-        // Once a model has reached any tool, replaying a failed turn is not
-        // provably safe: a physical action may have completed before the
-        // provider failed. Only pre-tool transport/provider failures retry.
+        // A failed continuation may be replayed only while every tool reached
+        // so far is explicitly read-only. Screenshots and status probes are
+        // safe to repeat after a transport failure; clicks, typing, scrolling,
+        // and unknown tools are not. Unknown names fail closed because the
+        // registry defaults tools to side-effecting unless they opt out.
         onProgress(progress) {
-          if (progress?.stage === "tool") toolAttempted = true;
+          if (progress?.stage !== "tool") return;
+          const tool = runtime.tools?.get?.(progress.tool);
+          if (!tool || tool.sideEffects !== false) mutatingToolAttempted = true;
         }
       });
       runtime.pendingActions.finishContinuation(actionId, { deliveryId, delivered: true });
     } catch (error) {
       logAgentFailure(error, { sessionId, requestId });
-      if (toolAttempted) {
+      if (mutatingToolAttempted) {
         const active = runtime.computerUseLog?.activeSessionFor?.(sessionId) ?? null;
         if (active) {
           try {

--- a/test/computer-use-approval.test.js
+++ b/test/computer-use-approval.test.js
@@ -180,6 +180,49 @@ test("a transient approval continuation failure retries without requiring anothe
   }
 });
 
+test("a provider failure after a read-only computer tool retries without renewing approval", async () => {
+  let calls = 0;
+  const { runtime, app, base, dataDir } = await appWithComputerUse({
+    generate: async (request) => {
+      calls += 1;
+      if (calls === 1) {
+        request.onProgress?.({ stage: "tool", tool: "computer_screenshot" });
+        throw new Error("provider transport failed after screenshot");
+      }
+      return {
+        id: "approval_readonly_retry_success",
+        text: "The live screenshot was verified.",
+        provider: "test",
+        model: "test-model",
+        toolCalls: []
+      };
+    }
+  });
+  try {
+    const queued = await runtime.tools.invoke("start_computer_use_session", {
+      goal: "Verify live pixels without input"
+    }, {
+      sessionId: "local:approval-readonly-retry:main",
+      channel: "local",
+      from: "user",
+      agentId: "main"
+    });
+    const response = await fetch(`${base}/pending-actions/${encodeURIComponent(queued.result.actionId)}/approve`, {
+      method: "POST"
+    });
+    assert.equal(response.status, 200);
+    await until(() => runtime.pendingActions.get(queued.result.actionId)?.continuation?.status === "delivered", 4_000);
+    const action = runtime.pendingActions.get(queued.result.actionId);
+    assert.equal(action.continuation.attempts, 2);
+    assert.equal(calls, 2);
+    assert.equal(runtime.computerUseLog.listSessions({ status: "active" }).length, 1,
+      "a read-only provider failure keeps the approved session active for the safe retry");
+  } finally {
+    await app.close();
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
 test("a continuation failure after any tool attempt aborts instead of replaying physical work", async () => {
   let calls = 0;
   const { runtime, app, base, dataDir } = await appWithComputerUse({


### PR DESCRIPTION
## What changed

- retry approval continuations after explicitly read-only tools such as Computer Use status checks and screenshots
- keep the approved session active across a transient provider transport failure in that safe case
- continue to abort and require fresh approval after clicks, typing, scrolling, unknown tools, or any other side-effecting tool

## Why

A live screenshot completed successfully after approval, but a transient provider fetch failure during the following synthesis step aborted the entire Computer Use session. Repeating a screenshot is safe; repeating physical input is not. The retry boundary now follows the tool registry's fail-closed `sideEffects` metadata.

## Verification

- focused Computer Use and streaming tests: 35/35 passed with the bundled Node runtime
- full suite advanced through 632 passing tests with no failures before the aggregate runner stopped emitting output and was terminated after three bounded checks
- `git diff --check` passed
- staged and commit-range secret safety scans passed
- live approval started a real session and returned a screenshot with nonzero dimensions and bytes; no input action was issued
