### PR TITLE
[codex] keep signed Mac nodes automatically updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ npm run update                 # auto-detects mode (docker/systemd/launchd/sourc
 npm run install-update-timer   # Linux: install a weekly auto-update timer (Sundays 04:00)
 ```
 
-For Docker, run [Watchtower](https://containrrr.dev/watchtower/) alongside the OpenAGI container. The Mac native `.app` updates via Sparkle automatically.
+For Docker, run [Watchtower](https://containrrr.dev/watchtower/) alongside the OpenAGI container. Signed Mac `.app` releases check daily and install/restart automatically by default, which keeps unattended nodes current. The menu-bar **Updates** submenu remains the source of truth and lets a user disable either behavior; saved choices override the first-run defaults.
 
 ---
 

--- a/mac/README.md
+++ b/mac/README.md
@@ -60,7 +60,7 @@ When you build a new release:
    ```
 3. Append a new entry to `appcast.xml` and upload it alongside the `.dmg` to GitHub Releases.
 
-Existing installs check daily and prompt the user to update.
+Fresh signed installs check daily and install/restart automatically so unattended nodes do not remain on an incompatible version. Users can disable automatic checks or automatic installation from the menu-bar **Updates** submenu; Sparkle persists that explicit choice across later releases. Existing installs that previously opted out remain opted out.
 
 ## How it runs
 

--- a/mac/Resources/Info.plist
+++ b/mac/Resources/Info.plist
@@ -50,10 +50,14 @@
   <string>unOtVkyA3akAScIoYYZ8UkqoBx56Ze1mDcEni8K1964=</string>
   <key>SUEnableAutomaticChecks</key>
   <true/>
-  <!-- Users can opt into immediate background install + relaunch from the
-       tray. Keep that disruptive choice off for a fresh installation. -->
+  <!-- Signed releases update unattended by default so headless/login-item
+       nodes do not remain on an old protocol indefinitely. Sparkle treats
+       these plist values as first-run defaults; a user's saved tray toggle
+       still overrides them. -->
+  <key>SUAllowsAutomaticUpdates</key>
+  <true/>
   <key>SUAutomaticallyUpdate</key>
-  <false/>
+  <true/>
   <key>SUScheduledCheckInterval</key>
   <integer>86400</integer>
 </dict>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagi",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "private": true,
   "type": "module",
   "description": "Generic ABI runtime scaffold for directional adaptive scrutiny, tiered memory, and propagation.",

--- a/test/mac-update-capture.test.js
+++ b/test/mac-update-capture.test.js
@@ -47,7 +47,7 @@ function between(source, start, end) {
   return source.slice(from, to);
 }
 
-test("Sparkle preserves preferences and exposes truthful tray settings", () => {
+test("Sparkle preserves preferences and defaults signed nodes to unattended updates", () => {
   const update = code(UPDATE);
   const start = between(update, "func start()", "func setAutomaticallyChecksForUpdates");
 
@@ -80,8 +80,8 @@ test("Sparkle preserves preferences and exposes truthful tray settings", () => {
 
   assert.match(
     read(INFO),
-    /<key>SUAutomaticallyUpdate<\/key>\s*<false\/>/,
-    "fresh installs must default the disruptive install-and-restart setting off"
+    /<key>SUEnableAutomaticChecks<\/key>\s*<true\/>[\s\S]*<key>SUAllowsAutomaticUpdates<\/key>\s*<true\/>[\s\S]*<key>SUAutomaticallyUpdate<\/key>\s*<true\/>/,
+    "fresh signed installs must check, download, install, and restart without an attended Mac"
   );
 });
 


### PR DESCRIPTION
## What changed

- bump the release version to `0.0.21`
- default fresh signed Mac installs to daily automatic checks and automatic signed install/restart
- keep both update toggles available in the menu-bar app; Sparkle persists explicit user choices over the first-run defaults
- document the unattended-node behavior

This release also includes merged PR #81, which safely retries Computer Use continuations after read-only screenshots/status checks while continuing to require fresh approval after possible physical input.

## Why

An unattended paired Mac can remain on an old node protocol indefinitely when it checks for releases but waits for someone to approve installation. OpenAGI nodes commonly run as login-item agents, so signed updates should be unattended by default while retaining an explicit opt-out.

## Verification

- `plutil -lint mac/Resources/Info.plist`
- focused Mac/update and topology tests: 21/21 passed
- Computer Use approval/update tests: 16/16 passed
- Swift tests: 35/35 passed
- staged and commit-range Git safety scans passed

## Security

Only Sparkle's existing EdDSA-signed, Apple-code-signed release path is enabled. No remote shell, endpoint, token, credential, machine name, address, or installation-specific policy is added.
