### PR TITLE
Harden G2 computer-control cancellation and isolate the OCU engine

### DIFF
--- a/.github/workflows/ocu-compatibility.yml
+++ b/.github/workflows/ocu-compatibility.yml
@@ -1,0 +1,32 @@
+name: Open Computer Use compatibility
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'src/integrations/*computer*'
+      - 'src/integrations/ocu-*'
+      - 'src/integrations/g2-channel.js'
+      - 'src/agent-host.js'
+      - 'src/node-control.js'
+      - 'scripts/install-open-computer-use.mjs'
+      - 'test/*computer*'
+      - 'test/ocu-*'
+      - 'test/node-control.test.js'
+      - 'test/g2-cancellation.test.js'
+      - '.github/workflows/ocu-compatibility.yml'
+permissions:
+  contents: read
+jobs:
+  guarded-adapter:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci --ignore-scripts --no-audit --no-fund
+      - run: node --test test/open-computer-use.test.js test/ocu-transport.test.js test/computer-use-request-cancel.test.js test/computer-server.test.js test/computer-use-approval.test.js test/node-control.test.js test/g2-cancellation.test.js

--- a/docs/setup/open-computer-use.md
+++ b/docs/setup/open-computer-use.md
@@ -46,8 +46,8 @@ there is no public MCP listener and no owner token sent to upstream.
 - OpenAGI still owns node selection, approvals, expiring leases, action IDs,
   screenshot freshness, cancellation, and logs. Changing windows invalidates
   the engine state. Global pointer fallback is disabled for upstream clicks.
-- Readiness checks verify the OpenAGI gate and installed binary, not upstream
-  permission grants. An upstream denial fails the action without automatic
+- Readiness checks verify both OpenAGI's gate and upstream's non-prompting
+  permission probe. An upstream denial fails the action without automatic
   retry. macOS permissions require human approval and a physical smoke test.
 - This is not a default replacement yet. Live cancellation, excluded-window
   behavior, Retina coordinates, window switching, and multi-node selection
@@ -59,7 +59,35 @@ there is no public MCP listener and no owner token sent to upstream.
 
 Upstream: https://github.com/iFurySt/open-codex-computer-use/tree/v0.3.3
 
-Review a release, update the version and archive digest together, run adapter
-regressions and physical Mac acceptance, then ship one OpenAGI update. Never
+Review a release, update `src/integrations/ocu-release.js` (version, exact
+archive URL and digest) together, run the Open Computer Use compatibility
+workflow and physical Mac acceptance, then ship one OpenAGI update. Never
 follow `latest` automatically. MIT permits redistribution with copyright and
 license notices retained; review upstream third-party notices on every update.
+
+The stdio transport explicitly sets `OPEN_COMPUTER_USE_DISABLE_APP_AGENT_PROXY=1`.
+Do not remove this: v0.3.3 otherwise delegates to a shared LaunchServices app
+agent which outlives the stdio child. Each OpenAGI engine connection must own its
+dispatcher and snapshot cache. Global pointer fallbacks remain disabled.
+
+## G2 rollout contract
+
+G2 is the voice/display node, not a desktop executor. Pair it with the main as
+usual. Install/configure the engine on each controlled Mac; do not install an
+unrestricted MCP server on the glasses or share the main's bearer token with
+upstream. A G2 question uses the main's existing computer tools and requests
+approval for a specific goal and Mac in OpenAGI's Approvals screen. Spoken
+instructions are not a substitute for that approval.
+
+Cancelling an in-flight G2 tool request now revokes its approved desktop
+session and dispatches `session.end` to the original target, including when
+cancellation races lease creation. It cannot undo already-delivered input.
+Do not equate closing the display with a confirmed Stop: the physical G2
+gesture, transport cancellation, and the target Mac must be tested together.
+
+These server-side changes alone do not require a new G2 bundle or re-pairing.
+They require updating the main and computer node runtimes. Production default
+promotion is still blocked by upstream's app-scoped dispatch: v0.3.3 accepts no
+expected window ID, privacy policy, or per-event secure-field guard. OpenAGI's
+precheck is not atomic with upstream input. Do not retire the native dispatcher
+until this contract is enforced at input dispatch, not merely in a UI test.

--- a/docs/verification/2026-09-06-ocu-g2-hardening.md
+++ b/docs/verification/2026-09-06-ocu-g2-hardening.md
@@ -1,0 +1,53 @@
+# G2 / Open Computer Use hardening
+
+## Implemented
+
+- Own upstream's actual dispatcher by disabling its LaunchServices app-agent
+  proxy. Preserve private stdin, credential isolation and disabled global
+  pointer fallback. Late output/errors from a retired process cannot close a
+  replacement process.
+- Combine upstream permission readiness with OpenAGI's existing privacy gate.
+  Preserve actionable native readiness detail instead of replacing it with a
+  generic ready message. Missing upstream grants cannot advertise control-ready.
+- Bind the upstream window header to its actual header line; a matching string
+  inside document content is not sufficient.
+- Propagate request cancellation through computer tools into main-side consent
+  revocation and the selected node's priority cancellation path. Check again
+  after lease creation and refuse late success after cancellation.
+- Centralize the reviewed upstream version/archive/digest; add a path-filtered
+  compatibility workflow. No automatic upstream updates or permanent fork.
+
+## Evidence
+
+- 48 focused Node 22 tests pass across request cancellation, adapter/transport,
+  approvals, node routing and G2 provider cancellation. Synthetic tests verify
+  cancellation during lease creation, typing, and capture; another chat's
+  approval remains untouched. They do not prove physical G2 gestures.
+- Three additional transport/pin/probe regressions pass, for 51 distinct
+  focused tests in this change's verification runs.
+- With the app-agent proxy disabled, the installed v0.3.3 executable completed
+  MCP discovery for all nine tools and captured TextEdit on this Mac.
+- The upstream permission probe reports both permissions granted. No permissions
+  or live runtime configuration were changed.
+- A newly-created blank TextEdit document passed native activation, the
+  adapter's before/after exact-focus checks, OCU capture, adapter typing, and
+  independent OCU readback of `OpenAGI isolated engine test.` The temporary
+  executor lease was closed afterward. This is a local adapter smoke test,
+  not a main approval or physical G2 round trip. The unsaved scratch remains
+  open; existing documents were not edited.
+
+## Remaining production gate
+
+Upstream's dispatcher accepts an app, not OpenAGI's expected window ID or its
+privacy/secure-field rules. Pre-dispatch checks outside that process cannot
+guarantee those rules for every physical event. Default promotion and native
+retirement are intentionally not performed. A physical successful edit alone
+does not close this gap. The previous focus/type failure did not reproduce in
+this isolated-process smoke test; no broad focus-check relaxation was made.
+
+After the dispatch guard is resolved and updated builds are installed on the
+main and each Mac, physical acceptance requires: G2 ask -> named-Mac approval
+(deny then approve) -> scratch edit; Stop during a multi-step edit; changed and
+privacy-excluded windows; screen lock; expired consent; disconnect/reconnect
+without rerouting or replay. Never use a password field or private document as
+a test fixture. Record visible effects separately from accepted tool receipts.

--- a/scripts/install-open-computer-use.mjs
+++ b/scripts/install-open-computer-use.mjs
@@ -5,9 +5,9 @@ import crypto from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { resolveDataDir } from "../src/data-dir.js";
-import { OCU_VERSION } from "../src/integrations/open-computer-use-executor.js";
+import { OCU_VERSION, OCU_RELEASE } from "../src/integrations/ocu-release.js";
 
-export const OCU_INTEGRITY = "A4xCoXgu+Mwi2OdhL15FHY/VcnhhxIJwRgSmC2LwX9mTya85VO2NZN8PNholvgQeTeOlPpej+eEucHXtPhhVrA==";
+export const OCU_INTEGRITY = OCU_RELEASE.integrity;
 export function verifyOcuArchive(bytes) {
   if (crypto.createHash("sha512").update(bytes).digest("base64") !== OCU_INTEGRITY) throw new Error("Open Computer Use archive integrity mismatch; nothing installed.");
 }
@@ -15,7 +15,7 @@ export async function installOpenComputerUse() {
   if (process.platform !== "darwin" || Number(os.release().split(".")[0]) < 23) throw new Error("This OpenAGI adapter currently requires macOS 14 or later.");
   const destination = path.join(resolveDataDir(), "tools", "open-computer-use", OCU_VERSION);
   if (fs.existsSync(destination)) throw new Error("This version's install directory already exists; inspect it rather than overwriting it.");
-  const response = await fetch(`https://registry.npmjs.org/open-computer-use/-/open-computer-use-${OCU_VERSION}.tgz`, { signal: AbortSignal.timeout(60_000) });
+  const response = await fetch(OCU_RELEASE.archive, { signal: AbortSignal.timeout(60_000) });
   if (!response.ok) throw new Error("Could not download the pinned Open Computer Use package.");
   const chunks = []; let total = 0;
   for await (const chunk of response.body) {

--- a/src/integrations/computer-use.js
+++ b/src/integrations/computer-use.js
@@ -401,8 +401,10 @@ export function registerComputerUseTools(registry, runtime, { fetchImpl = global
     }
   };
 
-  const invokeNodeAction = async (node, session, action, operation, payload = {}) => {
+  const invokeNodeAction = async (node, session, action, operation, payload = {}, signal) => {
+    signal?.throwIfAborted();
     const lease = await ensureNodeLease(node, session);
+    signal?.throwIfAborted();
     if (lease.inFlightSequence != null) {
       throw new Error("another computer-use action is already in progress");
     }
@@ -452,6 +454,23 @@ export function registerComputerUseTools(registry, runtime, { fetchImpl = global
       ? runtime.computerUseLog.getSession(sessionOrId)
       : sessionOrId;
     return await abortSession(session, reason, "aborted");
+  };
+
+  const invokeCancellableNodeAction = async (node, session, action, operation, payload, signal) => {
+    // G2's streaming request already carries this signal through AgentHost.
+    // Aborting a provider stream alone does not stop a dispatched desktop tool.
+    const stop = () => {
+      void abortSession(session, "source request cancelled; renew computer-use approval").catch(() => {});
+    };
+    if (signal?.aborted) { stop(); signal.throwIfAborted(); }
+    signal?.addEventListener("abort", stop, { once: true });
+    try {
+      const result = await invokeNodeAction(node, session, action, operation, payload, signal);
+      signal?.throwIfAborted();
+      return result;
+    } finally {
+      signal?.removeEventListener("abort", stop);
+    }
   };
 
   registry.register({
@@ -657,7 +676,7 @@ export function registerComputerUseTools(registry, runtime, { fetchImpl = global
       const node = computerNode(runtime, session);
       if (node) {
         try {
-          const shot = await invokeNodeAction(node, session, action, "screenshot", {});
+          const shot = await invokeCancellableNodeAction(node, session, action, "screenshot", {}, context.signal);
           runtime.computerUseLog.markActionResult(action.id, {
             status: "executed",
             result: { width: shot.width, height: shot.height, bytes: shot.bytes }
@@ -742,7 +761,7 @@ export function registerComputerUseTools(registry, runtime, { fetchImpl = global
           throw new Error(EXECUTION_UNAVAILABLE);
         }
         try {
-          const nodeResult = await invokeNodeAction(node, session, action, nodePath, payloadOf(actionArgs));
+          const nodeResult = await invokeCancellableNodeAction(node, session, action, nodePath, payloadOf(actionArgs), context.signal);
           if (runtime.computerUseLog.getSession(session.id)?.status !== "active") {
             runtime.computerUseLog.markActionResult(action.id, { status: "aborted", error: "session-stopped" });
             throw Object.assign(new Error("computer-use session was stopped before the action result was accepted"), {

--- a/src/integrations/ocu-release.js
+++ b/src/integrations/ocu-release.js
@@ -1,0 +1,11 @@
+// Reviewed upstream release. Installer and compatibility tests share this pin;
+// upgrades are explicit source changes, never a runtime `latest` lookup.
+export const OCU_RELEASE = Object.freeze({
+  version: "0.3.3",
+  repository: "https://github.com/iFurySt/open-codex-computer-use",
+  archive: "https://registry.npmjs.org/open-computer-use/-/open-computer-use-0.3.3.tgz",
+  integrity: "A4xCoXgu+Mwi2OdhL15FHY/VcnhhxIJwRgSmC2LwX9mTya85VO2NZN8PNholvgQeTeOlPpej+eEucHXtPhhVrA==",
+  license: "MIT"
+});
+
+export const OCU_VERSION = OCU_RELEASE.version;

--- a/src/integrations/ocu-transport.js
+++ b/src/integrations/ocu-transport.js
@@ -1,4 +1,22 @@
-import { spawn } from "node:child_process";
+import { spawn, execFile } from "node:child_process";
+
+function engineEnvironment() {
+  const env = Object.fromEntries(["HOME", "USER", "PATH", "LANG", "TMPDIR"]
+    .filter(key => process.env[key] !== undefined).map(key => [key, process.env[key]]));
+  env.OPEN_COMPUTER_USE_ALLOW_GLOBAL_POINTER_FALLBACKS = "0";
+  env.OPEN_COMPUTER_USE_DISABLE_APP_AGENT_PROXY = "1";
+  return env;
+}
+
+export function readOcuPermissions(command, run = execFile) {
+  return new Promise((resolve, reject) => {
+    run(command, ["doctor"], { env: engineEnvironment(), timeout: 3000,
+      maxBuffer: 16 * 1024, killSignal: "SIGKILL", encoding: "utf8" }, (error, stdout) => {
+      if (error) reject(new Error("Open Computer Use permission probe failed."));
+      else resolve(stdout);
+    });
+  });
+}
 
 // A private stdio connection, not an unrestricted MCP registration. No tool
 // arguments, screenshots, stderr, or provider credentials enter daemon logs.
@@ -14,14 +32,16 @@ export class OcuTransport {
   async connect(signal) {
     if (this.proc) return;
     signal?.throwIfAborted();
-    const env = Object.fromEntries(["HOME", "USER", "PATH", "LANG", "TMPDIR"]
-      .filter(key => process.env[key] !== undefined).map(key => [key, process.env[key]]));
-    env.OPEN_COMPUTER_USE_ALLOW_GLOBAL_POINTER_FALLBACKS = "0";
+    // v0.3.3 otherwise proxies even the native executable to a shared,
+    // LaunchServices-owned app agent. Killing that proxy does NOT cancel the
+    // app agent's input. Own the actual dispatcher and its snapshot cache.
+    const env = engineEnvironment();
     const child = this.spawn(this.command, ["mcp"], { stdio: ["pipe", "pipe", "pipe"], env });
     this.proc = child;
     child.stderr.resume();
     child.stdout.setEncoding("utf8");
     child.stdout.on("data", chunk => {
+      if (this.proc !== child) return;
       this.buffer += chunk;
       if (Buffer.byteLength(this.buffer) > 16 * 1024 * 1024) return this.close();
       let end;
@@ -39,9 +59,9 @@ export class OcuTransport {
         else pending.resolve(value.result);
       }
     });
-    child.on("error", () => this.close());
+    child.on("error", () => { if (this.proc === child) this.close(); });
     child.on("exit", () => { if (this.proc === child) this.close(); });
-    child.stdin.on("error", () => this.close());
+    child.stdin.on("error", () => { if (this.proc === child) this.close(); });
     const result = await this.request("initialize", { protocolVersion: "2024-11-05", capabilities: {},
       clientInfo: { name: "openagi-computer-node", version: "1" } }, signal);
     if (!result?.serverInfo) { this.close(); throw new Error("Invalid Open Computer Use initialization."); }

--- a/src/integrations/open-computer-use-executor.js
+++ b/src/integrations/open-computer-use-executor.js
@@ -1,9 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { createComputerExecutor, runComputerHelper } from "./computer-server.js";
-import { OcuTransport } from "./ocu-transport.js";
+import { OcuTransport, readOcuPermissions } from "./ocu-transport.js";
+import { OCU_VERSION } from "./ocu-release.js";
 
-export const OCU_VERSION = "0.3.3";
+export { OCU_VERSION };
 const OPERATIONS = ["list_apps", "activate_app", "click", "click_element", "drag", "move", "type", "key", "scroll", "set_value", "scroll_element"];
 const sameFocus = (a, b) => ["windowID", "processIdentifier", "bundleIdentifier", "title", "x", "y", "width", "height"].every(key => a?.[key] === b?.[key]);
 
@@ -11,6 +12,7 @@ const sameFocus = (a, b) => ["windowID", "processIdentifier", "bundleIdentifier"
 // privacy/focus gate and handles operations absent from upstream 0.3.3.
 export function createOpenComputerUseExecutor({ binaryPath, helperPath = process.env.OPENAGI_COMPUTER_HELPER,
   helperRun = runComputerHelper, transportFactory = () => new OcuTransport(binaryPath),
+  permissionProbe = async () => parseOcuPermissions(await readOcuPermissions(binaryPath)),
   binaryReady = file => { try { fs.accessSync(file, fs.constants.X_OK); return path.isAbsolute(file); } catch { return false; } },
   ...options } = {}) {
   let transport = null, snapshot = null, activeFrame = null, busy = false;
@@ -27,9 +29,18 @@ export function createOpenComputerUseExecutor({ binaryPath, helperPath = process
       if (!binaryReady(binaryPath) || !helperPath) return { operations: [], inputReady: false, screenshotReady: false,
         detail: "Install Open Computer Use 0.3.3 and configure the signed OpenAGI privacy helper." };
       try {
-        const status = JSON.parse(String((await native("status", null, { timeoutMs: 3000 })).stdout));
-        return { ...status, operations: OPERATIONS, detail: "Experimental Open Computer Use 0.3.3; upstream permissions are verified on use. Native privacy and lease checks remain enforced." };
-      } catch { return { operations: [], inputReady: false, screenshotReady: false, detail: "OpenAGI privacy/permission checks are unavailable." }; }
+        const [permissions, result] = await Promise.all([
+          permissionProbe(), native("status", null, { timeoutMs: 3000 })
+        ]);
+        const status = JSON.parse(String(result.stdout));
+        if (!permissions.accessibility || !permissions.screenRecording) return {
+          operations: [], inputReady: false, screenshotReady: false, capturePrerequisitesReady: false,
+          detail: "Open Computer Use needs Accessibility and Screen Recording permission on this Mac. Pairing is unchanged."
+        };
+        return { ...status, operations: OPERATIONS, detail: status.inputReady && status.screenshotReady
+          ? `Experimental Open Computer Use ${OCU_VERSION}; isolated engine process. Physical input safety acceptance is still required.`
+          : status.detail || "Focus an allowed window on the unlocked target Mac, then take a fresh screenshot." };
+      } catch { return { operations: [], inputReady: false, screenshotReady: false, detail: "OpenAGI or Open Computer Use permission checks are unavailable. Check both helpers on the target Mac." }; }
     },
     screenshot: async (_run, _geometry, { signal }) => {
       reset();
@@ -82,7 +93,7 @@ export function createOpenComputerUseExecutor({ binaryPath, helperPath = process
 export function parseOcuState(result, focus) {
   const text = result.content.filter(item => item.type === "text").map(item => item.text).join("\n");
   if (!text.startsWith(`App=${focus.bundleIdentifier} (pid ${focus.processIdentifier})\n`)
-    || !text.includes(`Window: ${JSON.stringify(focus.title)},`)) throw new Error("Upstream did not capture the approved app/window.");
+    || !text.split("\n")[1]?.startsWith(`Window: ${JSON.stringify(focus.title)}, App: `)) throw new Error("Upstream did not capture the approved app/window.");
   const image = result.content.find(item => item.type === "image" && item.mimeType === "image/png");
   if (!image || typeof image.data !== "string" || image.data.length > 12 * 1024 * 1024) throw new Error("Upstream did not return a bounded PNG screenshot.");
   const png = Buffer.from(image.data, "base64");
@@ -99,6 +110,12 @@ export function parseOcuState(result, focus) {
   });
   if (Buffer.byteLength(accessibility) > 96 * 1024) throw new Error("Upstream tree limit exceeded.");
   return { base64: image.data, width, height, bytes: png.length, accessibility, elements };
+}
+
+export function parseOcuPermissions(output) {
+  // Do not interpret arbitrary permission-related text as a successful grant.
+  const match = /^Permissions: accessibility=(granted|missing), screenRecording=(granted|missing)$/m.exec(output.trim());
+  return { accessibility: match?.[1] === "granted", screenRecording: match?.[2] === "granted" };
 }
 
 export function ocuAction(operation, payload) {

--- a/test/computer-use-request-cancel.test.js
+++ b/test/computer-use-request-cancel.test.js
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ToolRegistry } from "../src/tool-registry.js";
+import { ComputerUseLog } from "../src/computer-use-log.js";
+import { registerComputerUseTools } from "../src/integrations/computer-use.js";
+
+for (const cancelDuring of ["session.start", "type", "screenshot"]) {
+  test(`G2 request cancellation during ${cancelDuring} revokes only its approved desktop session`, async t => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-g2-control-stop-"));
+    t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+    const tools = new ToolRegistry();
+    const log = new ComputerUseLog({ dir });
+    const session = log.startSession({ goal: "Test scratch document", approvedBy: "user",
+      sourceSessionId: "node:test-g2:conversation:main", targetNodeId: "mac-target", capability: "computer-use" });
+    const other = log.startSession({ goal: "Other task", approvedBy: "user",
+      sourceSessionId: "chat:other", targetNodeId: "mac-other", capability: "computer-use" });
+    const calls = [], cancelled = [];
+    let reached, finish;
+    const started = new Promise(resolve => { reached = resolve; });
+    const pending = new Promise(resolve => { finish = resolve; });
+    const record = { nodeId: "mac-target", name: "Target Mac", local: true,
+      capabilities: [{ id: "computer-use", ready: true,
+        operations: ["session.start", "session.end", "screenshot", "click", "move", "type", "key", "scroll"] }] };
+    const runtime = { tools, computerUseLog: log, observations: { search: async () => [] },
+      nodeCapabilities: {
+        resolve: (_cap, selector = {}) => !selector.nodeId || selector.nodeId === record.nodeId ? record : null,
+        list: () => [record], refresh: async () => [record],
+        cancelSession: id => { cancelled.push(id); finish(); },
+        dispatch: async (node, _cap, operation) => {
+          calls.push({ node, operation });
+          if (operation === cancelDuring) { reached(); await pending; }
+          if (operation === "session.start") return { leaseId: "test-lease", nextSequence: 1 };
+          return { ok: true, frameId: "test-frame", width: 100, height: 100, bytes: 20 };
+        }
+      } };
+    registerComputerUseTools(tools, runtime);
+    const controller = new AbortController();
+    const context = { sessionId: session.sourceSessionId, channel: "g2", signal: controller.signal };
+    const work = tools.invoke(cancelDuring === "screenshot" ? "computer_screenshot" : "computer_type",
+      cancelDuring === "screenshot" ? {} : { text: "scratch", frameId: "test-frame" }, context);
+    await Promise.race([started, work.then(() => { throw new Error("tool ended before dispatch"); })]);
+    controller.abort();
+    const result = await work;
+    assert.equal(result.ok, false, "late node success is not accepted after cancellation");
+    assert.equal(log.getSession(session.id).status, "aborted");
+    assert.equal(log.getSession(other.id).status, "active");
+    assert.ok(cancelled.includes(session.id));
+    assert.ok(cancelled.every(id => id === session.id));
+    assert.ok(calls.every(call => call.node === "mac-target"));
+    assert.ok(calls.some(call => call.operation === "session.end"));
+    if (cancelDuring === "session.start") assert.equal(calls.some(call => call.operation === "type"), false);
+  });
+}

--- a/test/ocu-transport.test.js
+++ b/test/ocu-transport.test.js
@@ -2,7 +2,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import { PassThrough, Writable } from "node:stream";
-import { OcuTransport } from "../src/integrations/ocu-transport.js";
+import { OcuTransport, readOcuPermissions } from "../src/integrations/ocu-transport.js";
+import { OCU_RELEASE } from "../src/integrations/ocu-release.js";
 
 function fixture({ hang = false, malformed = false, refused = false, responseLine } = {}) {
   const child = new EventEmitter(); let killed = false, spawnArgs, requests = [];
@@ -28,6 +29,7 @@ test("private MCP uses stdin and does not inherit provider keys or global pointe
   await f.client.call("type_text", { app: "org.test", text: "fixture private text" });
   assert.deepEqual(f.spawnArgs[1], ["mcp"]);
   assert.equal(f.spawnArgs[2].env.OPEN_COMPUTER_USE_ALLOW_GLOBAL_POINTER_FALLBACKS, "0");
+  assert.equal(f.spawnArgs[2].env.OPEN_COMPUTER_USE_DISABLE_APP_AGENT_PROXY, "1");
   assert.equal(f.spawnArgs[2].env.OPENAI_API_KEY, undefined);
   assert.equal(f.requests.find(r => r.method === "tools/call").params.arguments.text, "fixture private text");
 });
@@ -58,4 +60,47 @@ test("valid JSON that is not an RPC object cannot crash the daemon", async () =>
     await assert.rejects(() => f.client.call("get_app_state", {}), /unconfirmed/);
     assert.equal(f.killed, true);
   }
+});
+
+test("reviewed release pin is exact and version-consistent", () => {
+  assert.match(OCU_RELEASE.version, /^\d+\.\d+\.\d+$/);
+  assert.equal(OCU_RELEASE.archive, `https://registry.npmjs.org/open-computer-use/-/open-computer-use-${OCU_RELEASE.version}.tgz`);
+  assert.equal(Buffer.from(OCU_RELEASE.integrity, "base64").length, 64);
+  assert.equal(OCU_RELEASE.license, "MIT");
+});
+
+test("permission probes isolate credentials and bound process lifetime too", async () => {
+  const output = await readOcuPermissions("/native/OpenComputerUse", (_file, args, options, callback) => {
+    assert.deepEqual(args, ["doctor"]);
+    assert.equal(options.env.OPEN_COMPUTER_USE_DISABLE_APP_AGENT_PROXY, "1");
+    assert.equal(options.env.OPENAI_API_KEY, undefined);
+    assert.equal(options.timeout, 3000);
+    assert.equal(options.maxBuffer, 16 * 1024);
+    callback(null, "Permissions: accessibility=granted, screenRecording=granted");
+  });
+  assert.match(output, /^Permissions:/);
+  await assert.rejects(readOcuPermissions("/native/OpenComputerUse", (_file, _args, _options, callback) => {
+    callback(new Error("sensitive provider output"));
+  }), error => error.message === "Open Computer Use permission probe failed.");
+});
+
+test("late output from a killed dispatcher cannot close its replacement", async t => {
+  const children = [];
+  const client = new OcuTransport("/native/OpenComputerUse", { spawnImpl: () => {
+    const f = fixture();
+    // Reuse the mock child's protocol implementation, but let this transport
+    // own it. The fixture never connects or starts timers of its own.
+    const child = f.client.spawn();
+    children.push(child);
+    return child;
+  } });
+  t.after(() => client.close());
+  await client.connect();
+  client.close();
+  await client.connect();
+  children[0].stdout.write("not json\n");
+  children[0].emit("error", new Error("late process error"));
+  children[0].stdin.emit("error", new Error("late pipe error"));
+  assert.equal(client.proc, children[1]);
+  await client.call("get_app_state", {});
 });

--- a/test/open-computer-use.test.js
+++ b/test/open-computer-use.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createOpenComputerUseExecutor, parseOcuState, ocuAction } from "../src/integrations/open-computer-use-executor.js";
+import { createOpenComputerUseExecutor, parseOcuState, ocuAction, parseOcuPermissions } from "../src/integrations/open-computer-use-executor.js";
 import { createConfiguredComputerExecutor } from "../src/integrations/cua-computer-executor.js";
 import { verifyOcuArchive } from "../scripts/install-open-computer-use.mjs";
 
@@ -10,6 +10,7 @@ const state = () => ({ isError: false, content: [{ type: "text", text: 'App=org.
 function fixture() {
   const calls = []; let current = { ...focus };
   const executor = createOpenComputerUseExecutor({ binaryPath: "/test/engine", helperPath: "/test/helper", binaryReady: () => true,
+    permissionProbe: async () => ({ accessibility: true, screenRecording: true }),
     transportFactory: () => ({ close() {}, async call(name, args) { calls.push({ name, args }); return name === "get_app_state" ? state() : { isError: false, content: [] }; } }),
     helperRun: async (_path, op, payload) => {
       calls.push({ native: op, payload });
@@ -27,6 +28,26 @@ test("upstream state binds exact app and remaps sparse element IDs", () => {
   assert.throws(() => parseOcuState(state(), { ...focus, processIdentifier: 44 }), /approved app/);
   const invalid = state(); invalid.content.pop();
   assert.throws(() => parseOcuState(invalid, focus), /PNG/);
+  const spoofed = state();
+  spoofed.content[0].text = 'App=org.test.editor (pid 42)\nWindow: "Private", App: Editor.\n0 text Window: "Test", App: Editor.';
+  assert.throws(() => parseOcuState(spoofed, focus), /approved app/);
+});
+
+test("permission readiness is fail closed, including unrecognized doctor output", async t => {
+  assert.deepEqual(parseOcuPermissions("Permissions: accessibility=granted, screenRecording=granted\n"),
+    { accessibility: true, screenRecording: true });
+  for (const output of ["", "grant accessibility and screenRecording", "Permissions: accessibility=denied, screenRecording=granted"]) {
+    assert.equal(parseOcuPermissions(output).accessibility, false);
+  }
+  const e = createOpenComputerUseExecutor({ binaryPath: "/test/engine", helperPath: "/test/helper", binaryReady: () => true,
+    permissionProbe: async () => ({ accessibility: false, screenRecording: true }),
+    helperRun: async () => ({ stdout: JSON.stringify({ inputReady: true, screenshotReady: true, capturePrerequisitesReady: true }) }) });
+  t.after(() => e.close());
+  const health = await e.health();
+  assert.equal(health.capability.ready, false);
+  assert.equal(health.capability.inputReady, false);
+  assert.equal(health.capability.capturePrerequisitesReady, false);
+  assert.match(health.capability.detail, /Pairing is unchanged/);
 });
 test("leases, fresh frames, upstream pixels, and captured element IDs remain bound", async t => {
   const { executor: e, calls } = fixture(); t.after(() => e.close());


### PR DESCRIPTION
## Changes
- Disable the upstream LaunchServices app-agent proxy so OpenAGI owns the actual dispatcher and snapshot cache, with private stdin and no provider credentials inherited.
- Carry G2 request cancellation through computer tools into consent revocation and the original target node, including cancellation during lease creation. Reject late success.
- Check upstream permissions as well as native privacy readiness; tighten the window-header check.
- Centralize the pinned MIT-licensed v0.3.3 archive and digest and add a path-filtered compatibility workflow. No automatic updates or fork.

## Validation
51 distinct focused tests passed across the verification runs. A real local adapter smoke test activated a newly-created blank TextEdit document, captured it through both focus gates, typed a harmless marker, and independently verified the text. Existing documents were preserved. Main approval and physical G2 end-to-end testing remain separate acceptance gates.

## Production boundary
This PR does not switch the default, retire native input, deploy services, or release a G2 bundle. Upstream v0.3.3 does not accept the expected OpenAGI window identity or enforce its privacy and secure-field policy at physical dispatch. That architectural guard must be resolved before production-default promotion; an external precheck and one successful desktop edit are not sufficient. The physical acceptance checklist is recorded in docs/verification/2026-09-06-ocu-g2-hardening.md.