### PR TITLE
[codex] recover daemon outages without resetting setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ npm run install-launchd      # macOS — auto-start at login + auto-restart on c
 npm run install-systemd      # Linux — same, via systemd (sudo for system-wide; pass 'user' for rootless)
 ```
 
+Supervised installs intentionally exit non-zero after an uncaught synchronous
+exception so launchd/systemd can replace a potentially corrupted process. A PID
+that still owns the port is not considered healthy unless `GET /health` answers;
+recoverable asynchronous integration failures remain logged without stopping
+the daemon.
+
 ### macOS native menu bar app
 
 A SwiftUI menubar app that bundles Node + the runtime + Sparkle auto-update + screen capture + replay confirmation:

--- a/docs/openagi-personal-agent-readiness.md
+++ b/docs/openagi-personal-agent-readiness.md
@@ -1,0 +1,111 @@
+# OpenAGI personal-agent readiness
+
+This is an implementation and acceptance map, not a claim that every capability
+is shipped or working on a particular machine. Keep account details, hostnames,
+session contents, tokens, and local paths out of public evidence.
+
+## Recovery before onboarding
+
+- An unreachable daemon means configuration is unknown, not that credentials
+  are missing. Show setup only after a successful health response explicitly
+  reports an unconfigured provider.
+- Uncaught synchronous exceptions must terminate non-zero so a supervisor can
+  recover. Do not repeatedly log a formatted stack and retain the listener.
+- The desktop daemon inherits its log file directly rather than depending on
+  parent-owned pipe readers. Preserve external processes unless ownership is
+  verified; do not broaden automatic process-killing to arbitrary app copies.
+- Reconcile approvals and the brief when health recovers. Missed SSE events
+  must not leave stale failure banners on screen.
+- Release acceptance: install the signed candidate, verify recovery with a
+  disposable daemon fault, and confirm both the API and visible UI recover.
+  Source tests alone do not prove an installed app contains the changes.
+
+## One orchestrator, several interfaces
+
+The intended architecture is G2 / desktop / chat -> OpenAGI -> bounded coding
+supervisor adapters -> Claude Code and Codex. The existing supervisor has
+discovery, attention classification, and delivery-route selection; reuse those
+contracts instead of adding a second LLM just to relay notifications.
+
+The G2 work lives in `src/integrations/g2-channel.js` and
+`integration-clients/even-g2-overlay/` on its feature branch. Preserve node-scoped
+enrollment: glasses receive no owner token, provider credential, or arbitrary
+access to another conversation.
+
+The coding-supervisor bridge is not implemented in this change. Its contract:
+
+1. Explicitly opt in to an adapter configured by the operator, not an agent-
+   supplied command or repository path. Discovery has deadlines, bounded
+   output, and provider/session/project identifiers with observed timestamps.
+2. List states and attention reasons, distinguish heuristic `waiting` from
+   provider-confirmed approval requests, and expose only recent context for
+   the selected session. Do not import every transcript into long-term memory.
+3. Bind each reply/delegation to one exact session and project. Keep provider
+   writer locks intact; never turn an ambiguous project name into fan-out.
+   Send message text over stdin or an authenticated transport, not command-line
+   arguments. Do not resume a session merely to inspect it.
+4. Route permission requests into OpenAGI's durable approval queue. Show the
+   target, proposed action, expected cost, and risk. Untrusted transcript text
+   cannot approve itself, change the routing policy, or escalate permissions.
+5. Send deduplicated transition notifications to the desktop and G2. Persist
+   delivery state, reconcile after disconnect, and require verified completion
+   rather than treating a queued send as success.
+6. Choose model/provider effort within declared capability and cost limits;
+   intelligence selection must never change approval requirements.
+
+Acceptance requires fixture tests for stale sessions, ambiguous IDs, writer
+conflicts, timeouts, duplicate notifications, and approval expiry; then a live
+round trip for each provider through G2 and desktop, with the operator choosing
+the test session. A successful CLI status scan is not that round trip.
+
+## Computer use
+
+OpenAGI already contains a signed native helper, session leases, approvals,
+screenshots, coordinate input, semantic Accessibility actions, and a Cua Driver
+adapter. Readiness must report the selected executor's *measured* operations;
+the enabled toggle is not proof of control. Capture and input permissions are
+different. Secure Input can block typing even with both permissions granted.
+
+Use the native helper for the existing path; evaluate Cua as an optional backend
+against the same contract, not as a substitute for approvals or verification.
+The upstream [Cua Driver documentation](https://github.com/trycua/cua/blob/main/libs/cua-driver/README.md)
+describes background app control and replayable trajectories. Pin and validate
+the selected driver version before relying on those capabilities.
+
+Acceptance: approve one session on an unlocked test machine, capture a fresh
+frame, perform click/type/scroll/drag and semantic actions where advertised,
+verify the rendered result after each action, then prove Stop prevents further
+input. Repeat over a node relay, including offline/locked/Secure Input cases.
+Do not disable macOS security protections automatically.
+
+## Mail and calendar
+
+The existing calendar integration reads ICS feeds; it does not manage events.
+The folder inbox watcher is not an email connector.
+
+The catalog now includes the official Superhuman Mail OAuth MCP. According to
+[Superhuman's documentation](https://help.superhuman.com/hc/en-us/articles/46005696690317-Superhuman-Mail-MCP-Server),
+it supports email search, drafts, sending, availability, and event management;
+it requires an eligible Mail plan, Ask AI, and its Chrome extension for sign-in.
+An endpoint in the catalog is not a connected account or tested OAuth flow.
+
+Acceptance: complete sign-in in OpenAGI, verify discovered tools, read a chosen
+test message/event, create a test draft, and prove send/delete/event mutation
+approval behavior. Keep drafts separate from sent messages. Verify disconnect
+and token refresh. If using Google APIs directly instead, request only the
+necessary scopes and complete the required public-app OAuth review.
+
+## Memory, review, and outcomes
+
+- Present tasks, drafts, clarifications, and skill suggestions separately.
+  Large suggestion counts must not masquerade as overdue tasks.
+- Suppress repetitive app-switching suggestions before they enter review;
+  merge near-duplicate workflows and retain only actionable, grounded skills.
+- Track recall usefulness, corrections, and tier pressure independently.
+  Recall coverage alone is not accuracy, and zero exact duplicates does not
+  establish semantic uniqueness.
+- Distinguish user ratings, verified task results, and inferred housekeeping
+  scores. Do not present a default inferred score as user satisfaction.
+- Acceptance: compare a representative bounded sample before/after, preserve
+  actionable user work, show why an item was retained or suppressed, and
+  measure verified outcomes over subsequent use.

--- a/mac/Sources/OpenAGI/AppState.swift
+++ b/mac/Sources/OpenAGI/AppState.swift
@@ -16,7 +16,14 @@ final class AppState: ObservableObject {
 
   // Health snapshot
   @Published var providerName: String = "—"
-  @Published var providerConfigured: Bool = false
+  // Missing health data is unknown, not evidence that a saved key disappeared.
+  @Published var providerConfigured: Bool? = nil
+  var providerSetupStatus: ProviderSetupStatus {
+    ProviderSetupStatus.resolve(
+      daemonResponding: status != .unknown && status != .down,
+      configured: providerConfigured
+    )
+  }
   @Published var memoryShort: Int = 0
   @Published var memoryMedium: Int = 0
   @Published var memoryLong: Int = 0
@@ -186,11 +193,12 @@ final class AppState: ObservableObject {
       // interval, so a wedge shows up on the next tick; local /health answers
       // in ~0.3s, so the headroom is ~13x.
       let h: HealthResponse = try await get("/health", timeout: 4)
+      let recoveredFromOutage = consecutiveFailures > 0
       status = computeStatus(h)
       reachability = .serving
       daemonManagedExternally = await DaemonController.shared.listenerOwnership() == .external
       providerName = h.status?.agentHost?.provider ?? "—"
-      providerConfigured = h.status?.agentHost?.providerConfigured ?? false
+      providerConfigured = h.status?.agentHost?.providerConfigured
       memoryShort = h.status?.memory?.short ?? 0
       memoryMedium = h.status?.memory?.medium ?? 0
       memoryLong = h.status?.memory?.long ?? 0
@@ -201,15 +209,19 @@ final class AppState: ObservableObject {
       // brief items, so without this it reads 0 until the user opens the
       // popover: the one always-visible "something needs you" signal was blank
       // exactly when there was something to see.
-      if !didInitialBriefRefresh {
+      if !didInitialBriefRefresh || recoveredFromOutage {
         didInitialBriefRefresh = true
         scheduleBriefRefresh()
+        // SSE notifications emitted while disconnected are not replayed.
+        // Reconcile durable approvals on recovery, without requiring the user
+        // to close and reopen a panel that still displays an outage error.
+        Task { await PendingApprovalConsumer.shared.refresh() }
       }
       if h.firstRun == true && !offeredSetupThisLaunch {
         offeredSetupThisLaunch = true
         notify(title: "Welcome to OpenAGI", body: "Two minutes of setup and your agent is live.", path: "/setup")
         openDashboard(path: "/setup")
-      } else if h.firstRun != true && !providerConfigured && !offeredSetupThisLaunch {
+      } else if h.firstRun != true && providerSetupStatus == .needsSetup && !offeredSetupThisLaunch {
         // Partially-configured install (auth token saved, model key missing —
         // isFirstRun() is false but the agent can't think). Nudge once per
         // launch with a notification only; don't grab a window from someone

--- a/mac/Sources/OpenAGI/DaemonController.swift
+++ b/mac/Sources/OpenAGI/DaemonController.swift
@@ -98,7 +98,8 @@ final class DaemonController {
     }
 
     if !FileManager.default.fileExists(atPath: logFile.path) {
-      FileManager.default.createFile(atPath: logFile.path, contents: nil)
+      FileManager.default.createFile(atPath: logFile.path, contents: nil,
+                                     attributes: [.posixPermissions: 0o600])
     }
     logHandle = try? FileHandle(forWritingTo: logFile)
     logHandle?.seekToEndOfFile()
@@ -115,18 +116,11 @@ final class DaemonController {
     env["OPENAGI_COMPUTER_HELPER"] = bundleResources.appendingPathComponent("OpenAGIComputerHelper").path
     proc.environment = env
 
-    let stdoutPipe = Pipe()
-    let stderrPipe = Pipe()
-    proc.standardOutput = stdoutPipe
-    proc.standardError = stderrPipe
-    stdoutPipe.fileHandleForReading.readabilityHandler = { [weak self] h in
-      let d = h.availableData
-      if !d.isEmpty { self?.logHandle?.write(d) }
-    }
-    stderrPipe.fileHandleForReading.readabilityHandler = { [weak self] h in
-      let d = h.availableData
-      if !d.isEmpty { self?.logHandle?.write(d) }
-    }
+    // Inherit the log file directly. A parent app crash must not leave the
+    // daemon writing to orphaned pipes (EPIPE), and log delivery must not rely
+    // on an app-side readability callback continuing to drain the pipes.
+    proc.standardOutput = logHandle ?? FileHandle.nullDevice
+    proc.standardError = logHandle ?? FileHandle.nullDevice
     proc.terminationHandler = { [weak self] p in
       NSLog("OpenAGI: daemon exited with \(p.terminationStatus)")
       DispatchQueue.main.async {

--- a/mac/Sources/OpenAGI/Overlay/PendingApprovalConsumer.swift
+++ b/mac/Sources/OpenAGI/Overlay/PendingApprovalConsumer.swift
@@ -70,6 +70,7 @@ final class PendingApprovalConsumer: ObservableObject {
       base: AppState.shared.baseURL,
       path: "/pending-actions?status=pending"))
     authed(&req)
+    req.timeoutInterval = 4
     do {
       let (data, response) = try await URLSession.shared.data(for: req)
       guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {

--- a/mac/Sources/OpenAGI/ProviderSetupStatus.swift
+++ b/mac/Sources/OpenAGI/ProviderSetupStatus.swift
@@ -1,0 +1,13 @@
+/// A failed health probe cannot establish whether credentials are configured.
+/// Keep recovery separate from onboarding, including after a previously valid
+/// health response becomes stale.
+enum ProviderSetupStatus: Equatable {
+  case unknown
+  case configured
+  case needsSetup
+
+  static func resolve(daemonResponding: Bool, configured: Bool?) -> Self {
+    guard daemonResponding, let configured else { return .unknown }
+    return configured ? .configured : .needsSetup
+  }
+}

--- a/mac/Sources/OpenAGI/TrayController.swift
+++ b/mac/Sources/OpenAGI/TrayController.swift
@@ -119,10 +119,13 @@ struct TrayMenu: View {
         Text("⚠ \(err)").disabled(true).foregroundStyle(.red).lineLimit(3)
         Button("Show daemon log…") { revealDaemonLog() }
       }
-      if state.providerConfigured {
+      switch state.providerSetupStatus {
+      case .configured:
         Text("Model: \(state.providerName)").disabled(true)
-      } else {
+      case .needsSetup:
         Button("⚠ Finish setup — agent has no model key") { state.openDashboard(path: "/setup") }
+      case .unknown:
+        Text("Model setup cannot be checked until the daemon responds").disabled(true)
       }
       Text("Today: $\(formatUsd(state.spentToday)) / $\(formatUsd(state.spentLimit))")
         .disabled(true)
@@ -175,7 +178,7 @@ struct TrayMenu: View {
   private var statusLine: String {
     // An unconfigured agent isn't "online" in any sense the user cares
     // about — say so before anything else.
-    if state.status == .healthy && !state.providerConfigured { return "● setup needed" }
+    if state.providerSetupStatus == .needsSetup { return "● setup needed" }
     switch state.status {
     case .healthy: return "● online"
     case .degraded: return "● needs attention"

--- a/mac/Tests/OpenAGITests/ProviderSetupStatusTests.swift
+++ b/mac/Tests/OpenAGITests/ProviderSetupStatusTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import OpenAGI
+
+final class ProviderSetupStatusTests: XCTestCase {
+  func testOfflineStateDoesNotClaimKeysAreMissing() {
+    for configured in [nil, true, false] as [Bool?] {
+      XCTAssertEqual(ProviderSetupStatus.resolve(daemonResponding: false, configured: configured), .unknown)
+    }
+  }
+
+  func testMissingHealthFieldIsNotAnUnconfiguredProvider() {
+    XCTAssertEqual(ProviderSetupStatus.resolve(daemonResponding: true, configured: nil), .unknown)
+  }
+
+  func testOnlyExplicitLiveConfigurationCanRequireSetup() {
+    XCTAssertEqual(ProviderSetupStatus.resolve(daemonResponding: true, configured: true), .configured)
+    XCTAssertEqual(ProviderSetupStatus.resolve(daemonResponding: true, configured: false), .needsSetup)
+  }
+}

--- a/src/boot.js
+++ b/src/boot.js
@@ -79,10 +79,11 @@ export function createFatalUncaughtExceptionHandler({ write, exit } = {}) {
       if (typeof error?.message === "string" && error.message.trim()) message = error.message.trim();
       else if (error != null) message = String(error);
     } catch { /* hostile Error accessors must not trap the fatal handler */ }
+    name = name.replace(/[\r\n\t]+/g, " ");
     message = message.replace(/[\r\n\t]+/g, " ").slice(0, 1_000);
 
     try {
-      writeLine(`[openagi] fatal uncaught exception ${livenessNote()}: ${name}: ${message}\n`);
+      writeLine(`[openagi] fatal uncaught exception (exiting for recovery): ${name}: ${message}\n`);
     } finally {
       exitNow(1);
     }

--- a/src/boot.js
+++ b/src/boot.js
@@ -52,6 +52,43 @@ export function loadBootEnv() {
 // before the runtime/MCP connects, so it covers every daemon launch (the CLI,
 // this example, systemd, the Mac DaemonController) identically.
 let crashGuardsInstalled = false;
+
+// Node explicitly warns that normal operation after an uncaught synchronous
+// exception is unsafe: application state may already be corrupted. Keeping the
+// event loop alive can be worse than a crash — a repeating callback can throw
+// forever while the process still owns its port, making liveness checks hang
+// and preventing launchd/systemd from replacing it. Keep this handler small,
+// synchronous, and independently testable. In production it writes one bounded
+// line without asking V8 to format a potentially huge/recursive stack, then
+// exits non-zero so the existing supervisor can recover the daemon.
+export function createFatalUncaughtExceptionHandler({ write, exit } = {}) {
+  const writeLine = write ?? ((line) => {
+    try { fs.writeSync(2, line); } catch { /* stderr may already be unavailable */ }
+  });
+  const exitNow = exit ?? ((code) => process.exit(code));
+  let exiting = false;
+
+  return (error) => {
+    if (exiting) return exitNow(1);
+    exiting = true;
+
+    let name = "Error";
+    let message = "unknown synchronous failure";
+    try {
+      if (typeof error?.name === "string" && error.name.trim()) name = error.name.trim().slice(0, 80);
+      if (typeof error?.message === "string" && error.message.trim()) message = error.message.trim();
+      else if (error != null) message = String(error);
+    } catch { /* hostile Error accessors must not trap the fatal handler */ }
+    message = message.replace(/[\r\n\t]+/g, " ").slice(0, 1_000);
+
+    try {
+      writeLine(`[openagi] fatal uncaught exception ${livenessNote()}: ${name}: ${message}\n`);
+    } finally {
+      exitNow(1);
+    }
+  };
+}
+
 export function installCrashGuards() {
   if (crashGuardsInstalled) return;
   crashGuardsInstalled = true;
@@ -59,12 +96,10 @@ export function installCrashGuards() {
     const err = reason instanceof Error ? reason : new Error(String(reason));
     console.error(`[openagi] unhandled rejection ${livenessNote()}: ${err.stack || err.message}`);
   });
-  // An uncaught synchronous exception can leave state undefined, but for a
-  // supervised, always-on daemon staying up beats crash-looping; the error is
-  // logged loudly so it's still diagnosable in daemon.log / journald.
-  process.on("uncaughtException", (err) => {
-    console.error(`[openagi] uncaught exception ${livenessNote()}: ${err?.stack || err}`);
-  });
+  // Unlike a recoverable integration rejection, an uncaught synchronous
+  // exception is fatal. Exit once and let launchd/systemd replace the process;
+  // retaining a possibly corrupted event loop can leave a port-owning zombie.
+  process.on("uncaughtException", createFatalUncaughtExceptionHandler());
 }
 
 // ─── Startup failures must be non-zero ────────────────────────────────────

--- a/src/mcp-catalog.js
+++ b/src/mcp-catalog.js
@@ -389,6 +389,19 @@ export const MCP_CATALOG = [
 
   // ─── Communication ──────────────────────────────────────────────────
   {
+    id: "superhuman-mail",
+    name: "Superhuman Mail",
+    description: "Search email and calendar, prepare drafts, and manage events. Requires Superhuman Mail Business or higher, Ask AI, and its Chrome extension for OAuth sign-in.",
+    category: "communication",
+    authType: "oauth",
+    status: "available",
+    matches: { hostnames: ["mail.superhuman.com"], keywords: ["superhuman mail"] },
+    // Official server, with dynamic OAuth client registration. Catalog
+    // discovery does not connect an account or grant permission to send mail.
+    // https://help.superhuman.com/hc/en-us/articles/46005696690317-Superhuman-Mail-MCP-Server
+    register: { url: "https://mcp.mail.superhuman.com/mcp", transport: "http", auth: "oauth" }
+  },
+  {
     id: "slack",
     name: "Slack",
     description: "Access Slack channels, messages, and user data. Coming soon — Slack's hosted MCP requires you to register your own Slack app and provide its client_id + client_secret, which the wizard doesn't collect yet.",

--- a/test/boot-crash-guards.test.js
+++ b/test/boot-crash-guards.test.js
@@ -62,6 +62,27 @@ test("fatal exception handler emits one bounded line and exits non-zero", () => 
   assert.equal(written[0].split("\n").length, 2, "embedded newlines are flattened");
   assert.ok(written[0].length < 1_200, "fatal diagnostic is bounded");
   assert.doesNotMatch(written[0], /\bat\s+/, "V8 stack formatting is never requested");
+  assert.match(written[0], /exiting for recovery/);
+  assert.doesNotMatch(written[0], /kept alive/);
+});
+
+test("fatal exception diagnostics remain single-line with a custom error name", () => {
+  const written = [];
+  const error = new Error("failed");
+  error.name = "Provider\nError";
+  createFatalUncaughtExceptionHandler({ write: (line) => written.push(line), exit: () => {} })(error);
+  assert.equal(written[0].split("\n").length, 2);
+});
+
+test("fatal exception exit survives hostile accessors and a failed diagnostic writer", () => {
+  const exits = [];
+  const handler = createFatalUncaughtExceptionHandler({
+    write: () => { throw new Error("closed stderr"); },
+    exit: (code) => exits.push(code)
+  });
+  const error = Object.defineProperty({}, "name", { get() { throw new Error("bad getter"); } });
+  assert.throws(() => handler(error), /closed stderr/);
+  assert.deepEqual(exits, [1]);
 });
 
 test("an installed handler terminates a child daemon process on an uncaught exception", () => {
@@ -80,4 +101,20 @@ test("an installed handler terminates a child daemon process on an uncaught exce
   assert.equal(child.signal, null);
   assert.match(child.stderr, /fatal uncaught exception/);
   assert.match(child.stderr, /child-fatal-marker/);
+});
+
+test("a daemon with closed stderr still exits instead of looping on its logger", () => {
+  const bootUrl = new URL("../src/boot.js", import.meta.url).href;
+  const script = `
+    import fs from "node:fs";
+    import { installCrashGuards } from ${JSON.stringify(bootUrl)};
+    installCrashGuards();
+    fs.closeSync(2);
+    setImmediate(() => { throw new Error("closed-stderr-fatal"); });
+  `;
+  const child = spawnSync(process.execPath, ["--input-type=module", "--eval", script], {
+    encoding: "utf8", timeout: 5_000
+  });
+  assert.equal(child.status, 1);
+  assert.equal(child.signal, null);
 });

--- a/test/boot-crash-guards.test.js
+++ b/test/boot-crash-guards.test.js
@@ -1,13 +1,15 @@
 // test/boot-crash-guards.test.js
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { installCrashGuards } from "../src/boot.js";
+import { spawnSync } from "node:child_process";
+import { createFatalUncaughtExceptionHandler, installCrashGuards } from "../src/boot.js";
 
 // A reauth-needed / unreachable MCP server rejects asynchronously during
 // connect (401, OAuth callback timeout, DNS failure). Node 15+ would terminate
 // the daemon on that unhandled rejection — crash-looping a recoverable error.
-// installCrashGuards must turn those into logged, non-fatal events.
-test("installCrashGuards installs non-fatal handlers and is idempotent", () => {
+// Those rejections remain non-fatal, while synchronous uncaught exceptions
+// terminate so the supervisor can replace a potentially corrupted daemon.
+test("installCrashGuards installs distinct rejection and exception policies idempotently", () => {
   const beforeRej = process.listeners("unhandledRejection").length;
   const beforeExc = process.listeners("uncaughtException").length;
 
@@ -22,7 +24,7 @@ test("installCrashGuards installs non-fatal handlers and is idempotent", () => {
   assert.equal(process.listeners("unhandledRejection").length, beforeRej + 1, "idempotent (rejection)");
   assert.equal(process.listeners("uncaughtException").length, beforeExc + 1, "idempotent (exception)");
 
-  // The handlers must log and NOT rethrow — an MCP 401 / OAuth timeout is not fatal.
+  // Rejections must log and NOT rethrow — an MCP 401 / OAuth timeout is not fatal.
   const ourRej = rejListeners[rejListeners.length - 1];
   const ourExc = excListeners[excListeners.length - 1];
   const origErr = console.error;
@@ -30,17 +32,52 @@ test("installCrashGuards installs non-fatal handlers and is idempotent", () => {
   console.error = (...a) => logged.push(a.join(" "));
   try {
     assert.doesNotThrow(() => ourRej(new Error("HTTP 401 from buildbetter staging: invalid_token")));
-    assert.doesNotThrow(() => ourExc(new Error("OAuth callback timed out")));
     // A non-Error reason (e.g. a rejected string) must also be handled.
     assert.doesNotThrow(() => ourRej("bare string rejection"));
   } finally {
     console.error = origErr;
   }
   assert.ok(logged.some((l) => l.includes("401")), "logged the 401 rejection");
-  assert.ok(logged.some((l) => l.includes("OAuth callback timed out")), "logged the exception");
   assert.ok(logged.some((l) => l.includes("bare string rejection")), "logged a non-Error reason");
 
   // Clean up the listeners we added so they don't leak into the test runner.
   process.removeListener("unhandledRejection", ourRej);
   process.removeListener("uncaughtException", ourExc);
+});
+
+test("fatal exception handler emits one bounded line and exits non-zero", () => {
+  const written = [];
+  const exits = [];
+  const handler = createFatalUncaughtExceptionHandler({
+    write: (line) => written.push(line),
+    exit: (code) => exits.push(code)
+  });
+
+  handler(new Error(`first line\n${"x".repeat(2_000)}`));
+  handler(new Error("second exception while exiting"));
+
+  assert.deepEqual(exits, [1, 1]);
+  assert.equal(written.length, 1, "nested fatal errors do not recurse through logging");
+  assert.match(written[0], /^\[openagi\] fatal uncaught exception .*Error: first line x+/);
+  assert.equal(written[0].split("\n").length, 2, "embedded newlines are flattened");
+  assert.ok(written[0].length < 1_200, "fatal diagnostic is bounded");
+  assert.doesNotMatch(written[0], /\bat\s+/, "V8 stack formatting is never requested");
+});
+
+test("an installed handler terminates a child daemon process on an uncaught exception", () => {
+  const bootUrl = new URL("../src/boot.js", import.meta.url).href;
+  const script = `
+    import { installCrashGuards } from ${JSON.stringify(bootUrl)};
+    installCrashGuards();
+    setImmediate(() => { throw new Error("child-fatal-marker"); });
+  `;
+  const child = spawnSync(process.execPath, ["--input-type=module", "--eval", script], {
+    encoding: "utf8",
+    timeout: 5_000
+  });
+
+  assert.equal(child.status, 1);
+  assert.equal(child.signal, null);
+  assert.match(child.stderr, /fatal uncaught exception/);
+  assert.match(child.stderr, /child-fatal-marker/);
 });

--- a/test/mac-daemon-status.test.js
+++ b/test/mac-daemon-status.test.js
@@ -29,6 +29,31 @@ function code(rel) {
     .join("\n");
 }
 
+test("provider setup is unknown until health explicitly reports configuration", () => {
+  const appstate = code(APPSTATE);
+  assert.match(appstate, /@Published var providerConfigured: Bool\? = nil/);
+  assert.match(appstate, /providerConfigured = h\.status\?\.agentHost\?\.providerConfigured\s*\n/);
+  assert.match(appstate, /providerSetupStatus == \.needsSetup && !offeredSetupThisLaunch/);
+  const tray = code(TRAY);
+  assert.match(tray, /switch state\.providerSetupStatus/);
+  assert.match(tray, /case \.unknown:\s*Text\("Model setup cannot be checked until the daemon responds"\)/);
+  assert.doesNotMatch(tray, /!state\.providerConfigured/);
+});
+
+test("health recovery reconciles approvals even when no SSE event is replayed", () => {
+  const appstate = code(APPSTATE);
+  assert.match(appstate, /let recoveredFromOutage = consecutiveFailures > 0/);
+  assert.match(appstate, /if !didInitialBriefRefresh \|\| recoveredFromOutage \{[^}]*scheduleBriefRefresh\(\)[^}]*PendingApprovalConsumer\.shared\.refresh\(\)/);
+});
+
+test("daemon logging does not depend on the parent draining a pipe", () => {
+  const daemon = code(DAEMON);
+  assert.match(daemon, /proc\.standardOutput = logHandle \?\? FileHandle\.nullDevice/);
+  assert.match(daemon, /proc\.standardError = logHandle \?\? FileHandle\.nullDevice/);
+  assert.doesNotMatch(daemon, /readabilityHandler/);
+  assert.match(daemon, /attributes: \[\.posixPermissions: 0o600\]/);
+});
+
 test("tray restart action never labels itself with recovery jargon", () => {
   // Shipped label: `Button(state.status == .down ? "↻ Restart daemon" : "↻ Restart daemon (recover)")`.
   // "(recover)" names an implementation detail — that bouncing a daemon which

--- a/test/superhuman-catalog.test.js
+++ b/test/superhuman-catalog.test.js
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { MCP_CATALOG, matchCatalog } from "../src/mcp-catalog.js";
+
+test("Superhuman Mail uses the official OAuth server without embedded credentials", () => {
+  const entries = MCP_CATALOG.filter((entry) => entry.id === "superhuman-mail");
+  assert.equal(entries.length, 1);
+  const entry = entries[0];
+  assert.equal(entry.status, "available");
+  assert.equal(entry.authType, "oauth");
+  assert.equal(entry.category, "communication");
+  assert.deepEqual(entry.register, {
+    url: "https://mcp.mail.superhuman.com/mcp", transport: "http", auth: "oauth"
+  });
+  assert.match(entry.description, /Business or higher/);
+});
+
+test("Superhuman suggestions stay specific to Mail and stop after registration", () => {
+  const mail = [{ text: "Open mail.superhuman.com to review the inbox" }];
+  const ids = (snippets, registered) => matchCatalog([], snippets, registered).map(({ entry }) => entry.id);
+  assert.ok(ids(mail).includes("superhuman-mail"));
+  assert.ok(!ids(mail, new Set(["superhuman-mail"])).includes("superhuman-mail"));
+  assert.ok(!ids([{ text: "Superhuman Docs" }]).includes("superhuman-mail"));
+});


### PR DESCRIPTION
## Summary

- Terminate after an uncaught synchronous exception so the daemon supervisor can recover, including when stderr is unavailable.
- Inherit a private daemon log file instead of relying on parent-owned pipe readers.
- Treat missing or stale provider health as unknown rather than incorrectly claiming credentials are absent.
- Reconcile approvals and the brief after health recovers, with bounded approval-refresh requests.
- Add the official Superhuman Mail OAuth MCP to the integration catalog and document remaining personal-agent acceptance checks.

## Validation

- 50 focused JavaScript tests passed (recovery, startup corruption, configuration, permissions, desktop status, catalog).
- 46 macOS Swift tests passed; the app target compiled successfully.
- Verified live daemon recovery, sustained localhost health, and the full floating-panel layout and refreshed approvals.
- Git safety scan passed for the full commit range.

## Boundaries

No credentials or installation-specific configuration are included. External daemon ownership protections are unchanged. Superhuman catalog availability does not connect an account or authorize email/calendar mutations. The new source changes have not yet been validated as an installed signed release.
