### PR TITLE
[codex] add drag and multi-click computer actions

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -119,7 +119,8 @@ constraint.
 OpenAGI now has a provider-neutral Computer Use tool set rather than a
 provider-specific prompt convention. It includes an explicit, human-approved
 session boundary; live action and reasoning logs; a kill switch; screen reads;
-and click/type/key/move/scroll actions through a node-scoped authenticated relay. When
+and click (including double-click)/drag/type/key/move/scroll actions through a
+node-scoped authenticated relay. When
 no node is reachable, screen inspection falls back to recent local OCR and
 input calls fail explicitly instead of reporting fake success.
 
@@ -149,9 +150,11 @@ fallback. The execution contract is:
 - Local execution stays local; remote nodes use a scoped credential and never
   receive provider or integration secrets.
 
-Native scrolling uses CGEvent. Every coordinate action is bound to a recent
-screenshot frame, and node leases enforce the approved goal, selected node,
-expiry, monotonic sequence, action limit, and idempotent action id.
+Native scrolling and drag use CGEvent. Drag cancellation always releases the
+mouse button, even if focus or readiness changes during movement. Every
+coordinate action is bound to a recent screenshot frame, and node leases
+enforce the approved goal, selected node, expiry, monotonic sequence, action
+limit, and idempotent action id.
 
 An optional Cua Driver backend is available for users who already operate a
 reviewed Cua installation. Set `OPENAGI_COMPUTER_BACKEND=cua` and

--- a/mac/Sources/OpenAGIComputerCore/ComputerInput.swift
+++ b/mac/Sources/OpenAGIComputerCore/ComputerInput.swift
@@ -12,6 +12,8 @@ public enum ComputerInputError: LocalizedError {
   case focusChanged
   case cancelled
   case invalidButton(String)
+  case invalidClickCount
+  case invalidDuration
   case invalidPoint
   case invalidText
   case unknownKey(String)
@@ -32,6 +34,10 @@ public enum ComputerInputError: LocalizedError {
       return "computer input was cancelled"
     case .invalidButton(let button):
       return "unknown mouse button '\(button)'"
+    case .invalidClickCount:
+      return "click count must be between 1 and 3"
+    case .invalidDuration:
+      return "drag duration must be between 0 and 2000 milliseconds"
     case .invalidPoint:
       return "coordinates are outside the main display"
     case .invalidText:
@@ -79,10 +85,11 @@ public enum ComputerInput {
     return session["CGSSessionScreenIsLocked"] as? Bool ?? false
   }
 
-  public static func click(x: Double, y: Double, button: String,
+  public static func click(x: Double, y: Double, button: String, count: Int = 1,
                            focus: ComputerFocusIdentity? = nil,
                            cancellation: ComputerInputCancellation? = nil) throws {
     try requirePoint(x: x, y: y)
+    guard (1...3).contains(count) else { throw ComputerInputError.invalidClickCount }
     let point = CGPoint(x: x, y: y)
     let source = CGEventSource(stateID: .hidSystemState)
     let downType: CGEventType
@@ -98,9 +105,63 @@ public enum ComputerInput {
     default:
       throw ComputerInputError.invalidButton(button)
     }
-    let down = CGEvent(mouseEventSource: source, mouseType: downType, mouseCursorPosition: point, mouseButton: mouseButton)
-    let up = CGEvent(mouseEventSource: source, mouseType: upType, mouseCursorPosition: point, mouseButton: mouseButton)
-    try postPhysicalPair(down, up, focus: focus, cancellation: cancellation)
+    for clickState in 1...count {
+      let down = CGEvent(mouseEventSource: source, mouseType: downType, mouseCursorPosition: point, mouseButton: mouseButton)
+      let up = CGEvent(mouseEventSource: source, mouseType: upType, mouseCursorPosition: point, mouseButton: mouseButton)
+      down?.setIntegerValueField(.mouseEventClickState, value: Int64(clickState))
+      up?.setIntegerValueField(.mouseEventClickState, value: Int64(clickState))
+      try postPhysicalPair(down, up, focus: focus, cancellation: cancellation)
+    }
+  }
+
+  public static func drag(fromX: Double, fromY: Double, toX: Double, toY: Double,
+                          button: String, durationMs: Int = 350,
+                          focus: ComputerFocusIdentity? = nil,
+                          cancellation: ComputerInputCancellation? = nil) throws {
+    try requirePoint(x: fromX, y: fromY)
+    try requirePoint(x: toX, y: toY)
+    guard (0...2_000).contains(durationMs) else { throw ComputerInputError.invalidDuration }
+    let source = CGEventSource(stateID: .hidSystemState)
+    let downType: CGEventType
+    let dragType: CGEventType
+    let upType: CGEventType
+    let mouseButton: CGMouseButton
+    switch button.lowercased() {
+    case "right":
+      downType = .rightMouseDown; dragType = .rightMouseDragged; upType = .rightMouseUp; mouseButton = .right
+    case "middle":
+      downType = .otherMouseDown; dragType = .otherMouseDragged; upType = .otherMouseUp; mouseButton = .center
+    case "left":
+      downType = .leftMouseDown; dragType = .leftMouseDragged; upType = .leftMouseUp; mouseButton = .left
+    default:
+      throw ComputerInputError.invalidButton(button)
+    }
+    try cancellation?.check()
+    try requirePhysicalInputReady(focus: focus)
+    var current = CGPoint(x: fromX, y: fromY)
+    let down = CGEvent(mouseEventSource: source, mouseType: downType, mouseCursorPosition: current, mouseButton: mouseButton)
+    down?.post(tap: .cghidEventTap)
+    // Once mouse-down is posted, mouse-up is an unconditional cleanup boundary.
+    // Cancellation or a focus change can stop movement, but can never strand a
+    // pressed mouse button in the system event stream.
+    defer {
+      let up = CGEvent(mouseEventSource: source, mouseType: upType, mouseCursorPosition: current, mouseButton: mouseButton)
+      up?.post(tap: .cghidEventTap)
+    }
+    let steps = max(1, min(120, durationMs == 0 ? 1 : durationMs / 16))
+    let delay = steps > 0 ? Double(durationMs) / Double(steps) / 1_000.0 : 0
+    for step in 1...steps {
+      try cancellation?.check()
+      try requirePhysicalInputReady(focus: focus)
+      let progress = Double(step) / Double(steps)
+      current = CGPoint(
+        x: fromX + ((toX - fromX) * progress),
+        y: fromY + ((toY - fromY) * progress)
+      )
+      let movement = CGEvent(mouseEventSource: source, mouseType: dragType, mouseCursorPosition: current, mouseButton: mouseButton)
+      movement?.post(tap: .cghidEventTap)
+      if delay > 0 && step < steps { Thread.sleep(forTimeInterval: delay) }
+    }
   }
 
   public static func move(x: Double, y: Double, focus: ComputerFocusIdentity? = nil,

--- a/mac/Sources/OpenAGIComputerHelper/main.swift
+++ b/mac/Sources/OpenAGIComputerHelper/main.swift
@@ -6,6 +6,12 @@ struct InputPayload: Decodable {
   var x: Double?
   var y: Double?
   var button: String?
+  var count: Int?
+  var fromX: Double?
+  var fromY: Double?
+  var toX: Double?
+  var toY: Double?
+  var durationMs: Int?
   var text: String?
   var chord: String?
   var deltaX: Double?
@@ -68,7 +74,7 @@ do {
       // identity cannot be established fail-closed.
       "screenshotReady": screenshotReady,
       "inputReady": input,
-      "operations": ["screenshot", "click", "move", "type", "key", "scroll"],
+      "operations": ["screenshot", "click", "drag", "move", "type", "key", "scroll"],
       "detail": screenshotReady && input ? "ready" : blockers.joined(separator: "; ")
     ])
     exit(0)
@@ -94,7 +100,25 @@ do {
           ["left", "right", "middle"].contains(button) else {
       throw NSError(domain: "OpenAGIComputerHelper", code: 4, userInfo: [NSLocalizedDescriptionKey: "click requires x, y, and a valid button"])
     }
-    try ComputerInput.click(x: x, y: y, button: button, focus: focus, cancellation: cancellation)
+    let count = payload.count ?? 1
+    guard (1...3).contains(count) else {
+      throw NSError(domain: "OpenAGIComputerHelper", code: 4, userInfo: [NSLocalizedDescriptionKey: "click count must be between 1 and 3"])
+    }
+    try ComputerInput.click(x: x, y: y, button: button, count: count, focus: focus, cancellation: cancellation)
+  case "drag":
+    guard let fromX = payload.fromX, let fromY = payload.fromY,
+          let toX = payload.toX, let toY = payload.toY,
+          let button = payload.button, ["left", "right", "middle"].contains(button) else {
+      throw NSError(domain: "OpenAGIComputerHelper", code: 4, userInfo: [NSLocalizedDescriptionKey: "drag requires fromX, fromY, toX, toY, and a valid button"])
+    }
+    let durationMs = payload.durationMs ?? 350
+    guard (0...2_000).contains(durationMs) else {
+      throw NSError(domain: "OpenAGIComputerHelper", code: 4, userInfo: [NSLocalizedDescriptionKey: "drag durationMs must be between 0 and 2000"])
+    }
+    try ComputerInput.drag(
+      fromX: fromX, fromY: fromY, toX: toX, toY: toY,
+      button: button, durationMs: durationMs, focus: focus, cancellation: cancellation
+    )
   case "move":
     guard let x = payload.x, let y = payload.y else {
       throw NSError(domain: "OpenAGIComputerHelper", code: 4, userInfo: [NSLocalizedDescriptionKey: "move requires x and y"])

--- a/src/integrations/computer-server.js
+++ b/src/integrations/computer-server.js
@@ -15,6 +15,7 @@ const execFileAsync = promisify(execFile);
 //   POST /session/end   { leaseId, ... } -> revoke lease
 //   POST /screenshot {}                  -> { format, base64, width, height, scale, ... }
 //   POST /click  { x, y, button? }       -> { ok: true }
+//   POST /drag   { fromX, fromY, toX, toY } -> { ok: true }
 //   POST /move   { x, y }                -> { ok: true }
 //   POST /type   { text }                -> { ok: true }
 //   POST /key    { chord }               -> { ok: true }   ("cmd+a", "enter", …)
@@ -35,7 +36,7 @@ const execFileAsync = promisify(execFile);
 // sensitive action data must travel over the helper's stdin, not process argv.
 
 const SCALE_WIDTH = Number(process.env.OPENAGI_COMPUTER_SCALE_WIDTH ?? "1280") || 0; // 0 = no scaling
-const INPUT_OPERATIONS = ["click", "move", "type", "key", "scroll"];
+const INPUT_OPERATIONS = ["click", "drag", "move", "type", "key", "scroll"];
 const ALL_OPERATIONS = ["session.start", "session.end", "screenshot", ...INPUT_OPERATIONS];
 const DEFAULT_IDLE_LEASE_MS = 2 * 60 * 1000;
 const DEFAULT_ABSOLUTE_LEASE_MS = 15 * 60 * 1000;
@@ -346,6 +347,7 @@ function operationForPath(pathname) {
     "/session/end": "session.end",
     "/screenshot": "screenshot",
     "/click": "click",
+    "/drag": "drag",
     "/move": "move",
     "/type": "type",
     "/key": "key",
@@ -428,7 +430,23 @@ function normalizeInputPayload(operation, payload, lease, at, frameTtlMs) {
     const button = payload.button;
     if (!["left", "right", "middle"].includes(button)) throw new Error("button must be left, right, or middle");
     const point = pointInFrame(payload, lease, at, frameTtlMs);
-    return { x: scale(point.x, point.frame.scale), y: scale(point.y, point.frame.scale), button, focus: point.frame.focus };
+    const count = payload.count == null ? 1 : finiteInteger(payload.count, "count");
+    if (count < 1 || count > 3) throw new Error("count must be between 1 and 3");
+    return { x: scale(point.x, point.frame.scale), y: scale(point.y, point.frame.scale), button, count, focus: point.frame.focus };
+  }
+  if (operation === "drag") {
+    const button = payload.button;
+    if (!["left", "right", "middle"].includes(button)) throw new Error("button must be left, right, or middle");
+    const frame = requireFreshFrame(payload, lease, at, frameTtlMs);
+    const from = pointCoordinatesInFrame(payload.fromX, payload.fromY, frame, "from");
+    const to = pointCoordinatesInFrame(payload.toX, payload.toY, frame, "to");
+    const durationMs = payload.durationMs == null ? 350 : finiteInteger(payload.durationMs, "durationMs");
+    if (durationMs < 0 || durationMs > 2_000) throw new Error("durationMs must be between 0 and 2000");
+    return {
+      fromX: scale(from.x, frame.scale), fromY: scale(from.y, frame.scale),
+      toX: scale(to.x, frame.scale), toY: scale(to.y, frame.scale),
+      button, durationMs, focus: frame.focus
+    };
   }
   if (operation === "move") {
     const point = pointInFrame(payload, lease, at, frameTtlMs);
@@ -470,12 +488,17 @@ function boundedScrollDelta(value, label) {
 
 function pointInFrame(payload, lease, at, frameTtlMs) {
   const frame = requireFreshFrame(payload, lease, at, frameTtlMs);
-  const x = finiteInteger(payload.x, "x");
-  const y = finiteInteger(payload.y, "y");
+  const { x, y } = pointCoordinatesInFrame(payload.x, payload.y, frame);
+  return { x, y, frame };
+}
+
+function pointCoordinatesInFrame(rawX, rawY, frame, prefix = "") {
+  const x = finiteInteger(rawX, prefix ? `${prefix}X` : "x");
+  const y = finiteInteger(rawY, prefix ? `${prefix}Y` : "y");
   if (x < 0 || y < 0 || x >= frame.width || y >= frame.height) {
     throw new Error("coordinates are outside the referenced screenshot frame");
   }
-  return { x: x + (frame.offsetX / frame.scale), y: y + (frame.offsetY / frame.scale), frame };
+  return { x: x + (frame.offsetX / frame.scale), y: y + (frame.offsetY / frame.scale) };
 }
 
 function requireFreshFrame(payload, lease, at, frameTtlMs) {

--- a/src/integrations/computer-use.js
+++ b/src/integrations/computer-use.js
@@ -17,6 +17,7 @@
 //                               since real screenshot transport needs the
 //                               Mac app).
 //   computer_click            — click at (x, y).
+//   computer_drag             — drag between two points.
 //   computer_type             — type a string.
 //   computer_key              — press a key chord.
 //   computer_scroll           — scroll at (x, y).
@@ -33,7 +34,7 @@ import { pinnedRemoteOrigin } from "../node-control.js";
 const SAFETY_NOTE = "Computer use is experimental. Every action is logged with the reasoning you provide; the log is visible to the user. Input synthesis requires a reachable computer-use node; without one, those calls are logged and refused, so do not assume they succeed.";
 
 const EXECUTION_UNAVAILABLE = "no reachable computer-use node is configured. The intent was recorded to the audit log but NOT performed. Do not assume the action succeeded.";
-const REQUIRED_INPUT_OPERATIONS = ["click", "move", "type", "key", "scroll"];
+const REQUIRED_INPUT_OPERATIONS = ["click", "drag", "move", "type", "key", "scroll"];
 
 // Tool names that this module registers. Kept here in one place so the
 // dynamic unregister path (used by the dashboard toggle) can remove
@@ -44,6 +45,7 @@ export const COMPUTER_USE_TOOL_NAMES = [
   "end_computer_use_session",
   "computer_screenshot",
   "computer_click",
+  "computer_drag",
   "computer_type",
   "computer_key",
   "computer_scroll",
@@ -86,7 +88,7 @@ export async function computerUseReadiness({
     liveScreenshot = capability?.ready === true && capability.operations?.includes?.("screenshot");
     operations = capability?.operations ?? [];
     inputAvailable = capability?.ready === true
-      && ["click", "move", "type", "key", "scroll"].every((operation) => operations.includes(operation));
+      && REQUIRED_INPUT_OPERATIONS.every((operation) => operations.includes(operation));
     detail = capability?.detail ?? null;
   } else if (node?.kind === "invalid") {
     detail = node.detail;
@@ -305,7 +307,7 @@ export function registerComputerUseTools(registry, runtime, { fetchImpl = global
         goalHash,
         expiresAt: session.expiresAt,
         maxActions: 200,
-        allowedOperations: ["session.end", "screenshot", "click", "move", "type", "key", "scroll"]
+        allowedOperations: ["session.end", "screenshot", ...REQUIRED_INPUT_OPERATIONS]
       }, fetchImpl);
       const lease = {
         nodeId: node.id,
@@ -683,8 +685,21 @@ export function registerComputerUseTools(registry, runtime, { fetchImpl = global
     frameId: { type: "string", description: "frameId from the screenshot these coordinates refer to." },
     x: { type: "integer", description: "Screen x (pixels)." },
     y: { type: "integer", description: "Screen y (pixels)." },
-    button: { type: "string", enum: ["left", "right", "middle"] }
-  }, (a) => ({ frameId: a.frameId, x: a.x, y: a.y, button: a.button }), ["frameId", "x", "y", "button"]);
+    button: { type: "string", enum: ["left", "right", "middle"] },
+    count: { type: "integer", minimum: 1, maximum: 3, description: "Click count. Use 2 for double-click and 3 for triple-click." }
+  }, (a) => ({ frameId: a.frameId, x: a.x, y: a.y, button: a.button, count: a.count ?? 1 }), ["frameId", "x", "y", "button"]);
+  registerAction("computer_drag", "drag", "Drag from one point to another in the referenced screenshot.", {
+    frameId: { type: "string", description: "frameId from the screenshot these coordinates refer to." },
+    fromX: { type: "integer" },
+    fromY: { type: "integer" },
+    toX: { type: "integer" },
+    toY: { type: "integer" },
+    button: { type: "string", enum: ["left", "right", "middle"] },
+    durationMs: { type: "integer", minimum: 0, maximum: 2000, description: "Drag duration in milliseconds." }
+  }, (a) => ({
+    frameId: a.frameId, fromX: a.fromX, fromY: a.fromY, toX: a.toX, toY: a.toY,
+    button: a.button, durationMs: a.durationMs ?? 350
+  }), ["frameId", "fromX", "fromY", "toX", "toY", "button"]);
   registerAction("computer_type", "type", "Type a string into the focused app.", {
     frameId: { type: "string", description: "Fresh frameId from the screenshot that established the current focus." },
     text: { type: "string", description: "Text to type. Use computer_key for non-printable keys." }

--- a/src/integrations/cua-computer-executor.js
+++ b/src/integrations/cua-computer-executor.js
@@ -4,7 +4,7 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import { createComputerExecutor } from "./computer-server.js";
 
-const INPUT_OPERATIONS = ["click", "move", "type", "key", "scroll"];
+const INPUT_OPERATIONS = ["click", "drag", "move", "type", "key", "scroll"];
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
 export function createConfiguredComputerExecutor({ env = process.env, ...options } = {}) {
@@ -159,7 +159,19 @@ function cuaAction(operation, payload = {}) {
     throw new Error("Cua Driver action is missing its captured window identity");
   }
   const base = { target: { kind: "window", pid, window_id: windowId }, session: "openagi" };
-  if (operation === "click") return { tool: "click", args: { ...base, x: payload.x, y: payload.y, button: payload.button } };
+  if (operation === "click") return { tool: "click", args: { ...base, x: payload.x, y: payload.y, button: payload.button, count: payload.count } };
+  if (operation === "drag") return {
+    tool: "drag",
+    args: {
+      ...base,
+      from_x: payload.fromX,
+      from_y: payload.fromY,
+      to_x: payload.toX,
+      to_y: payload.toY,
+      button: payload.button,
+      duration_ms: payload.durationMs
+    }
+  };
   if (operation === "move") return { tool: "move_cursor", args: { ...base, x: payload.x, y: payload.y } };
   if (operation === "type") return { tool: "type_text", args: { ...base, text: payload.text } };
   if (operation === "key") {

--- a/test/computer-server.test.js
+++ b/test/computer-server.test.js
@@ -8,7 +8,7 @@ import { createComputerExecutor, createComputerServer, runComputerHelper } from 
 const ready = async () => ({
   screenshotReady: true,
   inputReady: true,
-  operations: ["click", "move", "type", "key", "scroll"],
+  operations: ["click", "drag", "move", "type", "key", "scroll"],
   detail: "ready"
 });
 
@@ -39,7 +39,7 @@ async function lease(computer, sessionId = "chat:one", maxActions = 20) {
   return await computer.invoke("session.start", {
     sessionId,
     goalHash: "a".repeat(64),
-    allowedOperations: ["session.end", "screenshot", "click", "move", "type", "key", "scroll"],
+    allowedOperations: ["session.end", "screenshot", "click", "drag", "move", "type", "key", "scroll"],
     maxActions
   });
 }
@@ -78,14 +78,21 @@ test("executor binds coordinates to a screenshot frame and scales them", async (
   const active = await lease(computer);
   const shot = await action(computer, active, 1, "screenshot");
   assert.equal("focus" in shot, false, "private focus identity never leaves the node executor");
-  await action(computer, active, 2, "click", { frameId: shot.frameId, x: 100, y: 50, button: "right" });
+  await action(computer, active, 2, "click", { frameId: shot.frameId, x: 100, y: 50, button: "right", count: 2 });
   const nextShot = await action(computer, active, 3, "screenshot");
-  await action(computer, active, 4, "move", { frameId: nextShot.frameId, x: 640, y: 400 });
+  await action(computer, active, 4, "drag", {
+    frameId: nextShot.frameId, fromX: 10, fromY: 20, toX: 300, toY: 200, button: "left", durationMs: 500
+  });
+  const finalShot = await action(computer, active, 5, "screenshot");
+  await action(computer, active, 6, "move", { frameId: finalShot.frameId, x: 640, y: 400 });
   const inputCalls = calls.filter(([command]) => command === "/signed/helper");
-  assert.deepEqual(inputCalls.at(-2), ["/signed/helper", "click", { x: 200, y: 100, button: "right", focus: privateFocus }]);
+  assert.deepEqual(inputCalls.at(-3), ["/signed/helper", "click", { x: 200, y: 100, button: "right", count: 2, focus: privateFocus }]);
+  assert.deepEqual(inputCalls.at(-2), ["/signed/helper", "drag", {
+    fromX: 20, fromY: 40, toX: 600, toY: 400, button: "left", durationMs: 500, focus: privateFocus
+  }]);
   assert.deepEqual(inputCalls.at(-1), ["/signed/helper", "move", { x: 1280, y: 800, focus: privateFocus }]);
   await assert.rejects(
-    () => action(computer, active, 5, "click", { frameId: nextShot.frameId, x: 1280, y: 5, button: "left" }),
+    () => action(computer, active, 7, "click", { frameId: finalShot.frameId, x: 1280, y: 5, button: "left" }),
     /unknown, stale, or expired|outside the referenced screenshot/
   );
 });
@@ -154,6 +161,7 @@ test("all input, including type and key, requires a fresh screenshot frame", asy
   now += 1_001;
   const staleActions = [
     ["click", { frameId: shot.frameId, x: 1, y: 1, button: "left" }],
+    ["drag", { frameId: shot.frameId, fromX: 1, fromY: 1, toX: 2, toY: 2, button: "left" }],
     ["move", { frameId: shot.frameId, x: 1, y: 1 }],
     ["type", { frameId: shot.frameId, text: "never sent" }],
     ["key", { frameId: shot.frameId, chord: "enter" }],

--- a/test/computer-use-approval.test.js
+++ b/test/computer-use-approval.test.js
@@ -51,7 +51,7 @@ async function appWithComputerUse({ dataDir: suppliedDataDir = null, generate = 
       async health() {
         return { capability: {
           id: "computer-use", ready: true,
-          operations: ["session.start", "session.end", "screenshot", "click", "move", "type", "key", "scroll"]
+          operations: ["session.start", "session.end", "screenshot", "click", "drag", "move", "type", "key", "scroll"]
         } };
       },
       async invoke(operation) {
@@ -377,7 +377,7 @@ test("approved explicit node is re-authenticated and permission-checked before s
           id: "computer-use",
           screenshotReady: true,
           inputReady: false,
-          operations: ["session.start", "session.end", "screenshot", "click", "move", "type", "key", "scroll"]
+          operations: ["session.start", "session.end", "screenshot", "click", "drag", "move", "type", "key", "scroll"]
         }
       }), { status: 200, headers: { "content-type": "application/json" } });
     }

--- a/test/computer-use-readiness.test.js
+++ b/test/computer-use-readiness.test.js
@@ -35,7 +35,7 @@ test("computer-use readiness distinguishes disabled, observe-only, and control-r
             id: "computer-use",
             screenshotReady: true,
             inputReady: true,
-            operations: ["session.start", "session.end", "screenshot", "click", "move", "type", "key", "scroll"]
+            operations: ["session.start", "session.end", "screenshot", "click", "drag", "move", "type", "key", "scroll"]
           }
         })
       };

--- a/test/cua-computer-executor.test.js
+++ b/test/cua-computer-executor.test.js
@@ -49,7 +49,7 @@ async function start(executor) {
   return await executor.invoke("session.start", {
     sessionId: "chat:cua",
     goalHash: "a".repeat(64),
-    allowedOperations: ["session.end", "screenshot", "click", "move", "type", "key", "scroll"]
+    allowedOperations: ["session.end", "screenshot", "click", "drag", "move", "type", "key", "scroll"]
   });
 }
 
@@ -74,23 +74,33 @@ test("Cua backend preserves OpenAGI leases and maps fresh-frame desktop actions"
   try {
     const health = await executor.health();
     assert.equal(health.capability.ready, true);
-    assert.deepEqual(health.capability.operations, ["session.start", "session.end", "screenshot", "click", "move", "type", "key", "scroll"]);
+    assert.deepEqual(health.capability.operations, ["session.start", "session.end", "screenshot", "click", "drag", "move", "type", "key", "scroll"]);
 
     const lease = await start(executor);
     let shot = await invoke(executor, lease, 1, "screenshot");
     assert.equal(shot.width, 100);
     assert.equal(shot.scale, 2);
-    await invoke(executor, lease, 2, "click", { frameId: shot.frameId, x: 10, y: 5, button: "left" });
+    await invoke(executor, lease, 2, "click", { frameId: shot.frameId, x: 10, y: 5, button: "left", count: 2 });
     shot = await invoke(executor, lease, 3, "screenshot");
-    await invoke(executor, lease, 4, "type", { frameId: shot.frameId, text: "private typed text" });
+    await invoke(executor, lease, 4, "drag", {
+      frameId: shot.frameId, fromX: 5, fromY: 5, toX: 25, toY: 20, button: "left", durationMs: 400
+    });
     shot = await invoke(executor, lease, 5, "screenshot");
-    await invoke(executor, lease, 6, "key", { frameId: shot.frameId, chord: "cmd+shift+t" });
+    await invoke(executor, lease, 6, "type", { frameId: shot.frameId, text: "private typed text" });
     shot = await invoke(executor, lease, 7, "screenshot");
-    await invoke(executor, lease, 8, "scroll", { frameId: shot.frameId, x: 20, y: 10, deltaX: 0, deltaY: -3 });
+    await invoke(executor, lease, 8, "key", { frameId: shot.frameId, chord: "cmd+shift+t" });
+    shot = await invoke(executor, lease, 9, "screenshot");
+    await invoke(executor, lease, 10, "scroll", { frameId: shot.frameId, x: 20, y: 10, deltaX: 0, deltaY: -3 });
 
     const click = cua.calls.find((call) => call.args[1] === "click");
     assert.deepEqual(click.payload.target, { kind: "window", pid: 42, window_id: 7 });
     assert.deepEqual([click.payload.x, click.payload.y], [20, 10], "OpenAGI frame scaling is preserved");
+    assert.equal(click.payload.count, 2);
+    const drag = cua.calls.find((call) => call.args[1] === "drag");
+    assert.deepEqual(
+      [drag.payload.from_x, drag.payload.from_y, drag.payload.to_x, drag.payload.to_y, drag.payload.duration_ms],
+      [10, 10, 50, 40, 400]
+    );
     const typed = cua.calls.find((call) => call.args[1] === "type_text");
     assert.equal(typed.payload.text, "private typed text");
     assert.doesNotMatch(JSON.stringify(typed.args), /private typed text/, "typed text never enters process argv");

--- a/test/node-control.test.js
+++ b/test/node-control.test.js
@@ -9,7 +9,7 @@ import { NodeRegistry } from "../src/node-registry.js";
 const capability = () => [{
   id: "computer-use",
   ready: true,
-  operations: ["session.start", "session.end", "screenshot", "click", "move", "type", "key", "scroll"],
+  operations: ["session.start", "session.end", "screenshot", "click", "drag", "move", "type", "key", "scroll"],
   checkedAt: new Date().toISOString()
 }];
 


### PR DESCRIPTION
## Summary
- add approval-gated drag and multi-click actions across native Mac, paired-node, and optional Cua execution
- keep every coordinate bound to a fresh screenshot and immutable node lease
- guarantee mouse-up cleanup when drag is cancelled or focus/readiness changes

## Validation
- focused computer-use and node suites pass
- full JavaScript suite: 1020 pass; unrelated cron timing tests time out only under the highly parallel full run and pass when isolated
- staged and commit-range secret/path guards pass
- local Swift compiler stalls inside the installed Xcode toolchain before diagnostics; CI should provide the authoritative signed-helper compile

## Security
- no new listener, auth path, credential flow, shell fallback, or approval bypass
- drag duration is capped at 2 seconds; click count at 3
- typed data remains stdin-only and redacted from durable logs

## Follow-up
Semantic accessibility element targeting remains the next major Codex-parity slice.