### PR TITLE
Fix release compiler timeout in Quick Ask resize watchers

### DIFF
--- a/mac/Sources/OpenAGI/Overlay/OverlayView.swift
+++ b/mac/Sources/OpenAGI/Overlay/OverlayView.swift
@@ -19,13 +19,11 @@ struct OverlayView: View {
   var onExpand: () -> Void = {}
   var onContentChange: () -> Void = {}
 
-  // The resize watchers are applied in two chunks rather than one chain because
-  // the whole thing — the Group's ViewBuilder plus fifteen generic .onChange
-  // overloads — stopped type-checking in reasonable time as a single expression.
-  // Splitting it is purely a compile-time concern; the modifier order, and so
-  // the behaviour, is identical to writing them end to end.
+  // Keep the resize watcher chains short: the release compiler times out on
+  // a single chain of sixteen generic .onChange overloads. Opaque helper
+  // boundaries preserve modifier order without changing view identity/state.
   var body: some View {
-    briefWatchers(panelWatchers(panelBody))
+    briefWatchers(approvalWatchers(applicationWatchers(composerWatchers(panelWatchers(panelBody)))))
   }
 
   private var panelBody: some View {
@@ -62,6 +60,10 @@ struct OverlayView: View {
     .onChange(of: state.answer) { _, _ in onContentChange() }
     .onChange(of: state.isLoading) { _, _ in onContentChange() }
     .onChange(of: state.progressStage) { _, _ in onContentChange() }
+  }
+
+  private func composerWatchers<V: View>(_ content: V) -> some View {
+    content
     .onChange(of: state.error) { _, _ in onContentChange() }
     .onChange(of: state.contextNote) { _, _ in onContentChange() }
     .onChange(of: state.briefContext) { _, _ in onContentChange() }
@@ -69,6 +71,10 @@ struct OverlayView: View {
       fieldFocused = true
       onContentChange()
     }
+  }
+
+  private func applicationWatchers<V: View>(_ content: V) -> some View {
+    content
     .onChange(of: app.status) { _, _ in onContentChange() }
     // Swaps the answer footer's button between "Continue in chat" and the
     // shorter "Open chat". Same single row at the default text size, but that
@@ -81,6 +87,10 @@ struct OverlayView: View {
     // the count holds while the rows — and the panel's height — change. Equatable.
     .onChange(of: outreach.items) { _, _ in onContentChange() }
     .onChange(of: approvals.items) { _, _ in onContentChange() }
+  }
+
+  private func approvalWatchers<V: View>(_ content: V) -> some View {
+    content
     .onChange(of: approvals.inFlight) { _, _ in onContentChange() }
     .onChange(of: approvals.lastOutcome) { _, _ in onContentChange() }
     .onChange(of: approvals.lastError) { _, _ in onContentChange() }


### PR DESCRIPTION
The signed build of main at 58d1a56 failed at OverlayView.swift:48: the compiler could not type-check the sixteen-modifier panelWatchers expression in reasonable time. Split it into four opaque helper boundaries, retaining every watcher, modifier order, state binding, and callback. This is a build unblock for deploying the merged G2/OCU hardening, not a G2 bundle change.

Validation: 19 focused overlay continuation/approval tests pass. Native compile and notarization must pass the branch build before merge.