### PR TITLE
G2 0.4.18: focused onboarding and recoverable conversations

### DIFF
--- a/.github/workflows/g2-experience.yml
+++ b/.github/workflows/g2-experience.yml
@@ -1,0 +1,31 @@
+name: G2 experience
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'integration-clients/even-g2-overlay/**'
+      - '.github/workflows/g2-experience.yml'
+      - 'package*.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.21.1'
+      - run: npm install --global pnpm@10.24.0
+      - run: npm ci --ignore-scripts
+      - run: npm test
+      - run: pnpm install --frozen-lockfile
+        working-directory: integration-clients/even-g2-overlay
+      - run: pnpm run typecheck && pnpm run lint && pnpm run test && pnpm run package:agents && pnpm run check:bundle && pnpm run check:secrets
+        working-directory: integration-clients/even-g2-overlay

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@
 .openagi/*
 !.openagi/mcp.json.example
 node_modules/
+integration-clients/even-g2-overlay/node_modules
+integration-clients/even-g2-overlay/dist/
+integration-clients/even-g2-overlay/out.ehpk
+integration-clients/even-g2-overlay/coverage/
 npm-debug.log*
 .DS_Store
 logs/

--- a/docs/scopes/2026-09-12-g2-experience-redesign.md
+++ b/docs/scopes/2026-09-12-g2-experience-redesign.md
@@ -1,6 +1,6 @@
 # OpenAGI + G2: a simpler, dependable everyday experience
 
-Date: 2026-09-12. Status: proposed product and engineering scope, not implemented.
+Date: 2026-09-12. Status: full product and engineering scope. A bounded, reversible 0.4.18 candidate is implemented; see [candidate verification](../verification/2026-09-12-g2-experience.md) for delivered scope, exclusions and outstanding physical acceptance. The source audit below describes the pre-redesign baseline.
 
 ## Recommendation
 

--- a/docs/scopes/2026-09-12-g2-experience-redesign.md
+++ b/docs/scopes/2026-09-12-g2-experience-redesign.md
@@ -1,0 +1,213 @@
+# OpenAGI + G2: a simpler, dependable everyday experience
+
+Date: 2026-09-12. Status: proposed product and engineering scope, not implemented.
+
+## Recommendation
+
+Keep the existing OpenAGI architecture and safety boundaries. Redesign the first-run journey, information hierarchy, and interaction states as one experience across computer, phone, and glasses. The product should make three things immediately clear: what it is doing, where the result lives, and what the user can do next.
+
+The glasses are a quiet conversation surface. The phone handles setup, browsing, and detailed controls. The main owns conversations, memory, execution, and policy; connected computers provide explicitly authorized capabilities. OpenAI is one model provider, not a second name for OpenAGI.
+
+This pass inspected the reviewed G2 0.4.17 source at `2507228b8d41e4fa7e89513300bcb0850010b12f` in `/Users/shooby/Dev/openagi-pr101-rollout`, its main-side integration and desktop setup, and the locally available public coding-setup branch at `1f3acce6cad766b45d21cf18707360b2efb3c030`. It did not inspect the currently installed phone/glasses UI, measure latency, recheck GitHub CI, change runtime configuration, or submit anything. Historical scope documents are context, not proof of the current implementation. Existing unrelated work is untouched.
+
+## 1. What the current source tells us
+
+| Area | Evidence | Consequence for the scope |
+| --- | --- | --- |
+| First launch | [Phone pairing form](/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/src/ui/openagi-phone-companion.ts:54) starts with an HTTPS main URL and pairing code; token connection is already under an advanced disclosure. | Keep the scoped exchange, but add guided setup and connection transfer. A new user should not have to understand a main versus a node before seeing help. |
+| Everyday phone UI | [Companion controls](/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/src/ui/openagi-phone-companion.ts:71) combine Listen/Lifelog/Inbox/Recent, global navigation buttons, retention, providers, transport, and listening options. | Separate primary actions from settings; remove overlapping Listen/Lifelog controls. Existing tabs and bounded lists are useful, so do not rebuild them as if absent. |
+| Contradictory instructions | [Settings copy](/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/src/ui/openagi-phone-companion.ts:105) still says double-tap pauses; [root routing](/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/src/app/openagi-g2-app.ts:491) requests the native exit dialog. | Generate gesture help from the same interaction contract as the handlers. Root exit is a non-negotiable reviewer requirement. |
+| First-run OpenAGI | [Setup wizard](/Users/shooby/Dev/openagi-pr101-rollout/src/setup-wizard.js:203) presents eight sections and technical credentials; a useful early Save option already exists. | Turn the minimum setup into the main journey; optional channels, tools, observation, and automation come after the first successful interaction. |
+| Speech expectations | [Preferences](/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/src/openagi/store.ts:20) default to buffered OpenAI; live Deepgram and relay/direct options exist. | Identify supported, configured speech modes before presenting live transcription. A model-provider name does not establish streaming capability. |
+| Recovery | [G2 ask route](/Users/shooby/Dev/openagi-pr101-rollout/src/hosted-interface.js:1565) accepts audio/text and conversation ID, but no client request key; disconnect aborts that stream. Client recovery preserves text but can report uncertain delivery. | Keep the recent recovery fixes and add a durable request receipt/resume contract. Reconnecting must not mean sending the question again. |
+| History | [Main session routing](/Users/shooby/Dev/openagi-pr101-rollout/src/integrations/g2-channel.js:142) uses stable node-scoped sessions; [phone history](/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/src/openagi/store.ts:25) stores only 30 answer entries. | Main-owned history already exists. Build scoped retrieval and explicit handoff, not another independent history system. |
+| Lifelog | [Companion persistence](/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/src/openagi/proactive.ts:131) batches final text; [owner page](/Users/shooby/Dev/openagi-pr101-rollout/src/lifelog-page.js:1) offers moments, analysis, corrections, and follow-ups. | Surface these existing features through a coherent History view and explicit save states. Capture, saving, and analysis are different states. |
+| Computer capabilities | [Coding setup](/Users/shooby/Dev/openagi-pr101-rollout/src/coding-supervisor-ui.js:91) and [readiness guide](/Users/shooby/Dev/openagi-pr101-rollout/docs/setup/computer-use-readiness.md:1) distinguish setup, reachability, and permission. | Add capability-specific setup cards on the selected computer. A connected Mac does not imply every local session is readable or controllable. Preserve the public-setup branch's recoverability improvements. |
+| Maintenance | [App controller](/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/src/app/openagi-g2-app.ts:32) coordinates many independent flags; [phone rendering](/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/src/ui/openagi-phone-companion.ts:227) infers button behavior from status text. | Introduce typed state/view models incrementally; do not make English copy part of the control API. |
+| Documentation/build identity | [Setup guide](/Users/shooby/Dev/openagi-pr101-rollout/docs/setup/even-g2.md:12) says ten-minute codes while [implementation](/Users/shooby/Dev/openagi-pr101-rollout/src/node-enrollment.js:3) uses thirty; [package generation](/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/scripts/package-openagi.mjs:25) defines 0.4.17 separately from package.json. | Consolidate current instructions and release metadata. Keep historical changelogs clearly historical; make clean-checkout packaging reproducible without an undocumented local base. |
+
+## 2. One understandable product
+
+Recommended public name: **OpenAGI for G2**, subject to the existing store identity. Keep compatible third-party agent hosts as an advanced connection option. Do not rename package IDs or reset storage to achieve a branding change.
+
+Use these terms consistently:
+
+- **Home computer:** the machine hosting OpenAGI main. Show its actual user-selected name.
+- **Connected computers:** other authorized execution targets. Show the target for each action.
+- **Ask:** explicit conversation with the assistant.
+- **Lifelog:** opted-in background conversation capture while the platform permits recording, with retained final text.
+- **Inbox:** updates and items needing attention.
+- **History:** Chats and Lifelog, clearly labeled and searchable.
+
+Keep node IDs, bearer tokens, PCM, relay selection, provider permission tiers, and raw diagnostic messages in advanced settings or support details. Do not hide meaningful privacy or billing information.
+
+## 3. First-run and connection setup
+
+### Existing OpenAGI user
+
+`Add glasses on home computer → transfer connection → confirm computer → pair → test speech and one answer`
+
+1. Add **Connect glasses** to OpenAGI's visible first-run actions and Devices page, not only a technical Nodes screen.
+2. Show a short-lived connection QR/link plus a manual URL-and-code fallback. The transfer includes the exact HTTPS origin and single-use enrollment material, never an owner token or permanent provider key.
+3. Show the computer name, verified origin, and what access the glasses receive before confirming. Do not silently select a nearby machine or promote a node to main.
+4. Verify pairing, compatible main version, configured speech capability, and connection from the phone-hosted client. Distinguish main unavailable, TLS/network failure, expired code, revoked pairing, and missing speech configuration.
+5. Offer a brief microphone/gesture tutorial and a user-initiated test question. Show actual words and an answer, not merely a successful health check. State any provider usage before a paid test.
+
+QR scanning or deep-link entry into an Even-hosted app must be proven against the supported Even SDK/app. Do not assume the phone camera can open a particular plugin or prefill its fields. If that path is unavailable, ship an explicit paste-connection flow and keep manual URL/code entry. The goal is no manually typed host/token in the recommended path, not a false promise that a six-digit code can discover any private server on the Internet.
+
+### New OpenAGI user
+
+`Install OpenAGI on a computer → choose home/connect existing → configure assistant → secure phone access → connect glasses`
+
+- Offer **I already use OpenAGI**, **Set up on my computer**, and a clearly labeled, non-recording **Preview** with sample content. No-main preview is not a functioning standalone assistant.
+- A phone-first install gets a short computer setup link/QR with the next step preserved. It should not dead-end at an empty server URL field.
+- The computer setup asks whether this is a new home or a computer joining an existing home. Never create two mains by accident.
+- Validate the selected reasoning provider/account using supported authentication. Do not imply a ChatGPT subscription automatically supplies an OpenAI API key. Defer raw model IDs and advanced reasoning controls.
+- Offer a guided, explicitly authorized Tailscale/private HTTPS setup or an existing HTTPS server. Verify access from the phone, including cellular when remote use is requested. Do not expose the service publicly or weaken TLS as a shortcut.
+- Configure live speech only when wanted. Reuse a configured, tested live provider after disclosing where audio goes; otherwise offer setup or honestly labeled transcription-after-stop. Never silently switch providers.
+- Set a visible budget before paid background features. Introduce integrations, coding agents, and computer control after the first successful question.
+
+Returning users land in their existing conversation or saved Lifelog mode. Recoverable connectivity failure must not trigger onboarding, erase pairing, or require a fresh code. Replacement/revoked devices use a guided owner-approved repair flow.
+
+## 4. Phone information architecture
+
+Use three primary destinations and a Settings button:
+
+| Destination | Primary content | Keep out of the primary view |
+| --- | --- | --- |
+| Talk | One Talk/Stop action, current conversation, live words during an explicit question, current request state, Ask only/Lifelog mode selector | Provider transport, token fields, global page-navigation buttons, long lifecycle explanations |
+| Inbox | Needs your attention / Updates; bounded items with source and relevant actions | Raw logs, unrelated transcript-retention settings, an unbounded task wall |
+| History | Chats / Lifelog filter, search, date, recent conversation cards, exact conversation continuation | Repeated setup panels or settings above the history |
+| Settings | Connection/devices, speech, talk gestures, privacy, notifications, spending, diagnostics | Daily-use actions that require hunting through settings |
+
+Talk layout, as a hierarchy rather than a final visual design:
+
+```text
+OpenAGI                              Settings
+Connected to [home computer]
+
+[ Ask only | Lifelog ]
+
+Current conversation / recording / answer
+[ One primary action for this state ]
+
+Talk                 Inbox             History
+```
+
+Keep a compact connection indicator; remove the permanently dominant status card. Details expand only when useful. Avoid showing New conversation, Last answer, Next page, Previous page, Disconnect, and Exit as peer controls on every tab.
+
+Visual system: system typography, neutral surfaces, one accent for the primary action, consistent 8/16/24 spacing, at least 44 CSS-pixel phone targets, visible focus, accessible labels and contrast, system light/dark support, reduced motion, safe-area handling, and layout that survives larger text and narrow screens. Prefer one main scroll surface per destination. Replace browser prompt dialogs in the richer lifelog flows with accessible in-context forms.
+
+## 5. Glasses interaction contract
+
+Preserve Even's root-page exit convention. Do not reassign root double-tap to pause, sleep, or marking a moment.
+
+| Context | Tap | Swipe | Double-tap |
+| --- | --- | --- | --- |
+| Ask home | Start question | Up: Inbox; down: Recent, even when either is empty | Native exit confirmation via `shutDownPageContainer(1)` |
+| Quiet Lifelog root | Start question in tap mode; no accidental Talk in verified hold mode | Up: Inbox; down: listening controls | Native exit confirmation |
+| Manual recording | Stop and send, or review if chosen | Do not navigate away unintentionally | Cancel recording without sending |
+| Transcript review | Send | Read transcript | Return to a draft/action choice; preserve text until explicit discard |
+| Request running | Toggle answer/activity | Read without moving the user's position | Explicit stop confirmation |
+| Answer | Follow-up in this conversation | Read pages | Back to the prior home/Lifelog state |
+| Lists/details | Open selected item/relevant actions | Browse items or detail pages consistently | Back one level |
+
+Hold-to-talk remains optional, with tap and phone equivalents. Enable it confidently only after the device tutorial verifies press and matching release events. No release event means cancel/recover, never auto-send. Do not assign hold both Talk and task completion in the same context.
+
+Quiet Lifelog shows the small upper-right recording dot, without standing instructional text. Preserve truthful capture indication when another screen is open. A brief, opted-in actionable notice can appear during idle, then return to the prior screen; never steal an answer's reading position or a draft's focus. Contextual help lives in controls/the phone, with short hints during first use.
+
+Answers begin with a concise, plain-text response sized for the display. Longer detail remains reachable; do not truncate or silently discard safety-critical content. Expose actual public stages and tool activity, such as **Checking Codex sessions**, not private chain-of-thought or invented progress. “Connected” is transport status, not evidence of ongoing work.
+
+Display blanking is not hardware sleep. Its wake behavior must remain compatible with root exit. Do not promise gesture or battery behavior based on SDK declarations alone.
+
+## 6. One Lifelog mode, with honest state
+
+Replace the constellation of Keep microphone listening, Quiet listening, Keep lifelog on, and retention controls with one primary Lifelog action and a compact setup sheet.
+
+- On first enable: explain audio destination, saved final text, retention, and participant consent. Analysis and proactive notifications remain separate explicit choices, not silently enabled consequences.
+- Persist the preference, but model actual capture separately: **Starting**, **Recording**, **Paused**, **Reconnecting**, **Consent needed**. Preserve the current four-hour consent limit; resuming never extends it.
+- User Pause stays paused until Resume. Turning Lifelog Off disables automatic resumption. A system interruption can resume only with the existing valid grant and permitted foreground/lifecycle conditions.
+- Distinguish **Listening**, **Saving**, **Saved on home computer**, and **Some text was not saved**. A visible dot is not a save receipt.
+- Put transcripts, marked moments, inferred actions, and daily summaries under History → Lifelog. Label unverified speakers and inferred commitments; make source excerpts easy to inspect.
+- An utterance such as “remind me to file taxes tomorrow” can produce **Reminder suggested**, with interpreted date/time and confirmation. Do not claim it is scheduled until main confirms the operation.
+- Make moment edits, export, retention, and deletion discoverable while keeping owner-only operations behind owner authentication. Accepted tasks and transcript deletion have different lifecycles.
+
+Phone-lock recording is a separate feasibility gate. Submission/developer mode, shorter packets, or changing a toggle cannot establish OS background entitlement. Keep the existing experimental path explicitly experimental and off by default unless real phone/Even/firmware combinations pass capture-and-save testing. If the host suspends capture, say so and resume honestly; any supported native companion/background solution would be a separate scoped dependency, not a promised UI fix.
+
+## 7. Request reliability and continuity
+
+Introduce a scoped, durable request contract shared by main and client:
+
+`Draft → Sending → Accepted → Working / Awaiting approval → Completed / Failed / Cancelled`
+
+**Delivery unknown** is a distinct recoverable state, not a normal failed draft.
+
+- Generate a client request key before submission. Main persists a receipt bound to node, conversation, payload, and request key. Repeated transport submissions return the same request rather than starting another turn.
+- Reconnect to request status/events using a cursor or snapshot. If acceptance was lost, query by the original key first. Do not automatically resend a possible tool action.
+- Keep explicit cancellation separate from losing the phone connection. Bound server work with existing deadlines/budgets; backgrounding must never start a new microphone or grant additional authority.
+- Preserve verified answer text, incomplete streamed answers, and review drafts. Existing PR #103 recovery behavior is a foundation, not missing work to redo.
+- Prefer brief reasons and one next action: **Connection lost — reconnecting to your answer**, **Question saved here — review and send**, **Speech setup needed — open settings**. Put technical codes and request IDs in diagnostics.
+- Keep manual-question draft persistence separate from ambient transcript retention. Any crash-surviving draft cache needs a bounded lifetime, clear disclosure, deletion rules, and storage-security review. No durable raw-audio backlog or replay is proposed.
+- Use main-owned scoped chat retrieval for full history. Return to the same conversation, selection, and reading position on glasses/phone/desktop. A local history write failure must not turn a completed request into “send again.”
+- Reuse desktop authentication where available. A device-scoped handoff can grant access only to its permitted conversation, with expiring, single-use exchange material; it must not convert a G2 token into owner privileges. Owner operations still require owner sign-in.
+
+Transport deduplication is not a blanket exactly-once guarantee for external tools. Interrupted side effects still need operation receipts, reconciliation, or explicit uncertainty before any retry.
+
+## 8. Proactivity, computer actions, and costs
+
+Make Inbox the place for **Needs approval**, **Needs a reply**, and **Finished**. Each card identifies source, computer/session, last update, and available action. Preserve filters, selection, read state, and quiet hours. Dismiss, complete a task, and approve a computer action are different operations.
+
+For Codex/Claude, provide a per-computer checklist: reachable, provider installed, signed in, chosen project folders, session inventory, and supported delivery route. Distinguish discovered/read-only sessions from managed/reply-capable sessions; missing or stopped sessions are not automatically “done.” Use a deliberately selected disposable session for the first end-to-end control test.
+
+For computer use, show the exact target and next permission needed. Retain authenticated routing, user approval, expiry, cancellation, privacy exclusions, audit logs, and stale-screenshot rejection. Scanning or onboarding never changes OS permissions or sends session messages by itself.
+
+Expose three different cost categories: assistant reasoning, speech transcription, and optional background analysis. Preserve the owner's chosen main model; recommend a supported low-cost model such as Luna for bounded background analysis, not for every role by default. Provider/CLI charges outside OpenAGI's ledger must be explicitly labeled. UI refreshes, unchanged watches, and readiness checks must not invoke a model. Do not turn on all connectors or recurring analysis during onboarding.
+
+## 9. Engineering cleanup that enables the UX
+
+1. Create typed connection, capture, request, and navigation states with explicit transitions and effects. Keep these separate instead of multiplying unrelated flags into a single giant mode enum.
+2. Derive phone labels, glasses hints, and allowed gestures from those states. Remove status-string parsing and conflicting handwritten legends. Preserve the existing tested SDK adapter.
+3. Add a versioned, scoped capability/readiness response: main role/name, protocol support, speech availability, history/resume support, and precise configuration blockers. Before authentication expose only the minimum required for safe connection, not private topology or credentials.
+4. Split companion views into setup, Talk, Inbox, History, and Settings modules with shared spacing, fields, status, and empty/error components. No framework replacement is required just to split these files.
+5. Keep main-owned canonical stores; add migrations and compatibility fallbacks rather than creating duplicate schedulers/history stores in the glasses client.
+6. Make the G2 build reproducible from committed, pinned source and lockfiles. Keep a deliberate shared boundary with the base G2 project, preserve unrelated BuildBetter functionality, and remove dependence on an undocumented local assembly. Record one source manifest, bundle version, minimum main capabilities, and artifact checksum.
+7. Consolidate current user documentation and capability-driven help. Archive historical behavior descriptions so old double-tap, expiry, and provider-key instructions do not read as current setup requirements.
+8. Add a local bounded diagnostic timeline: gesture, microphone-ready, first PCM, speech-ready, first text, stop, main acceptance, last progress, save receipt, terminal result, and lifecycle transition. Default logs exclude transcripts, audio, credentials, and tool payloads. Export is previewed and user-initiated, not automatic telemetry.
+
+## 10. Delivery order
+
+| Batch | Scope | Completion gate |
+| --- | --- | --- |
+| A — Trust foundation (P0) | Typed request/capture state, durable request receipts/resume, precise failures, capability handshake, preserve current exit/recovery fixes | Network/lifecycle fault tests show no duplicate turn and no false recording/saved state |
+| B — First successful use (P1) | Computer/phone setup, connection transfer feasibility, guided pairing/repair, provider readiness, first-question tutorial | Fresh installation completes without engineering help or raw owner-token entry on glasses |
+| C — Everyday experience (P1) | Three phone destinations, minimal glasses screens, unified Lifelog control, consistent gestures, shared history/handoff, contextual activity | Full ask/follow-up/history/Lifelog loop passes on actual glasses |
+| D — Proactive polish (P1/P2) | Clear coding/computer capability setup, evidence-linked inbox actions, moment review, cost controls, diagnostics | Explicit-action and quiet/cost tests plus targeted computer dry run |
+
+Treat these as dependent engineering slices, not a new public version for every slice. Ship compatible main changes first, then one coherent G2 candidate after integrated testing. Do not bump or relabel the existing 0.4.17 artifact during scoping. Pin a candidate for hardware feedback; batch fixes before the next candidate. Clean up modules as their behavior moves, not in a simultaneous full rewrite.
+
+## 11. Acceptance criteria and physical testing
+
+The following are proposed targets, not measured results:
+
+- With an already configured, reachable main, a first-time tester pairs and receives an answer within two minutes without help. Fresh computer setup has its own measurement excluding installer/provider-login waits; target five minutes of active setup effort.
+- At least four of five new testers can find Talk, Lifelog history, Pause, follow-up, and Exit without verbal instructions.
+- A recognized gesture gets visible feedback within 250 ms, excluding native double-tap disambiguation. On the agreed healthy live-speech test network, target p95 first interim text within 1.5 seconds of speech onset and Stop-to-main-acceptance within two seconds. Measure these stages separately from model/tool time.
+- No recorded draft/partial answer disappears solely because of navigation or a stream interruption. An uncertain delivery never causes an automatic duplicate action.
+- Fifty automated interruption/reopen state sequences preserve credentials and valid preferences; explicit Off, pause, revocation, expired consent, or changed main never silently starts recording.
+- Ten minutes of quiet foreground Lifelog shows only the recording indicator, except genuine errors or eligible notices. A marked phrase is verified in main's saved history. Longer endurance testing checks actual saved segments and resource use, not only a dot.
+- Eighty-item inbox fixtures remain browsable with swipes, preserve selection, and keep task completion separate from dismissal. New arrivals cannot change a pending action's target.
+- Root double-tap opens native exit; cancelling preserves the session. Child Back, hold/release cancellation, re-entry, and continued pairing all pass on the installed candidate.
+- Phone layouts pass narrow/wide widths, larger text, keyboard navigation and screen-reader checks; glasses text is readable, plain text, and not clipped while streaming or paging.
+- Revocation, scope isolation, permission expiry, stale screenshots, provider failure, denied microphone access, dropped final transcript, lost acceptance/result, budget refusal, and interrupted side effects are covered by focused tests.
+
+Physical test session with the user: pair a clean install; ask a 15-second question; make two follow-ups; browse old answers; try the optional hold gesture on the actual glasses/ring; cancel and dismiss the native exit dialog; record/mark a Lifelog phrase; interrupt Bluetooth/network and recover; verify saved text on main; then test phone lock and another foreground app separately. Use one disposable Codex/Claude session for an explicitly approved read/reply and one harmless, approved action on the selected Mac.
+
+Phone-lock acceptance must include a baseline phrase, a distinct phrase each minute while locked for five minutes, app switching, unlock, and verification of every expected phrase in main history. Repeat per supported phone OS, Even app version, and firmware. A failed run means that combination is not marketed as continuous background recording.
+
+Automated checks, CI, packaged artifact, installed build, device behavior, and store approval remain separate gates. Use remote build infrastructure for production builds; no heavy local build or live service is needed to finish this scope.
+
+## 12. Boundaries
+
+This is a source-backed scope, not a complete security audit or a pixel-accurate assessment of the installed app. Remaining feasibility decisions are Even connection-link/camera support, reliable hold/release delivery, and supported lock-screen behavior. Test those early; keep a viable manual/foreground path regardless.
+
+Not included: a hosted multi-tenant OpenAGI service, accounts/subscriptions, standalone on-glasses reasoning, recording without consent, unrestricted computer control, automatic outbound actions, a replacement transcription company, or a full redesign of unrelated OpenAGI subsystems. The next implementation should begin with the trust foundation and a small set of approved screen/state designs, not more settings.

--- a/docs/scopes/g2-next/contracts/g2-experience.md
+++ b/docs/scopes/g2-next/contracts/g2-experience.md
@@ -1,0 +1,15 @@
+# G2 experience protocol
+
+Add `POST /nodes/g2/experience`, requiring the existing G2-scoped bearer and optional matching node ID. It is not a public route. Authenticated token-only compatible agents use the same exact-route exception as current G2 endpoints.
+
+Operations:
+
+- `capabilities`: protocol version, configured (not paid-tested) speech modes, request recovery support, scoped history, and safe main name/role. No private topology, credentials or owner data.
+- `submit`: client request ID and the existing bounded ask payload. Validate and persist receipt before invoking the existing channel. Identical retries return the same receipt; changed payloads conflict. Audio is transient.
+- `get`: retrieve this node's request receipt. Never create work.
+- `cancel`: explicitly stop this node's request. Completed actions are not undone.
+- `history`: bounded public messages/conversations from this node's canonical sessions; validate provenance/namespace, never accept arbitrary owner session IDs.
+
+Recovery is bounded, not a claim of globally exactly-once external effects. Restart-interrupted work becomes unconfirmed and never automatically executes again. Revocation and expiry are enforced on reads and active work. Generic old hosts retain the existing API without new capability assumptions.
+
+Connection transfer: an explicit text card with format/version, exact HTTPS origin and six-digit expiring code. Parse strictly; reject credentials in URLs, unknown fields, oversized data and expired cards. Never execute a transfer automatically, change the main without confirmation, or carry an owner token.

--- a/docs/scopes/g2-next/data-model.md
+++ b/docs/scopes/g2-next/data-model.md
@@ -1,0 +1,8 @@
+# State and entities
+
+- Request receipt: node binding, client request key, payload hash, immutable conversation binding, created/expiry times, accepted/working/completed/failed/cancelled/unconfirmed state, bounded public stage/partial text, optional terminal result. No provider key, raw audio, tool arguments, or private reasoning.
+- Request identity includes an issuance timestamp and random UUID. Its fixed recovery lifetime prevents an expired/pruned request from becoming new work when replayed.
+- Navigation: Talk/Inbox/History/Settings plus History Chats/Lifelog filter; independent of microphone and request state.
+- Capture: persisted Lifelog preference, explicit user-pause flag, existing consent grant, and actual runtime capture state. Only the original consent validity authorizes resumption.
+- Conversation: canonical main-owned session. Scoped history returns only user/public assistant content and an opaque continuation discriminator bound to the requesting G2.
+- Interface preference: Simplified or Classic, independent of credentials and recording consent.

--- a/docs/scopes/g2-next/plan.md
+++ b/docs/scopes/g2-next/plan.md
@@ -1,0 +1,24 @@
+# Implementation plan
+
+## Technical context and safety gates
+
+Worktree: `/Users/shooby/Dev/openagi-pr101-rollout`, branch `codex/g2-experience-redesign`. Baseline: `08b80e194d3643ae1e9ca20a69c17d8560996648` (0.4.17 code plus approved scope).
+
+Use existing TypeScript/DOM/Vite/Even SDK client and Node hosted interface. No new frontend framework, model worker, database service, public auth bypass, or automatic provider selection. Project constitution/template files are absent at the inspected standard locations; this plan follows the existing architecture and supplied safety instructions. BuildBetter customer artifacts are not applicable: evidence is the user's G2 feedback and linked source scope.
+
+## Implementation
+
+1. Finish rollback checkpoint and design contracts before source changes.
+2. Add owner-only file-backed request receipts with injected temp-directory tests. Bound admission, lifetime, payload, response size, and execution; preserve an unconfirmed receipt after process interruption. Never persist audio or credentials.
+3. Add an exact G2-scoped endpoint for capabilities, requests and conversation history. Reuse existing route authentication/CORS gates. Old ask/listen endpoints are unchanged.
+4. Add capability-negotiated client request recovery. Save request identifiers before submission; reattach/read before offering another send. Explicit cancellation is separate from document visibility.
+5. Improve phone structure using a separable layout/view model and a Classic switch. Keep existing selectors/actions where possible to avoid rewriting stable audio/consent code.
+6. Add guided connection transfer and readiness, clearer Lifelog controls and history, typed primary-action state, draft-safe Back, and truthful public activity.
+7. Use a reproducible OpenAGI-only build entry with pinned shared adapter inputs, while retaining the existing generic/base integration. Package one 0.4.18 candidate.
+8. Verify focused tests locally; production build and package on BuildBot3 against committed source. Inspect/range-scan before a normal fast-forward push/PR. Leave physical acceptance unchecked.
+
+## Rollback
+
+The old source and artifact remain immutable. A user can choose Classic for a UI comparison without resetting storage. New APIs are additive; 0.4.17 stays a compatible rollback client. New data records live in a separate main data subdirectory and are not a migration of existing chat/credential stores. Reverting a source commit or reinstalling a client does not undo completed external actions.
+
+Record scope still incomplete, test failures, deployment and device gates honestly; do not mark the entire design delivered just because an interface compiles.

--- a/docs/scopes/g2-next/quickstart.md
+++ b/docs/scopes/g2-next/quickstart.md
@@ -1,0 +1,18 @@
+# Checkpoints and candidate testing
+
+No live service or installed glasses app has been changed.
+
+| Preserved work | Commit | Branch |
+| --- | --- | --- |
+| Original OpenAGI working-tree changes (68 files) | `a16ed63c3055842ad69743b3ac501bcb29d188f1` | `codex/checkpoint-g2-before-redesign-20260912` |
+| Existing G2 base source/review notes (4 paths) | `4408eb1fc545d0b43509b24a4f84f63d027c9fc4` | `codex/checkpoint-before-openagi-redesign-20260912` in the G2 repo |
+| Reviewed 0.4.17 plus approved scope | `08b80e194d3643ae1e9ca20a69c17d8560996648` | Parent of redesign implementation |
+
+The two historical working-tree checkpoints are local safety copies, not new verified releases. Ignored environment files, private runtime state, dependencies and generated artifacts were not staged.
+
+Preserved 0.4.17 artifact: `/Users/shooby/Downloads/OpenAGI-Agent-0.4.17-2507228.ehpk`.
+SHA-256: `374c0cff1c557d939cee29566e9bc34b4ae46caed842c51cf42885e0ef1e0e7b`.
+
+For source comparison, use `git diff 08b80e194d3643ae1e9ca20a69c17d8560996648..codex/g2-experience-redesign`. Create a separate worktree at that immutable commit if needed; never hard-reset a working checkout. Reinstallation of the retained client is a separate device operation requiring explicit user action/authorization.
+
+Candidate verification commands and artifact paths will be added to the implementation verification record. Any saved manual draft/request receipt has its own lifetime; source rollback does not revert server side effects or grant fresh recording consent.

--- a/docs/scopes/g2-next/research.md
+++ b/docs/scopes/g2-next/research.md
@@ -1,0 +1,9 @@
+# Research decisions
+
+- Keep the pinned Even SDK 0.0.15. The existing bridge already supplies the required capture/display/gesture boundaries; hold/release still requires device verification.
+- A camera-to-plugin universal link is not established by available source. Implement paste connection plus manual HTTPS origin/code fallback; do not invent a native deep link or enable camera access.
+- Existing G2 sessions use a hashed node/conversation namespace. Preserve exact scoped continuation rather than treating a session ID as a new conversation ID. Existing owner `/sessions` APIs remain owner-only.
+- Request IDs passed to AgentHost are correlation, not deduplication. Model the new receipt store on the existing coding-supervisor durable claim/hash/no-replay-after-restart pattern.
+- Keep the existing provider budget guard and model selection. Capability reads, history reads and request polling never invoke a model.
+- `bb-remote` on this laptop uses force push and hook bypass internally to transfer a checkout. Those operations conflict with the task's git safety rules. Use a committed Git archive transferred to a new owned BuildBot3 temporary directory for production verification instead; never transfer private runtime data.
+- Preserve all safety/lifecycle limits. Submission status cannot establish reliable phone-lock recording; leave the experiment off by default.

--- a/docs/scopes/g2-next/spec.md
+++ b/docs/scopes/g2-next/spec.md
@@ -1,0 +1,16 @@
+# G2 0.4.18 experience specification
+
+The approved product scope is [the complete UX scope](../2026-09-12-g2-experience-redesign.md). This specification makes its next candidate executable without treating hardware aspirations as delivered capability.
+
+- US1 (P0): After losing a connection, see the same accepted question and result without duplicating agent work. Cancel explicitly; distinguish an interrupted main from an unsent draft.
+- US2 (P1): Connect an existing home computer through a pasteable short-lived connection card; new users can open the computer setup guide and preview the interface without recording. Check actual configured capabilities after scoped pairing.
+- US3 (P1): Use Talk, Inbox and History with Settings separate. Try Classic without changing pairing, consent, history, or server configuration.
+- US4 (P1): Enable Lifelog once, pause intentionally, return while existing consent is valid, and find saved text in History. No new background-recording claim.
+- US5 (P1): Resume the correct main-owned chat and see meaningful tool progress on glasses. Root double-tap retains native exit confirmation.
+- US6 (P1/P2): Find coding/computer requirements and bounded notification/privacy/cost settings without enabling new permissions or paid work.
+
+Acceptance: focused fault/auth/ownership tests, client gesture/storage/UI tests, TypeScript and production package checks. Physical onboarding, gestures, lock-screen, readability, live latency and actual provider control remain explicit user acceptance gates from the complete scope.
+
+Not authorized in this implementation: live deployment, provider-key changes, live recording or paid model tests, unrestricted computer control, merging PRs, or Even Hub upload/submission.
+
+Candidate boundaries: main history enumerates the 200 most recently updated active G2 conversations, searches question/reply previews, and pages public messages. It is not full-archive semantic search. There is no hosted main service, native installer rewrite, QR scanner, local/offline speech recognizer, or newly guaranteed background capture. These remain separate work from this reversible candidate. Public stage/tool events are shown, never private model reasoning.

--- a/docs/scopes/g2-next/tasks.md
+++ b/docs/scopes/g2-next/tasks.md
@@ -1,0 +1,36 @@
+# Tasks
+
+## Checkpoint and foundation
+
+- [x] T001 Preserve current working trees and reviewed source before redesign; record commits in `/Users/shooby/Dev/openagi-pr101-rollout/docs/scopes/g2-next/quickstart.md`.
+- [x] T002 Define scoped additive contracts, data model and rollback in `/Users/shooby/Dev/openagi-pr101-rollout/docs/scopes/g2-next/`.
+- [ ] T003 Establish a pinned reproducible OpenAGI client build in `/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/`.
+
+## US1 — Request recovery
+
+- [x] T004 [US1] Write admission/replay/expiry/restart/isolation tests in `/Users/shooby/Dev/openagi-pr101-rollout/test/g2-requests.test.js`.
+- [x] T005 [US1] Implement bounded durable receipts in `/Users/shooby/Dev/openagi-pr101-rollout/src/g2-requests.js`.
+- [x] T006 [US1] Add authenticated experience routing and endpoint tests in `/Users/shooby/Dev/openagi-pr101-rollout/src/hosted-interface.js` and `/Users/shooby/Dev/openagi-pr101-rollout/test/g2-experience.test.js`.
+- [x] T007 [US1] Add negotiated resume/cancel and pending request persistence in `/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/src/openagi/api-client.ts` and `store.ts`.
+
+## US2/US3 — Setup and phone experience
+
+- [x] T008 [US2] Add tested connection-card parsing and readiness onboarding in `/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/src/openagi/connection-card.ts`.
+- [x] T009 [US2] Add main Connect glasses setup guidance in `/Users/shooby/Dev/openagi-pr101-rollout/src/hosted-interface.js` and `/Users/shooby/Dev/openagi-pr101-rollout/src/setup-wizard.js`.
+- [x] T010 [US3] Implement Talk/Inbox/History/Settings with a Classic comparison in `/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/src/ui/phone-experience.ts`.
+- [x] T011 [US3] Replace status-string control inference with typed primary-action state in `/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/src/ui/openagi-phone-companion.ts`.
+
+## US4/US5/US6 — Everyday continuity
+
+- [x] T012 [US4] Implement one Lifelog entry and explicit pause preservation in `/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/src/app/openagi-g2-app.ts` and `src/openagi/store.ts`.
+- [x] T013 [US5] Add exact scoped history continuation, draft-safe Back and consistent gestures in `/Users/shooby/Dev/openagi-pr101-rollout/src/integrations/g2-channel.js` and the G2 app/renderer.
+- [x] T014 [US6] Expose existing capability, privacy, cost and notification controls contextually in the companion and main setup guidance.
+
+## Verification and delivery
+
+- [ ] T015 Expand client/auth/fault tests; run focused backend files twice and G2 tests/typecheck/lint with isolated data.
+- [ ] T016 Review exact changes, secret-scan and commit; produce one 0.4.18 artifact on BuildBot3 and record checksum/inputs in `/Users/shooby/Dev/openagi-pr101-rollout/docs/verification/2026-09-12-g2-experience.md`.
+- [ ] T017 Compare remote heads, normal fast-forward push and open the scoped PR; check external status once, with no merge/deploy/Hub submission.
+- [ ] T018 Physical acceptance: clean pairing, speech, follow-up, Classic switch, pause/reopen, network/Bluetooth recovery, native Exit and lock-screen capture. Requires user hardware; not an automated pass.
+
+Dependencies: checkpoint → contracts → receipts/routes → negotiated client → integrated experience → verification/package/PR → device testing. Independent test-writing/layout work may proceed alongside receipt implementation, but shared app/HTTP files are edited serially. No broad rewrite of unrelated subsystems.

--- a/docs/scopes/g2-next/tasks.md
+++ b/docs/scopes/g2-next/tasks.md
@@ -4,7 +4,7 @@
 
 - [x] T001 Preserve current working trees and reviewed source before redesign; record commits in `/Users/shooby/Dev/openagi-pr101-rollout/docs/scopes/g2-next/quickstart.md`.
 - [x] T002 Define scoped additive contracts, data model and rollback in `/Users/shooby/Dev/openagi-pr101-rollout/docs/scopes/g2-next/`.
-- [ ] T003 Establish a pinned reproducible OpenAGI client build in `/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/`.
+- [x] T003 Establish a pinned reproducible OpenAGI client build in `/Users/shooby/Dev/openagi-pr101-rollout/integration-clients/even-g2-overlay/`.
 
 ## US1 — Request recovery
 
@@ -28,8 +28,8 @@
 
 ## Verification and delivery
 
-- [ ] T015 Expand client/auth/fault tests; run focused backend files twice and G2 tests/typecheck/lint with isolated data.
-- [ ] T016 Review exact changes, secret-scan and commit; produce one 0.4.18 artifact on BuildBot3 and record checksum/inputs in `/Users/shooby/Dev/openagi-pr101-rollout/docs/verification/2026-09-12-g2-experience.md`.
+- [x] T015 Expand client/auth/fault tests; run focused backend files twice and G2 tests/typecheck/lint with isolated data.
+- [x] T016 Review exact changes, secret-scan and commit; produce one 0.4.18 artifact on BuildBot3 and record checksum/inputs in `/Users/shooby/Dev/openagi-pr101-rollout/docs/verification/2026-09-12-g2-experience.md`.
 - [ ] T017 Compare remote heads, normal fast-forward push and open the scoped PR; check external status once, with no merge/deploy/Hub submission.
 - [ ] T018 Physical acceptance: clean pairing, speech, follow-up, Classic switch, pause/reopen, network/Bluetooth recovery, native Exit and lock-screen capture. Requires user hardware; not an automated pass.
 

--- a/docs/verification/2026-09-12-g2-experience.md
+++ b/docs/verification/2026-09-12-g2-experience.md
@@ -1,0 +1,51 @@
+# G2 0.4.18 candidate verification
+
+## Scope and delivery boundary
+
+This is a reversible next-version candidate, not a deployment or an assertion that every aspiration in the full experience scope is complete. Both main and the G2 client need updating to use durable recovery and main history. An older main keeps the legacy ask path. No main/node deployment, provider configuration, real recording, paid model execution, physical computer control, PR merge, or Even Hub upload/submission occurred.
+
+The client adds Focused Talk / Inbox / History / Settings and a Classic switch; connection-card onboarding and configured-capability guidance; saved drafts and main-owned request recovery; exact G2 chat continuation; persistent intentional Lifelog pause; bounded public tool progress. Native root double-tap exit remains intact. Authentication and persistent-data skill guidance kept the new API node-scoped and receipts private under the configured data directory.
+
+Main history covers the 200 most recently updated active conversations for this G2, preview search and public-message pages. Full archives, a new native installer, automatic HTTPS setup, QR/plugin deep links, local speech recognition, light-theme polish and guaranteed phone-lock recording are not delivered by this candidate. A capability response checks configuration, not a real provider or device connection. Manual text drafts remain until sent/discarded or the connection is removed; raw audio is never persisted for replay. Private model reasoning and tool arguments are not progress text.
+
+## Immutable source and bundle
+
+- Baseline/rollback: `08b80e194d3643ae1e9ca20a69c17d8560996648`, retained as `codex/g2-pre-redesign-0.4.17`.
+- Implementation and package input: `f176f8962ae052182e1760bdc3548505e0425996`.
+- Backend verified head: `2487564857eddfcec421c9d91d378170f17439a4`; its only change after packaging makes the cancellation test fixture explicitly CommonJS. Client and runtime source are identical to package input.
+- Package ID: `sh.agents.even.g2`; manifest version: `0.4.18`; Even SDK: `0.0.15`; minimum Even app: `2.2.6`.
+- Artifact: `/Users/shooby/Downloads/OpenAGI-Agent-0.4.18-f176f89.ehpk`, 95,823 bytes.
+- SHA-256: `b57b7d72f68a8e393e2b748e8b9e40805d3f56860d9530875eef499c1986b99a`.
+- Generic package: no personal main URL or provider key supplied to packaging. Frozen lockfile and shared-source provenance are checked in.
+
+## Automated evidence
+
+- Production verification ran on BuildBot3 from committed `git archive` source, in an owned temporary directory, with Node `22.21.1`, pnpm `10.24.0`, `npm ci --ignore-scripts` and `pnpm install --frozen-lockfile`.
+- Full backend suite: **1,181 passed, zero failed, one skipped**, 1,182 total. Full output retained locally at `/Users/shooby/Downloads/OpenAGI-G2-0.4.18-backend-test.log`.
+- Client suite: **197 passed**, 19 test files; TypeScript and ESLint passed both locally and remotely.
+- Production TypeScript/Vite build, Even packaging, 2 MiB bundle ceiling and packaged-secret scan: passed. Uncompressed production assets: 296,995 bytes.
+- Focused local backend G2/auth/history/restart/cancellation/storage/retention checks: **29 passed**, also exercised by the full remote suite.
+- Git staged and publication-range secret checks passed before publication; no hook bypass or force push.
+- A Node 20 local client invocation could not start its test environment; rerunning with the declared Node 22 runtime passed. This was not counted as a passing run.
+- The initial full backend run had one failure: a CommonJS test helper named `.js` inherited `/tmp/package.json` with `type: module`. The fixture is now `.cjs`; the full suite was rerun successfully without production helper changes.
+- Read-only sample preview opened and exposed the Focused controls in browser accessibility state. Full visual/responsive screenshot review and physical gesture behavior are **not verified**. The owned preview server was stopped after inspection.
+
+New PR CI verifies the backend and standalone client/package on future changes. GitHub status is separate from the completed remote checks and is checked once after publication, not polled indefinitely. This record precedes PR creation; the final handoff supplies the PR URL/current state.
+
+## Try the design without a live connection
+
+In `integration-clients/even-g2-overlay`, with Node 22.21.1 and pnpm 10.24.0: run `pnpm install --frozen-lockfile`, then `pnpm dev --host 127.0.0.1`. Open `http://127.0.0.1:5173/preview.html`. The preview uses sample content and has no microphone, SDK connection, server credentials or agent execution. The preview entry is excluded from the production package.
+
+## Physical acceptance required before rollout
+
+1. Clean install/pair on a supported phone + Even app + G2 firmware: paste a new card, confirm the main origin, complete one read-only question. Confirm an existing install retains pairing.
+2. Compare Focused and Classic while a draft exists. Confirm consent and saved text are unchanged. Check narrow phone width, large text, contrast and page spacing.
+3. Ask for 15 seconds, stop/send and interrupt phone networking before/after acceptance. Reopen and check the same request: one agent turn, retained answer, no silent resend. Cancel a deliberately selected read-only task and inspect the result.
+4. History → conversation → follow-up stays in the exact main chat. Draft Back preserves text, explicit Discard removes it; answer scrolling never discards the result.
+5. Enable Lifelog with participant consent, ask a question, return to the upper-right dot; Pause survives app reopening and Resume does not extend consent. Confirm final text actually appears on main.
+6. Native root double-tap opens Even's exit confirmation; cancel it without losing state, then confirm exit stops capture. Verify actual press/release before relying on hold-to-talk.
+7. With the existing experimental background option explicitly enabled, separately test lock/unlock and Bluetooth/network interruptions. Check capture **and saved text**, not just the dot. Record phone OS, Even app and glasses firmware. A failed lock-screen test blocks any reliable-background claim.
+
+## Rollback
+
+Use Settings' interface selector to compare Classic without reinstalling or resetting data. For source rollback, use a separate worktree at the baseline or revert the scoped commits; never hard-reset an active checkout. The preserved 0.4.17 bundle and both original-repository checkpoints are listed in `docs/scopes/g2-next/quickstart.md`. Source/UI rollback does not reverse agent actions or extend recording consent.

--- a/integration-clients/even-g2-overlay/SHARED-SOURCE.md
+++ b/integration-clients/even-g2-overlay/SHARED-SOURCE.md
@@ -1,0 +1,25 @@
+# Reproducible client inputs
+
+Shared helpers retain their original BuildBetter G2 names and implementation.
+This is a frozen source snapshot from the assembled 0.4.17 verification client,
+not an upstream release or a claim that the independent G2 repo contains it.
+The exact inputs are now checked in: no dirty workspace or moving branch is needed.
+
+The standalone entry is src/openagi-main.ts. The older src/main.ts remains an
+overlay entry for compatible combined clients, excluded from this build.
+The lockfile pins the dependency graph, including Even SDK 0.0.15.
+Use pnpm install --frozen-lockfile, then pnpm test and pnpm package:agents.
+Shared-input or SDK upgrades require client regressions and physical testing.
+
+Original SHA-256 values:
+
+```text
+ccffef4b87e2b067a828a97f5ba176296a96de60bdc22613fe8dd8134af1f2ef  src/even/audio-source.ts
+77c94be7c71ee6851b4d376d23c7158f979d18ef70e05e92c12ad7d4c7636244  src/even/input-controller.ts
+58a7254832bc5a76de10f689fc0fb0909a9c3a188e0367f8153c7c04b4d3dfe7  src/even/display-controller.ts
+a0b6b3b9d78fba13c2391b589e1f4cc389f9aa8b8ebeba8e57b263469f2002dc  src/storage/recovery-store.ts
+99b1da751d33e8533cdcbee99a409e7bf1e5e47291881949697f97e279ebe4a6  src/buildbetter/question-audio.ts
+b1497522366643264d6b92973c7132a303ade2d40f12609d381cb237a8257598  src/buildbetter/audio-frame.ts
+737b4eb5f06754b1715ac289ca6d02cb520718e7eec0bc290ff696f2b395b167  src/state/ask-state-machine.ts
+6e28827868c4aa636ca97683489a0b065ff4bd0c077af441f4831158d581fe9c  pnpm-lock.yaml
+```

--- a/integration-clients/even-g2-overlay/eslint.config.js
+++ b/integration-clients/even-g2-overlay/eslint.config.js
@@ -1,0 +1,33 @@
+import eslint from '@eslint/js'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config(
+  {
+    ignores: [
+      'node_modules/**',
+      'dist/**',
+      'coverage/**',
+      'build/**',
+      'buildbetter/**',
+      'pr5563-*/**',
+      'scripts/**',
+      'src/main.ts',
+      'eslint.config.js',
+    ],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/only-throw-error': 'error',
+      'prefer-const': 'off',
+    },
+  },
+)

--- a/integration-clients/even-g2-overlay/index.html
+++ b/integration-clients/even-g2-overlay/index.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover"><meta name="color-scheme" content="dark light"><title>OpenAGI for G2</title></head><body><div id="app"></div><script type="module" src="/src/openagi-main.ts"></script></body></html>

--- a/integration-clients/even-g2-overlay/package.json
+++ b/integration-clients/even-g2-overlay/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@buildbetter/even-g2",
-  "version": "0.1.1",
+  "name": "@openagi/even-g2",
+  "version": "0.4.18",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.24.0",

--- a/integration-clients/even-g2-overlay/pnpm-lock.yaml
+++ b/integration-clients/even-g2-overlay/pnpm-lock.yaml
@@ -1,0 +1,2295 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@evenrealities/even_hub_sdk':
+        specifier: 0.0.15
+        version: 0.0.15
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@eslint/js':
+        specifier: 10.0.1
+        version: 10.0.1(eslint@10.8.1)
+      '@evenrealities/evenhub-cli':
+        specifier: 0.1.13
+        version: 0.1.13(typescript@5.9.3)
+      '@evenrealities/evenhub-simulator':
+        specifier: 0.8.0
+        version: 0.8.0
+      eslint:
+        specifier: 10.8.1
+        version: 10.8.1
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      typescript-eslint:
+        specifier: 8.66.0
+        version: 8.66.0(eslint@10.8.1)(typescript@5.9.3)
+      vite:
+        specifier: 8.2.1
+        version: 8.2.1
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(jsdom@30.0.1)(vite@8.2.1)
+
+packages:
+
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.10':
+    resolution: {integrity: sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7':
+    resolution: {integrity: sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@eslint-community/eslint-utils@4.10.1':
+    resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.2':
+    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@evenrealities/even_hub_sdk@0.0.15':
+    resolution: {integrity: sha512-N4SuDg/4MIgpah61IJAdtzOMcUg05/x0jz/+FkEdPnd9Dq7pCgOq5AtOSoU2i00hoYCOCdRSlBjWyq8LQCsfDQ==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+
+  '@evenrealities/evenhub-cli@0.1.13':
+    resolution: {integrity: sha512-glkkGfImds8ceh1YTbVvwuw7jlcSAKnI6Q7ATrDynKSvODs9/FV/R+0CliyCog3JJRTON0+EXBLW3lxU4x8NBQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5
+
+  '@evenrealities/evenhub-simulator@0.8.0':
+    resolution: {integrity: sha512-mfogXHtRRTQl8ZsaiESf/nFAmNSlH1LtGbkEIcaERDFcDizWTrXomB5FULz3W1gG+qsMQuJYSmB+jLp0tPHtKg==}
+    hasBin: true
+
+  '@evenrealities/sim-darwin-arm64@0.8.0':
+    resolution: {integrity: sha512-k/yW7mUh+6HgvjP8VrSBlkPj2BBa9qp2kJB95ewdXKhwWeCLCfS/q6eFNK0IXCRXo7CkRg1mbvl68REN9UxQEA==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@evenrealities/sim-darwin-x64@0.8.0':
+    resolution: {integrity: sha512-eXKfEsa67wb1SQOHsIKiHCRmWry8arENBt501gC8qP5hbMvmdkFMNbBGi2EOUfxqMrd+3jl7TdneraAaU4NGtA==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@evenrealities/sim-linux-x64@0.8.0':
+    resolution: {integrity: sha512-XIQX4IuHCAMFaJMiz9Jl9M8aakvGcefUgOc/PTj+8gAJANwdSmBLJhmoRcELlOHxPMeRG1RqfMrZI7neioqTJg==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  '@evenrealities/sim-win32-x64@0.8.0':
+    resolution: {integrity: sha512-PvcJr56lHUzDmHj889DOTR1iwPUC9NOplFkyd7UL7xvIZyhctO74BLoBKbyajZsEuqR8weVZQObUV89NGLpZ5A==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
+  '@inquirer/checkbox@5.2.1':
+    resolution: {integrity: sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@5.2.2':
+    resolution: {integrity: sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.1.1':
+    resolution: {integrity: sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@3.0.3':
+    resolution: {integrity: sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.7':
+    resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
+  '@inquirer/input@5.1.2':
+    resolution: {integrity: sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@4.1.1':
+    resolution: {integrity: sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.1.1':
+    resolution: {integrity: sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@8.5.2':
+    resolution: {integrity: sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.3.1':
+    resolution: {integrity: sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@4.2.1':
+    resolution: {integrity: sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@5.2.1':
+    resolution: {integrity: sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@oxc-project/types@0.143.0':
+    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
+
+  '@rolldown/binding-android-arm64@1.2.3':
+    resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    resolution: {integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.3':
+    resolution: {integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    resolution: {integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    resolution: {integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    resolution: {integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    resolution: {integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@typescript-eslint/eslint-plugin@8.66.0':
+    resolution: {integrity: sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.66.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.66.0':
+    resolution: {integrity: sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.66.0':
+    resolution: {integrity: sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.66.0':
+    resolution: {integrity: sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.66.0':
+    resolution: {integrity: sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.66.0':
+    resolution: {integrity: sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.66.0':
+    resolution: {integrity: sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.66.0':
+    resolution: {integrity: sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.66.0':
+    resolution: {integrity: sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.66.0':
+    resolution: {integrity: sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chardet@2.2.0:
+    resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.8.1:
+    resolution: {integrity: sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.4:
+    resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
+    engines: {node: '>= 4'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  inquirer@13.4.3:
+    resolution: {integrity: sha512-EPd3IqieHSavSOXh+LZhrIkdQcOELWeRblLT6kslQr+cF9XTh/HxZdSt1YkHH1iq4dvqBnV42uwg2YlorgOy6g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+    hasBin: true
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  open@11.0.0:
+    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+    engines: {node: '>=20'}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  qr-image@3.2.0:
+    resolution: {integrity: sha512-rXKDS5Sx3YipVsqmlMJsJsk6jXylEpiHRC2+nJy66fxA5ExYyGa4PqwteW69SaVmAb2OQ18HbYriT7cGQMbduw==}
+
+  qrcode-terminal@0.12.0:
+    resolution: {integrity: sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==}
+    hasBin: true
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  rolldown@1.2.3:
+    resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
+  run-async@4.0.6:
+    resolution: {integrity: sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==}
+    engines: {node: '>=0.12.0'}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.10:
+    resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
+
+  tldts@7.4.10:
+    resolution: {integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==}
+    hasBin: true
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript-eslint@8.66.0:
+    resolution: {integrity: sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  wsl-utils@0.3.1:
+    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+    engines: {node: '>=20'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+snapshots:
+
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.1)':
+    dependencies:
+      eslint: 10.8.1
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.7.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/js@10.0.1(eslint@10.8.1)':
+    optionalDependencies:
+      eslint: 10.8.1
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.2':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
+  '@evenrealities/even_hub_sdk@0.0.15': {}
+
+  '@evenrealities/evenhub-cli@0.1.13(typescript@5.9.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 14.0.3
+      inquirer: 13.4.3
+      js-yaml: 4.3.1
+      open: 11.0.0
+      qr-image: 3.2.0
+      qrcode-terminal: 0.12.0
+      typescript: 5.9.3
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@evenrealities/evenhub-simulator@0.8.0':
+    optionalDependencies:
+      '@evenrealities/sim-darwin-arm64': 0.8.0
+      '@evenrealities/sim-darwin-x64': 0.8.0
+      '@evenrealities/sim-linux-x64': 0.8.0
+      '@evenrealities/sim-win32-x64': 0.8.0
+
+  '@evenrealities/sim-darwin-arm64@0.8.0':
+    optional: true
+
+  '@evenrealities/sim-darwin-x64@0.8.0':
+    optional: true
+
+  '@evenrealities/sim-linux-x64@0.8.0':
+    optional: true
+
+  '@evenrealities/sim-win32-x64@0.8.0':
+    optional: true
+
+  '@exodus/bytes@1.15.1': {}
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@inquirer/ansi@2.0.7': {}
+
+  '@inquirer/checkbox@5.2.1':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7
+
+  '@inquirer/confirm@6.1.1':
+    dependencies:
+      '@inquirer/core': 11.2.1
+      '@inquirer/type': 4.0.7
+
+  '@inquirer/core@11.2.1':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+
+  '@inquirer/editor@5.2.2':
+    dependencies:
+      '@inquirer/core': 11.2.1
+      '@inquirer/external-editor': 3.0.3
+      '@inquirer/type': 4.0.7
+
+  '@inquirer/expand@5.1.1':
+    dependencies:
+      '@inquirer/core': 11.2.1
+      '@inquirer/type': 4.0.7
+
+  '@inquirer/external-editor@3.0.3':
+    dependencies:
+      chardet: 2.2.0
+      iconv-lite: 0.7.3
+
+  '@inquirer/figures@2.0.7': {}
+
+  '@inquirer/input@5.1.2':
+    dependencies:
+      '@inquirer/core': 11.2.1
+      '@inquirer/type': 4.0.7
+
+  '@inquirer/number@4.1.1':
+    dependencies:
+      '@inquirer/core': 11.2.1
+      '@inquirer/type': 4.0.7
+
+  '@inquirer/password@5.1.1':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1
+      '@inquirer/type': 4.0.7
+
+  '@inquirer/prompts@8.5.2':
+    dependencies:
+      '@inquirer/checkbox': 5.2.1
+      '@inquirer/confirm': 6.1.1
+      '@inquirer/editor': 5.2.2
+      '@inquirer/expand': 5.1.1
+      '@inquirer/input': 5.1.2
+      '@inquirer/number': 4.1.1
+      '@inquirer/password': 5.1.1
+      '@inquirer/rawlist': 5.3.1
+      '@inquirer/search': 4.2.1
+      '@inquirer/select': 5.2.1
+
+  '@inquirer/rawlist@5.3.1':
+    dependencies:
+      '@inquirer/core': 11.2.1
+      '@inquirer/type': 4.0.7
+
+  '@inquirer/search@4.2.1':
+    dependencies:
+      '@inquirer/core': 11.2.1
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7
+
+  '@inquirer/select@5.2.1':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7
+
+  '@inquirer/type@4.0.7': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@oxc-project/types@0.143.0': {}
+
+  '@rolldown/binding-android-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/esrecurse@4.3.1': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.1)(typescript@5.9.3))(eslint@10.8.1)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.1)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/type-utils': 8.66.0(eslint@10.8.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.1)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.66.0
+      eslint: 10.8.1
+      ignore: 7.0.6
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.66.0(eslint@10.8.1)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.66.0
+      debug: 4.4.3
+      eslint: 10.8.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.66.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.66.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.66.0':
+    dependencies:
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/visitor-keys': 8.66.0
+
+  '@typescript-eslint/tsconfig-utils@8.66.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.66.0(eslint@10.8.1)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.1)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 10.8.1
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.66.0': {}
+
+  '@typescript-eslint/typescript-estree@8.66.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/visitor-keys': 8.66.0
+      debug: 4.4.3
+      minimatch: 10.2.6
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.66.0(eslint@10.8.1)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1)
+      '@typescript-eslint/scope-manager': 8.66.0
+      '@typescript-eslint/types': 8.66.0
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@5.9.3)
+      eslint: 10.8.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.66.0':
+    dependencies:
+      '@typescript-eslint/types': 8.66.0
+      eslint-visitor-keys: 5.0.1
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.2.1)':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.1
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
+  acorn-jsx@5.3.2(acorn@8.18.0):
+    dependencies:
+      acorn: 8.18.0
+
+  acorn@8.18.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
+
+  balanced-match@4.0.4: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
+  chai@6.2.2: {}
+
+  chalk@5.6.2: {}
+
+  chardet@2.2.0: {}
+
+  cli-width@4.1.0: {}
+
+  commander@14.0.3: {}
+
+  convert-source-map@2.0.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decimal.js@10.6.0: {}
+
+  deep-is@0.1.4: {}
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
+
+  detect-libc@2.1.2: {}
+
+  entities@8.0.0: {}
+
+  es-module-lexer@2.3.1: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.8.1:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.7.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.6
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
+      eslint-visitor-keys: 5.0.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  esutils@2.0.3: {}
+
+  expect-type@1.4.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.4
+      keyv: 4.5.4
+
+  flatted@3.4.4: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.6: {}
+
+  imurmurhash@0.1.4: {}
+
+  inquirer@13.4.3:
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1
+      '@inquirer/prompts': 8.5.2
+      '@inquirer/type': 4.0.7
+      mute-stream: 3.0.0
+      run-async: 4.0.6
+      rxjs: 7.8.2
+
+  is-docker@3.0.0: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-in-ssh@1.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
+
+  isexe@2.0.0: {}
+
+  js-yaml@4.3.1:
+    dependencies:
+      argparse: 2.0.1
+
+  jsdom@30.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lru-cache@11.5.2: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdn-data@2.27.1: {}
+
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  ms@2.1.3: {}
+
+  mute-stream@3.0.0: {}
+
+  nanoid@3.3.18: {}
+
+  natural-compare@1.4.0: {}
+
+  obug@2.1.4: {}
+
+  open@11.0.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  powershell-utils@0.1.0: {}
+
+  prelude-ls@1.2.1: {}
+
+  punycode@2.3.1: {}
+
+  qr-image@3.2.0: {}
+
+  qrcode-terminal@0.12.0: {}
+
+  require-from-string@2.0.2: {}
+
+  rolldown@1.2.3:
+    dependencies:
+      '@oxc-project/types': 0.143.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.3
+      '@rolldown/binding-darwin-arm64': 1.2.3
+      '@rolldown/binding-darwin-x64': 1.2.3
+      '@rolldown/binding-freebsd-x64': 1.2.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.3
+      '@rolldown/binding-linux-arm64-gnu': 1.2.3
+      '@rolldown/binding-linux-arm64-musl': 1.2.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.3
+      '@rolldown/binding-linux-s390x-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-musl': 1.2.3
+      '@rolldown/binding-openharmony-arm64': 1.2.3
+      '@rolldown/binding-win32-arm64-msvc': 1.2.3
+      '@rolldown/binding-win32-x64-msvc': 1.2.3
+
+  run-applescript@7.1.0: {}
+
+  run-async@4.0.6: {}
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  semver@7.8.5: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  symbol-tree@3.2.4: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
+
+  tldts-core@7.4.10: {}
+
+  tldts@7.4.10:
+    dependencies:
+      tldts-core: 7.4.10
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.10
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  tslib@2.8.1: {}
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript-eslint@8.66.0(eslint@10.8.1)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.1)(typescript@5.9.3))(eslint@10.8.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.1)(typescript@5.9.3)
+      eslint: 10.8.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript@5.9.3: {}
+
+  undici@8.10.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  vite@8.2.1:
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@4.1.10(jsdom@30.0.1)(vite@8.2.1):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.1)
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.1
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      jsdom: 30.0.1
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  word-wrap@1.2.5: {}
+
+  wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
+
+  yocto-queue@0.1.0: {}
+
+  zod@4.4.3: {}

--- a/integration-clients/even-g2-overlay/preview.html
+++ b/integration-clients/even-g2-overlay/preview.html
@@ -1,0 +1,1 @@
+<!doctype html><html lang="en"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>G2 design preview · no live connection</title><div id="app"></div><script type="module" src="/src/design-preview.ts"></script></html>

--- a/integration-clients/even-g2-overlay/scripts/check-bundle.mjs
+++ b/integration-clients/even-g2-overlay/scripts/check-bundle.mjs
@@ -1,0 +1,22 @@
+import { readdir, stat } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+
+const MAX_BYTES = 2 * 1024 * 1024
+
+async function total(path) {
+  const entries = await readdir(path)
+  let bytes = 0
+  for (const entry of entries) {
+    const item = join(path, entry)
+    const info = await stat(item)
+    bytes += info.isDirectory() ? await total(item) : info.size
+  }
+  return bytes
+}
+
+const bytes = await total(fileURLToPath(new URL('../dist', import.meta.url)))
+if (bytes > MAX_BYTES) {
+  throw new Error(`Bundle is ${bytes} bytes; limit is ${MAX_BYTES}`)
+}
+console.log(`Bundle size: ${bytes} bytes`)

--- a/integration-clients/even-g2-overlay/scripts/check-secrets.mjs
+++ b/integration-clients/even-g2-overlay/scripts/check-secrets.mjs
@@ -1,0 +1,28 @@
+import { readFile, readdir, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const suspicious = [
+  /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/,
+  /(?:api[_-]?key|client[_-]?secret|refresh[_-]?token)\s*[:=]\s*["'][^"']{12,}["']/i,
+  /Authorization\s*:\s*["']Bearer\s+[A-Za-z0-9._-]{20,}/i,
+]
+
+async function files(path) {
+  const result = []
+  for (const entry of await readdir(path)) {
+    const item = join(path, entry)
+    const info = await stat(item)
+    if (info.isDirectory()) result.push(...(await files(item)))
+    else result.push(item)
+  }
+  return result
+}
+
+const findings = []
+for (const file of await files(fileURLToPath(new URL('../dist', import.meta.url)))) {
+  const text = await readFile(file, 'utf8').catch(() => '')
+  if (suspicious.some(pattern => pattern.test(text))) findings.push(file)
+}
+if (findings.length) throw new Error(`Potential secret material in: ${findings.join(', ')}`)
+console.log('Packaged secret scan passed')

--- a/integration-clients/even-g2-overlay/scripts/package-openagi.mjs
+++ b/integration-clients/even-g2-overlay/scripts/package-openagi.mjs
@@ -4,6 +4,7 @@ import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const { version } = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'))
 const rawOrigins = process.argv.slice(2).filter(argument => argument !== '--')
 const origins = [...new Set(rawOrigins.map(normalizeOrigin))]
 if (origins.length > 16) fail('Agents packages support at most 16 exact origins.')
@@ -20,7 +21,7 @@ const manifestDir = path.join(root, 'build', 'openagi-g2')
 fs.mkdirSync(manifestDir, { recursive: true })
 const manifestPath = path.join(manifestDir, 'app.json')
 fs.writeFileSync(manifestPath, JSON.stringify({
-  package_id: 'sh.agents.even.g2', edition: '202601', name: 'Agents', version: '0.4.17', min_app_version: '2.2.6', min_sdk_version: '0.0.15', entrypoint: 'index.html',
+  package_id: 'sh.agents.even.g2', edition: '202601', name: 'Agents', version, min_app_version: '2.2.6', min_sdk_version: '0.0.15', entrypoint: 'index.html',
   permissions: [
     { name: 'g2-microphone', desc: 'Listen after Ask or consented lifelog. Optional lock-screen listening continues live lifelog while Even remains running.' },
     { name: 'network', desc: 'Connect to your selected agent. Optional live speech streams through your main or directly to Deepgram.', whitelist: networkOrigins },

--- a/integration-clients/even-g2-overlay/src/app/openagi-g2-app.ts
+++ b/integration-clients/even-g2-overlay/src/app/openagi-g2-app.ts
@@ -29,7 +29,55 @@ export class OpenAGIG2App {
     this.renderer.notice?.(label, plainAnswer(item.title))
     this.noticeTimer = setTimeout(() => { this.noticeTimer = null; if (['home', 'ambient'].includes(this.mode) && this.foregroundActive && !this.exited) this.showHome() }, 4500)
   }
-  private mode: Mode = 'unpaired'
+  private currentMode: Mode = 'unpaired'
+  private get mode(): Mode { return this.currentMode }
+  private set mode(value: Mode) {
+    this.currentMode = value
+    this.phone?.interaction?.(value === 'unpaired' || value === 'pairing' ? 'unavailable' : value === 'thinking' ? 'working' : value === 'listening' ? 'recording' : value === 'review' ? 'review' : 'idle')
+  }
+  async configureInterface(style: 'focused' | 'classic'): Promise<void> {
+    await this.store.update({ interfaceStyle: style }); this.phone.interfaceStyle?.(style)
+  }
+  private async checkExperience(): Promise<void> {
+    try { this.phone.readiness?.(await this.api.configureExperience?.(this.store) ?? null) }
+    catch (error) { this.phone.readiness?.(null, `Main readiness could not be checked: ${safeOpenAGIError(error)}`) }
+  }
+  async readHistory(continuation?: string, offset = 0, query = ''): Promise<void> {
+    this.phone.historyStatus?.('Loading from main…')
+    try { this.phone.mainHistory?.(await this.api.readHistory(continuation, offset, query), continuation) }
+    catch (error) { this.phone.historyStatus?.(`Could not load main history: ${safeOpenAGIError(error)} Local recent answers remain below.`) }
+  }
+  async continueHistory(continuation: string): Promise<void> {
+    if (this.requestController || this.microphoneOpening || this.store.snapshot().pendingRequest || this.store.snapshot().savedDraft || ['listening', 'review', 'pairing'].includes(this.mode)) {
+      this.phone.set('Keep your current question', 'Finish or clear the saved question before switching conversations.'); return
+    }
+    try {
+      const history = await this.api.readHistory(continuation)
+      const answer = history.messages?.filter(m => m.role === 'assistant').at(-1)?.text
+      await this.store.update({ continuation, conversationId: crypto.randomUUID() })
+      if (answer) { this.pages = paginateText(plainAnswer(answer), 260); this.phone.preview?.(plainAnswer(answer)); this.showAnswer(0) } else this.showHome()
+      this.phone.set('Conversation resumed', 'Your next question continues this exact chat on main.')
+    } catch (error) { this.phone.set('Could not resume conversation', safeOpenAGIError(error)) }
+  }
+  async resumeRequest(allowSubmit = true): Promise<void> {
+    if (this.requestController || this.exited || !this.foregroundActive || this.microphoneOpening) return
+    const pending = this.store.snapshot().pendingRequest
+    if (!pending) return
+    await this.stopAmbient(true)
+    await this.store.update({ conversationId: pending.conversationId, continuation: pending.continuation })
+    await this.runQuestion(pending.text ?? '', { resume: true, allowSubmit })
+  }
+  async dismissRequest(): Promise<void> {
+    if (this.requestController) return
+    await this.store.update({ pendingRequest: null }); this.phone.pendingQuestion?.(null); this.showHome()
+  }
+  async pauseLifelog(): Promise<void> {
+    if (this.requestController || this.microphoneOpening || this.mode === 'listening') return
+    await this.store.update({ lifelogPaused: true })
+    this.memoryRequest++; this.resumeAfterAsk = false; this.pausedLifelog = this.store.snapshot().lifelogEnabled
+    await this.stopAmbient(true); this.proactive.suspendMemory(); this.showPaused()
+    this.phone.set('Lifelog paused by you', 'Microphone off. Reopening will keep it paused until you choose Resume.')
+  }
   private audioBuffer: QuestionAudioBuffer | null = null
   private pages: string[] = []
   private page = 0
@@ -228,8 +276,7 @@ export class OpenAGIG2App {
   private async chooseInboxAction(): Promise<void> {
     const target = this.actionTarget, action = this.inboxActions()[this.actionIndex]; if (!target || !action) return
     if (action.op === 'pause') {
-      this.pausedLifelog = this.proactive.memoryActive
-      await this.configureAmbient(false, this.store.snapshot().wakePhrase, this.store.snapshot().answerQuestions)
+      await this.pauseLifelog()
       if (!this.exited && this.foregroundActive && !this.ambientRunning) this.showPaused()
       return
     }
@@ -309,6 +356,7 @@ export class OpenAGIG2App {
     }
     if (this.proactive.memoryActive && this.ambientRunning) { this.showHome(); return }
     this.phone.memoryPending?.(true)
+    await this.store.update({ lifelogPaused: false })
     this.phone.memoryStatus?.(false, 'Starting lifelog… opening the microphone, then requesting retention consent.')
     try {
       const startedHere = !this.ambientRunning
@@ -368,6 +416,7 @@ export class OpenAGIG2App {
   async boot(): Promise<void> {
     document.addEventListener('visibilitychange', this.onVisibility)
     const stored = await this.store.load()
+    this.phone.interfaceStyle?.(stored.interfaceStyle)
     this.phone.listeningMode?.(stored.listeningMode)
     this.phone.idleTapAction?.(stored.idleTapAction)
     this.phone.lifelogTalkMode?.(stored.lifelogTalkMode)
@@ -385,7 +434,11 @@ export class OpenAGIG2App {
           this.startHeartbeat()
         }
         this.phone.ambient(stored.ambientEnabled, stored.wakePhrase, stored.answerQuestions)
-        if (stored.lifelogEnabled) { this.showHome(); await this.restoreLifelog() }
+        await this.checkExperience()
+        if (stored.pendingRequest) { this.showHome(); await this.resumeRequest(false); return }
+        if (stored.savedDraft) { this.showHome(); this.reviewDraft(stored.savedDraft, 'speech'); return }
+        if (stored.lifelogPaused) { this.pausedLifelog = stored.lifelogEnabled; this.showPaused() }
+        else if (stored.lifelogEnabled) { this.showHome(); await this.restoreLifelog() }
         else if (stored.ambientEnabled) {
           try { await this.startAmbient() }
           catch (error) { this.showHome(); this.phone.set('Always listening unavailable', safeOpenAGIError(error)) }
@@ -417,7 +470,8 @@ export class OpenAGIG2App {
       return
     }
     if (this.mode === 'paused') {
-      if (this.pausedLifelog) { this.mode = 'resume-consent'; this.renderer.paused?.(true, true) }
+      if (this.pausedLifelog && this.store.snapshot().lifelogPaused) void this.retryListening()
+      else if (this.pausedLifelog) { this.mode = 'resume-consent'; this.renderer.paused?.(true, true) }
       else void this.configureAmbient(true, this.store.snapshot().wakePhrase, this.store.snapshot().answerQuestions)
     }
     else if (this.mode === 'resume-consent') void this.configureMemory(true, true)
@@ -455,9 +509,14 @@ export class OpenAGIG2App {
     }
     else if (this.mode === 'recent') this.showRecent(this.recentIndex - direction)
   }
-  cancelRequest(): void { this.cancelConfirmation = false; this.requestController?.abort(); if (this.preparingDraft) this.stopLiveSpeech() }
+  cancelRequest(): void {
+    this.cancelConfirmation = false; this.requestController?.abort(); if (this.preparingDraft) this.stopLiveSpeech()
+    if (this.store.snapshot().pendingRequest) void this.api.cancelPending?.().then(() => this.phone.pendingQuestion?.(this.store.snapshot().pendingRequest ? 'Main already finished. Check the saved result.' : null))
+      .catch(error => { this.phone.pendingQuestion?.(`Cancel could not be confirmed: ${safeOpenAGIError(error)} Check the saved request.`) })
+  }
   async discardDraft(): Promise<void> {
     if (this.mode !== 'review') return
+    await this.store.update({ savedDraft: '' })
     this.voiceTarget = null; this.draft = ''; this.phone.draft?.(null); this.showHome(); await this.resumeListening()
   }
   async rerecordDraft(): Promise<void> { if (this.mode !== 'review') return; await this.discardDraft(); await this.startAsk() }
@@ -471,9 +530,10 @@ export class OpenAGIG2App {
     if (!clean) throw new Error('No speech was recognized. Nothing was sent; please retry.')
     if (clean.length > 4000) throw new Error('Question is too long. Nothing was sent; please record a shorter question.')
     this.draft = clean; this.draftRecovery = recovery; this.mode = 'review'; this.pages = paginateText(plainAnswer(clean), 220); this.page = 0
+    void this.store.update({ savedDraft: clean }).catch(error => this.phone.set('Draft is only on screen', `Could not save it for reopening: ${safeOpenAGIError(error)}`))
     if (this.store.snapshot().autoSend && !recovery) { this.phone.transcript?.(clean); return }
     this.phone.transcript?.(clean); this.phone.draft?.(clean, recovery)
-    this.phone.set('Review question · not sent', 'Tap to send. Double-tap to discard. Swipe to read the whole transcript, or re-record on the phone.')
+    this.phone.set('Review question · not sent', 'Tap to send. Double-tap goes back and keeps the draft. Swipe to read, or explicitly Discard on the phone.')
     this.showDraftPage()
   }
   private recoverQuestion(text: string, error: unknown, recovery: 'speech' | 'delivery'): void {
@@ -530,7 +590,7 @@ export class OpenAGIG2App {
       else this.renderActiveProgress?.()
       return
     }
-    if (this.mode === 'review') { await this.discardDraft(); return }
+    if (this.mode === 'review') { this.showHome(); this.phone.set('Draft kept', 'Tap Talk to return to your question. Discard on the phone to delete it.'); return }
     if (this.mode === 'resume-consent') { this.showPaused(); return }
     if (this.mode === 'paused') { this.showHome(); return }
     if (this.mode === 'inbox-confirm') { this.mode = 'inbox-action'; this.showInboxAction(); await this.resumeListening(); return }
@@ -560,7 +620,8 @@ export class OpenAGIG2App {
     this.proactive.stop(this.store.snapshot().lifelogEnabled)
     this.exited = true
     this.stopLiveSpeech()
-    this.cancelRequest()
+    // Closing the observer is not cancellation of main-owned accepted work.
+    this.requestController?.abort()
     if (this.heartbeatTimer) clearInterval(this.heartbeatTimer)
     this.heartbeatTimer = null
     this.ambientRunning = false
@@ -604,6 +665,7 @@ export class OpenAGIG2App {
       await this.heartbeatWithoutLosingEnrollment(enrolled.node.name)
       this.startHeartbeat()
       this.showHome()
+      await this.checkExperience()
     }
     catch (error) {
       // Preserve pending credentials across failed attempts: a prior response
@@ -629,16 +691,18 @@ export class OpenAGIG2App {
     await this.store.clearCredential(); this.showUnpaired()
   }
   async newConversation(): Promise<void> {
+    if (this.store.snapshot().pendingRequest || this.store.snapshot().savedDraft) { this.phone.set('Keep your current question', 'Finish or clear your saved question before starting a new chat.'); return }
     if (this.mode === 'review') return
     if (this.mode === 'thinking' || this.mode === 'listening' || this.mode === 'pairing' || this.ambientProcessing) return
-    await this.store.update({ conversationId: crypto.randomUUID() }); this.pages = []; this.phone.preview?.(''); this.showHome(); this.phone.set('New conversation', 'Your next question starts a fresh agent chat.')
+    await this.store.update({ conversationId: crypto.randomUUID(), continuation: null }); this.pages = []; this.phone.preview?.(''); this.showHome(); this.phone.set('New conversation', 'Your next question starts a fresh agent chat.')
   }
   async selectAnswer(index: number): Promise<void> {
+    if (this.store.snapshot().pendingRequest || this.store.snapshot().savedDraft) return
     if (this.mode === 'review') return
     if (this.mode === 'thinking' || this.mode === 'listening' || this.mode === 'pairing' || this.ambientProcessing) return
     const entry = this.store.snapshot().history[index]
     if (!entry) return
-    await this.store.update({ conversationId: entry.conversationId })
+    await this.store.update({ conversationId: entry.conversationId, continuation: entry.continuation })
     this.pages = paginateText(plainAnswer(entry.reply), 260); this.phone.paired(true); this.showAnswer(0)
     this.phone.history?.(this.store.snapshot().history); this.phone.preview?.(entry.reply)
     this.phone.set('Conversation resumed', `${entry.question} — Tap the glasses to ask a follow-up, or use Ask on the phone.`)
@@ -666,6 +730,7 @@ export class OpenAGIG2App {
     this.heartbeatTimer = null
     this.showHome()
     this.phone.set('Agent connected', `G2 will use ${normalizedOrigin}. The token stays in this app's local storage.`)
+    await this.checkExperience()
   }
   async configureAmbient(enabled: boolean, wakePhrase: string, answerQuestions: boolean): Promise<void> {
     const next = this.ambientConfiguration.then(() => this.applyAmbientConfiguration(enabled, wakePhrase, answerQuestions))
@@ -688,6 +753,7 @@ export class OpenAGIG2App {
     if (!visible()) return
     this.foregroundActive = true; this.proactive.setForeground(true)
     this.cancelSpeechRecovery()
+    await this.store.update({ lifelogPaused: false })
     const state = this.store.snapshot()
     if (state.lifelogEnabled) {
       if (this.ambientRunning && this.proactive.memoryActive) { this.showHome(); return }
@@ -735,6 +801,8 @@ export class OpenAGIG2App {
     }
   }
   async startAsk(fromHold = false): Promise<void> {
+    if (this.store.snapshot().pendingRequest) { this.phone.pendingQuestion?.('Check your saved question before asking another. Reconnecting will not submit it twice.'); return }
+    if (this.mode !== 'review' && this.store.snapshot().savedDraft) { this.reviewDraft(this.store.snapshot().savedDraft, 'speech'); return }
     if (document.visibilityState === 'hidden') { this.phone.activity?.('Unlock the phone to ask; background mode only retains lifelog.'); return }
     if (this.recoveringSpeech) return
     if (this.heldQuestion && !fromHold) return
@@ -846,8 +914,11 @@ export class OpenAGIG2App {
     } catch (error) { this.phone.autoSend?.(this.store.snapshot().autoSend); this.phone.set('Could not save preference', safeOpenAGIError(error)) }
     finally { this.navigationBusy = false }
   }
-  private async runQuestion(input: Blob | string): Promise<void> {
+  private async runQuestion(input: Blob | string, recovery?: { resume: boolean; allowSubmit: boolean }): Promise<void> {
     if (this.requestController) return
+    try { await this.store.update({ savedDraft: '' }) }
+    catch (error) { this.phone.set('Question not sent', `Could not save delivery state: ${safeOpenAGIError(error)}`); return }
+    if (this.requestController || this.exited) return
     const target = this.voiceTarget; this.voiceTarget = null
     if (target && typeof input === 'string') {
       if (/^(?:(?:please )?mark )?(?:this (?:one|task)|it)(?:['’]s| is)? (?:as )?(?:done|complete|completed)[.!]?$/i.test(input.trim())) {
@@ -907,10 +978,12 @@ export class OpenAGIG2App {
           renderProgress()
         }
       }
-      const result = typeof input === 'string'
+      const result = recovery?.resume ? await this.api.resumePending(onProgress, controller.signal, recovery.allowSubmit) : typeof input === 'string'
         ? await this.api.askText(input, conversationId, onProgress, controller.signal)
         : await this.api.ask(input, conversationId, onProgress, controller.signal)
       received = result
+      await this.store.update({ savedDraft: '' })
+      this.phone.pendingQuestion?.(null); this.phone.draft?.(null)
       await this.store.remember(result.question, result.reply)
       this.phone.history?.(this.store.snapshot().history); this.phone.preview?.(plainAnswer(result.reply))
       this.pages = paginateText(plainAnswer(result.reply), 260); this.showAnswer(Math.min(this.page, this.pages.length - 1))
@@ -931,7 +1004,11 @@ export class OpenAGIG2App {
       } else if (controller.signal.aborted) {
         this.mode = 'message'; this.renderer.message('Request stopped', 'No automatic retry. Completed actions cannot be undone. Your recent answers are still saved.')
       } else this.fail(error)
-      if (!received) {
+      if (!received && this.store.snapshot().pendingRequest) {
+        this.phone.pendingQuestion?.(`${safeOpenAGIError(error)} Your question is saved. Check the same request, or review History before clearing it.`)
+        this.mode = 'message'; this.renderer.message('Question saved', 'Connection interrupted. Check saved request on phone; it will not send twice.')
+        this.phone.set('Question saved · needs attention', safeOpenAGIError(error))
+      } else if (!received) {
         if (!partial && !controller.signal.aborted && !this.exited && typeof input === 'string') this.recoverQuestion(input, error, 'delivery')
         else this.phone.set(controller.signal.aborted ? 'Request interrupted' : 'Connection interrupted', `${safeOpenAGIError(error)} No automatic retry. Recent answers remain available.`)
       }
@@ -959,6 +1036,7 @@ export class OpenAGIG2App {
   private fail(error: unknown): void { this.voiceTarget = null; this.clearNotice(); this.mode = 'message'; const message = safeOpenAGIError(error); this.renderer.message('Could not ask agent', message); this.phone.set('Ask failed', message) }
   private async startAmbient(): Promise<void> {
     if (this.exited) return
+    if (this.store.snapshot().lifelogPaused) { this.showPaused(); return }
     if (!this.foregroundActive || document.visibilityState === 'hidden') {
       this.pausedLifelog = this.store.snapshot().lifelogEnabled; this.showPaused()
       this.phone.set('Listening paused', 'Microphone was not started: open Agents on the glasses and the Even app on your phone, then retry.')
@@ -1008,6 +1086,7 @@ export class OpenAGIG2App {
     if (this.audio.active) await this.audio.stop().catch(() => undefined)
   }
   private async resumeListening(): Promise<void> {
+    if (this.store.snapshot().lifelogPaused) return
     if (this.mode === 'review') return // Keep recovery text visible until Send or Discard.
     if (!this.resumeAfterAsk || this.exited || !this.foregroundActive || !this.store.snapshot().ambientEnabled) return
     this.resumeAfterAsk = false
@@ -1219,6 +1298,7 @@ export class OpenAGIG2App {
     try {
       await this.foregroundTransition
       const state = this.store.snapshot()
+      if (state.lifelogPaused) { this.pausedLifelog = state.lifelogEnabled; this.showPaused(); return }
       if (!state.lifelogEnabled || !state.nodeToken || !this.foregroundActive || this.exited || request !== this.memoryRequest) return
       if (this.requestController || this.microphoneOpening || ['listening', 'review'].includes(this.mode)) return
       this.proactive.start()

--- a/integration-clients/even-g2-overlay/src/buildbetter/audio-frame.ts
+++ b/integration-clients/even-g2-overlay/src/buildbetter/audio-frame.ts
@@ -1,0 +1,109 @@
+export const AUDIO_FRAME_MAGIC = new Uint8Array([0x42, 0x42, 0x47, 0x32])
+export const AUDIO_FRAME_HEADER_BYTES = 24
+export const AUDIO_PROTOCOL_VERSION = 1
+export const AUDIO_SAMPLE_RATE_HZ = 16_000
+export const AUDIO_CHANNELS = 1
+export const AUDIO_BYTES_PER_SAMPLE = 2
+export const AUDIO_TARGET_SAMPLES = 1_600
+export const AUDIO_MAX_SAMPLES = 8_000
+
+export interface DecodedAudioFrame {
+  sequence: bigint
+  sampleCount: number
+  pcm: Uint8Array
+}
+
+export class AudioFrameError extends Error {
+  constructor(readonly code: string, message: string) {
+    super(message)
+    this.name = 'AudioFrameError'
+  }
+}
+
+export function encodeAudioFrame(sequence: bigint, pcm: Uint8Array): Uint8Array {
+  if (sequence < 0n) throw new AudioFrameError('invalid_sequence', 'Sequence must be non-negative')
+  if (pcm.byteLength === 0 || pcm.byteLength % AUDIO_BYTES_PER_SAMPLE !== 0) {
+    throw new AudioFrameError('invalid_pcm_length', 'PCM must contain complete signed 16-bit samples')
+  }
+  const sampleCount = pcm.byteLength / AUDIO_BYTES_PER_SAMPLE
+  if (sampleCount > AUDIO_MAX_SAMPLES) {
+    throw new AudioFrameError('frame_too_large', `Audio frame contains ${sampleCount} samples`)
+  }
+
+  const frame = new Uint8Array(AUDIO_FRAME_HEADER_BYTES + pcm.byteLength)
+  frame.set(AUDIO_FRAME_MAGIC, 0)
+  const view = new DataView(frame.buffer)
+  view.setUint8(4, AUDIO_PROTOCOL_VERSION)
+  view.setUint8(5, 0)
+  view.setUint16(6, AUDIO_FRAME_HEADER_BYTES, false)
+  view.setBigUint64(8, sequence, false)
+  view.setUint32(16, sampleCount, false)
+  view.setUint32(20, pcm.byteLength, false)
+  frame.set(pcm, AUDIO_FRAME_HEADER_BYTES)
+  return frame
+}
+
+export function decodeAudioFrame(input: ArrayBuffer | Uint8Array): DecodedAudioFrame {
+  const bytes = input instanceof Uint8Array ? input : new Uint8Array(input)
+  if (bytes.byteLength < AUDIO_FRAME_HEADER_BYTES) {
+    throw new AudioFrameError('truncated_header', 'Audio frame header is truncated')
+  }
+  for (let index = 0; index < AUDIO_FRAME_MAGIC.length; index += 1) {
+    if (bytes[index] !== AUDIO_FRAME_MAGIC[index]) throw new AudioFrameError('invalid_magic', 'Invalid audio frame magic')
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  if (view.getUint8(4) !== AUDIO_PROTOCOL_VERSION) throw new AudioFrameError('unsupported_version', 'Unsupported audio protocol')
+  if (view.getUint8(5) !== 0) throw new AudioFrameError('unsupported_flags', 'Audio frame flags must be zero')
+  if (view.getUint16(6, false) !== AUDIO_FRAME_HEADER_BYTES) throw new AudioFrameError('invalid_header_length', 'Invalid header length')
+
+  const sequence = view.getBigUint64(8, false)
+  const sampleCount = view.getUint32(16, false)
+  const payloadBytes = view.getUint32(20, false)
+  if (sampleCount === 0 || sampleCount > AUDIO_MAX_SAMPLES) throw new AudioFrameError('invalid_sample_count', 'Invalid sample count')
+  if (payloadBytes !== sampleCount * AUDIO_CHANNELS * AUDIO_BYTES_PER_SAMPLE) {
+    throw new AudioFrameError('sample_length_mismatch', 'Sample count does not match PCM bytes')
+  }
+  if (bytes.byteLength !== AUDIO_FRAME_HEADER_BYTES + payloadBytes) {
+    throw new AudioFrameError('payload_length_mismatch', 'PCM payload is truncated or has trailing bytes')
+  }
+  return {
+    sequence,
+    sampleCount,
+    pcm: bytes.slice(AUDIO_FRAME_HEADER_BYTES),
+  }
+}
+
+export class PcmFrameCoalescer {
+  private pending = new Uint8Array(0)
+
+  constructor(private readonly targetBytes = AUDIO_TARGET_SAMPLES * AUDIO_BYTES_PER_SAMPLE) {
+    if (targetBytes <= 0 || targetBytes % AUDIO_BYTES_PER_SAMPLE !== 0) throw new Error('targetBytes must contain full samples')
+  }
+
+  push(chunk: Uint8Array): Uint8Array[] {
+    if (chunk.byteLength % AUDIO_BYTES_PER_SAMPLE !== 0) throw new AudioFrameError('invalid_pcm_length', 'PCM chunk has a partial sample')
+    if (chunk.byteLength === 0) return []
+    const joined = new Uint8Array(this.pending.byteLength + chunk.byteLength)
+    joined.set(this.pending)
+    joined.set(chunk, this.pending.byteLength)
+    const frames: Uint8Array[] = []
+    let offset = 0
+    while (joined.byteLength - offset >= this.targetBytes) {
+      frames.push(joined.slice(offset, offset + this.targetBytes))
+      offset += this.targetBytes
+    }
+    this.pending = joined.slice(offset)
+    return frames
+  }
+
+  flush(): Uint8Array | null {
+    if (!this.pending.byteLength) return null
+    const result = this.pending
+    this.pending = new Uint8Array(0)
+    return result
+  }
+
+  get pendingBytes(): number {
+    return this.pending.byteLength
+  }
+}

--- a/integration-clients/even-g2-overlay/src/buildbetter/question-audio.ts
+++ b/integration-clients/even-g2-overlay/src/buildbetter/question-audio.ts
@@ -1,0 +1,46 @@
+import { AUDIO_BYTES_PER_SAMPLE, AUDIO_CHANNELS, AUDIO_SAMPLE_RATE_HZ } from './audio-frame'
+
+const MAX_QUESTION_SECONDS = 30
+const MAX_PCM_BYTES = AUDIO_SAMPLE_RATE_HZ * AUDIO_BYTES_PER_SAMPLE * AUDIO_CHANNELS * MAX_QUESTION_SECONDS
+
+export class QuestionAudioBuffer {
+  private readonly chunks: Uint8Array[] = []
+  private byteLength = 0
+
+  push(pcm: Uint8Array): void {
+    if (pcm.byteLength % 2 !== 0) throw new Error('Question PCM has a partial sample')
+    if (this.byteLength + pcm.byteLength > MAX_PCM_BYTES) throw new Error('Question reached the 30 second limit')
+    this.chunks.push(pcm.slice())
+    this.byteLength += pcm.byteLength
+  }
+
+  toWav(): Blob {
+    const wav = new Uint8Array(44 + this.byteLength)
+    const view = new DataView(wav.buffer)
+    ascii(wav, 0, 'RIFF')
+    view.setUint32(4, 36 + this.byteLength, true)
+    ascii(wav, 8, 'WAVE')
+    ascii(wav, 12, 'fmt ')
+    view.setUint32(16, 16, true)
+    view.setUint16(20, 1, true)
+    view.setUint16(22, AUDIO_CHANNELS, true)
+    view.setUint32(24, AUDIO_SAMPLE_RATE_HZ, true)
+    view.setUint32(28, AUDIO_SAMPLE_RATE_HZ * AUDIO_CHANNELS * AUDIO_BYTES_PER_SAMPLE, true)
+    view.setUint16(32, AUDIO_CHANNELS * AUDIO_BYTES_PER_SAMPLE, true)
+    view.setUint16(34, 16, true)
+    ascii(wav, 36, 'data')
+    view.setUint32(40, this.byteLength, true)
+    let offset = 44
+    for (const chunk of this.chunks) {
+      wav.set(chunk, offset)
+      offset += chunk.byteLength
+    }
+    return new Blob([wav], { type: 'audio/wav' })
+  }
+
+  get durationSeconds(): number { return this.byteLength / (AUDIO_SAMPLE_RATE_HZ * AUDIO_CHANNELS * AUDIO_BYTES_PER_SAMPLE) }
+}
+
+function ascii(target: Uint8Array, offset: number, text: string): void {
+  for (let index = 0; index < text.length; index += 1) target[offset + index] = text.charCodeAt(index)
+}

--- a/integration-clients/even-g2-overlay/src/design-preview.ts
+++ b/integration-clients/even-g2-overlay/src/design-preview.ts
@@ -1,0 +1,15 @@
+// Dev-only entry (not a Vite production input). No SDK, microphone, token, or API.
+import { OpenAGIPhoneCompanion } from './ui/openagi-phone-companion'
+const noop = (): void => { phone.set('Design preview', 'Sample content only. No microphone or connection is active.') }
+let recording = false
+const phone = new OpenAGIPhoneCompanion({
+  pair: noop, ask: () => { recording = !recording; phone.interaction(recording ? 'recording' : 'idle'); phone.set(recording ? 'Listening…' : 'Ready', 'Design preview only · no microphone or connection'); phone.transcript(recording ? 'What should I focus on this afternoon?' : '') },
+  newConversation: noop, unlink: noop, connectAgent: noop, configureAmbient: noop,
+  configureInterface: style => phone.interfaceStyle(style), pauseLifelog: noop, returnToLifelog: noop,
+}, [])
+phone.paired(true); phone.interaction('idle')
+phone.set('Ready when you are.', 'Design preview · no microphone or connection')
+phone.readiness({ protocol: 1, recovery: true, history: true, mainRole: 'main', speech: { liveTranscriptionConfigured: true, transcriptionConfigured: true } }, 'Design preview — no main is connected.')
+phone.memoryStatus(false, 'Off. Turn on when you have participant consent.')
+phone.history([{ question: 'Help me plan my afternoon', at: new Date().toISOString() }])
+phone.inbox([{ id: 'preview', title: 'A coding task is ready for review', summary: 'Sample notification. Check the changes before deciding what happens next.', category: 'approvals', action: 'review-on-main', seen: false, important: false }])

--- a/integration-clients/even-g2-overlay/src/even/audio-source.ts
+++ b/integration-clients/even-g2-overlay/src/even/audio-source.ts
@@ -1,0 +1,38 @@
+import { AudioInputSource, type EvenAppBridge } from '@evenrealities/even_hub_sdk'
+
+export interface AudioSource {
+  start(onPcm: (pcm: Uint8Array) => void): Promise<void>
+  stop(): Promise<void>
+  readonly active: boolean
+}
+
+export class EvenAudioSource implements AudioSource {
+  private unsubscribe: (() => void) | null = null
+  private isActive = false
+
+  constructor(private readonly bridge: EvenAppBridge) {}
+
+  async start(onPcm: (pcm: Uint8Array) => void): Promise<void> {
+    if (this.isActive) throw new Error('G2 microphone is already active')
+    this.unsubscribe = this.bridge.onEvenHubEvent(event => {
+      const pcm = event.audioEvent?.audioPcm
+      if (pcm && this.isActive) onPcm(pcm)
+    })
+    const opened = await this.bridge.audioControl(true, AudioInputSource.Glasses)
+    if (!opened) {
+      this.unsubscribe()
+      this.unsubscribe = null
+      throw new Error('G2 microphone permission or connection is unavailable')
+    }
+    this.isActive = true
+  }
+
+  async stop(): Promise<void> {
+    this.isActive = false
+    this.unsubscribe?.()
+    this.unsubscribe = null
+    await this.bridge.audioControl(false)
+  }
+
+  get active(): boolean { return this.isActive }
+}

--- a/integration-clients/even-g2-overlay/src/even/display-controller.ts
+++ b/integration-clients/even-g2-overlay/src/even/display-controller.ts
@@ -1,0 +1,68 @@
+import {
+  CreateStartUpPageContainer,
+  TextContainerProperty,
+  TextContainerUpgrade,
+  type EvenAppBridge,
+  StartUpPageCreateResult,
+} from '@evenrealities/even_hub_sdk'
+
+export interface DisplaySurface {
+  initialize(content: string): Promise<void>
+  show(content: string, immediate?: boolean): void
+}
+
+export class EvenDisplayController implements DisplaySurface {
+  private last = ''
+  private pending = ''
+  private timer: number | null = null
+  private initialized = false
+
+  constructor(private readonly bridge: EvenAppBridge, private readonly debounceMs = 160) {}
+
+  async initialize(content: string): Promise<void> {
+    const result = await this.bridge.createStartUpPageContainer(new CreateStartUpPageContainer({
+      containerTotalNum: 1,
+      textObject: [new TextContainerProperty({
+        xPosition: 0,
+        yPosition: 0,
+        width: 576,
+        height: 288,
+        borderWidth: 0,
+        borderColor: 5,
+        paddingLength: 4,
+        containerID: 1,
+        containerName: 'buildbetter',
+        content,
+        isEventCapture: 1,
+      })],
+    }))
+    if (result !== StartUpPageCreateResult.success) throw new Error(`Could not create G2 display (${result})`)
+    this.initialized = true
+    this.last = content
+    this.pending = content
+  }
+
+  show(content: string, immediate = false): void {
+    this.pending = content.slice(0, 500)
+    if (!this.initialized || this.pending === this.last) return
+    if (immediate) {
+      if (this.timer !== null) window.clearTimeout(this.timer)
+      this.timer = null
+      void this.render()
+      return
+    }
+    if (this.timer !== null) return
+    this.timer = window.setTimeout(() => { this.timer = null; void this.render() }, this.debounceMs)
+  }
+
+  private async render(): Promise<void> {
+    if (this.pending === this.last) return
+    const content = this.pending
+    const updated = await this.bridge.textContainerUpgrade(new TextContainerUpgrade({
+      containerID: 1,
+      containerName: 'buildbetter',
+      content,
+    }))
+    if (updated) this.last = content
+  }
+}

--- a/integration-clients/even-g2-overlay/src/even/input-controller.ts
+++ b/integration-clients/even-g2-overlay/src/even/input-controller.ts
@@ -1,0 +1,38 @@
+import { OsEventTypeList, type EvenAppBridge } from '@evenrealities/even_hub_sdk'
+
+export interface InputHandlers {
+  tap(): void
+  scrollUp(): void
+  scrollDown(): void
+  doubleTap(): void
+  systemExit(): void
+}
+
+export class EvenInputController {
+  private unsubscribe: (() => void) | null = null
+
+  constructor(private readonly bridge: EvenAppBridge, private readonly handlers: InputHandlers) {}
+
+  start(): void {
+    if (this.unsubscribe) return
+    this.unsubscribe = this.bridge.onEvenHubEvent(event => {
+      const types = [eventTypeOf(event.sysEvent), eventTypeOf(event.textEvent)].filter((value): value is OsEventTypeList => value !== null)
+      if (types.includes(OsEventTypeList.DOUBLE_CLICK_EVENT)) {
+        this.handlers.doubleTap()
+        void this.bridge.shutDownPageContainer(1)
+        return
+      }
+      if (types.includes(OsEventTypeList.CLICK_EVENT)) this.handlers.tap()
+      else if (types.includes(OsEventTypeList.SCROLL_TOP_EVENT)) this.handlers.scrollUp()
+      else if (types.includes(OsEventTypeList.SCROLL_BOTTOM_EVENT)) this.handlers.scrollDown()
+      else if (types.includes(OsEventTypeList.SYSTEM_EXIT_EVENT) || types.includes(OsEventTypeList.ABNORMAL_EXIT_EVENT)) this.handlers.systemExit()
+    })
+  }
+
+  stop(): void { this.unsubscribe?.(); this.unsubscribe = null }
+}
+
+export function eventTypeOf(envelope?: { eventType?: OsEventTypeList }): OsEventTypeList | null {
+  if (!envelope) return null
+  return envelope.eventType ?? OsEventTypeList.CLICK_EVENT
+}

--- a/integration-clients/even-g2-overlay/src/openagi-main.ts
+++ b/integration-clients/even-g2-overlay/src/openagi-main.ts
@@ -1,11 +1,5 @@
 import { waitForEvenAppBridge, type EvenAppBridge } from '@evenrealities/even_hub_sdk'
-import { G2App } from './app/g2-app'
 import { OpenAGIG2App } from './app/openagi-g2-app'
-import { BuildBetterApiClient } from './buildbetter/api-client'
-import { loadConfig, safeErrorMessage } from './config'
-import { EvenAudioSource } from './even/audio-source'
-import { EvenDisplayController } from './even/display-controller'
-import { EvenInputController } from './even/input-controller'
 import { OpenAGIApiClient } from './openagi/api-client'
 import { loadOpenAGIConfig, safeOpenAGIError } from './openagi/config'
 import { OpenAGIStore } from './openagi/store'
@@ -13,15 +7,13 @@ import { SerializedAudioSource } from './openagi/audio-source'
 import { AgentsInputController } from './openagi/input-controller'
 import { AgentsDisplayController } from './openagi/display-controller'
 import { EvenKeyValueStorage } from './openagi/persistent-storage'
-import { BrowserKeyValueStorage, RecoveryStore } from './storage/recovery-store'
-import { GlassesRenderer } from './ui/glasses-renderer'
+import { BrowserKeyValueStorage } from './storage/recovery-store'
 import { OpenAGIGlassesRenderer } from './ui/openagi-glasses-renderer'
 import { OpenAGIPhoneCompanion } from './ui/openagi-phone-companion'
-import { PhoneCompanion } from './ui/phone-companion'
+
 
 const bridge = await waitForEvenAppBridge()
-if (import.meta.env.VITE_G2_MODE === 'openagi') await launchOpenAGI(bridge)
-else await launchBuildBetter(bridge)
+await launchOpenAGI(bridge)
 
 async function launchOpenAGI(bridge: EvenAppBridge): Promise<void> {
   const config = loadOpenAGIConfig()
@@ -81,34 +73,5 @@ async function launchOpenAGI(bridge: EvenAppBridge): Promise<void> {
   input.start()
   try { await app.boot() }
   catch (error) { renderer.message('OpenAGI could not start', safeOpenAGIError(error)); phone.set('Startup failed', safeOpenAGIError(error)) }
-  bindExit(input, app)
-}
-
-async function launchBuildBetter(bridge: EvenAppBridge): Promise<void> {
-  const display = new EvenDisplayController(bridge)
-  await display.initialize('BuildBetter\n\nStarting…')
-  const renderer = new GlassesRenderer(display)
-  const store = new RecoveryStore(new BrowserKeyValueStorage())
-  let credential: string | null = null
-  let app!: G2App
-  const api = new BuildBetterApiClient(loadConfig(), () => credential ?? store.snapshot().deviceCredential)
-  const phone = new PhoneCompanion({
-    link: () => { void app.link() }, record: () => { void app.startRecording() }, ask: () => { void app.startAsk() },
-    live: () => { void app.startLive() }, unlink: () => { void app.unlink() },
-  })
-  app = new G2App(api, store, new EvenAudioSource(bridge), renderer, phone)
-  const input = bindInput(bridge, app)
-  try { await app.boot(); credential = store.snapshot().deviceCredential }
-  catch (error) { renderer.message('BuildBetter could not start', safeErrorMessage(error)); phone.set('Startup failed', safeErrorMessage(error)) }
-  bindExit(input, app)
-}
-
-interface G2InputTarget { tap(): void; scrollUp(): void; scrollDown(): void; doubleTap(): void; systemExit(): Promise<void> }
-function bindInput(bridge: EvenAppBridge, app: G2InputTarget): EvenInputController {
-  const input = new EvenInputController(bridge, { tap: () => app.tap(), scrollUp: () => app.scrollUp(), scrollDown: () => app.scrollDown(), doubleTap: () => app.doubleTap(), systemExit: () => { void app.systemExit() } })
-  input.start()
-  return input
-}
-function bindExit(input: { stop(): void }, app: G2InputTarget): void {
   window.addEventListener('beforeunload', () => { input.stop(); void app.systemExit() })
 }

--- a/integration-clients/even-g2-overlay/src/openagi/-tests/display-controller.test.ts
+++ b/integration-clients/even-g2-overlay/src/openagi/-tests/display-controller.test.ts
@@ -6,8 +6,8 @@ afterEach(() => vi.useRealTimers())
 
 async function fixture() {
   const bridge = {
-    createStartUpPageContainer: vi.fn(async () => StartUpPageCreateResult.success),
-    textContainerUpgrade: vi.fn(async (_value: unknown) => true),
+    createStartUpPageContainer: vi.fn(() => Promise.resolve(StartUpPageCreateResult.success)),
+    textContainerUpgrade: vi.fn((value: unknown) => { void value; return Promise.resolve(true) }),
   }
   const display = new AgentsDisplayController(bridge as never)
   await display.initialize('Starting')
@@ -63,7 +63,7 @@ it('clears an in-flight dot before sleeping and restores it on the next active r
   display.show(' ', true)
   finish(true)
   await vi.waitFor(() => expect(bridge.textContainerUpgrade).toHaveBeenLastCalledWith(expect.objectContaining({ containerID: 2, content: ' ' })))
-  bridge.textContainerUpgrade.mockImplementation(async () => true)
+  bridge.textContainerUpgrade.mockImplementation(() => Promise.resolve(true))
   display.show('●', true, true)
   await vi.waitFor(() => expect(bridge.textContainerUpgrade).toHaveBeenLastCalledWith(expect.objectContaining({ containerID: 2, content: '●' })))
 })

--- a/integration-clients/even-g2-overlay/src/openagi/-tests/experience.test.ts
+++ b/integration-clients/even-g2-overlay/src/openagi/-tests/experience.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, expect, it, vi } from 'vitest'
+import { parseConnectionCard } from '../connection-card'
+import { OpenAGIStore } from '../store'
+import { G2ExperienceClient, type RequestReceipt } from '../experience-client'
+import { OpenAGIApiError } from '../config'
+import { OpenAGIPhoneCompanion } from '../../ui/openagi-phone-companion'
+
+beforeEach(() => { document.body.innerHTML = '<div id="app"></div>' })
+function storeFixture(): OpenAGIStore {
+  const values = new Map<string, string>()
+  return new OpenAGIStore({ get: key => Promise.resolve(values.get(key) ?? null), set: (key, value) => { values.set(key, value); return Promise.resolve() }, remove: key => { values.delete(key); return Promise.resolve() } })
+}
+it('connection cards reject token fields, expired codes, non-HTTPS and credential URLs', () => {
+  const base = { format: 'openagi-g2', version: 1, origin: 'https://main.example.test', code: '000123', expiresAt: new Date(Date.now() + 60_000).toISOString() }
+  expect(parseConnectionCard(JSON.stringify(base)).code).toBe('000123')
+  for (const patch of [{ token: 'do-not-transfer' }, { origin: 'http://main.test' }, { origin: 'https://owner:secret@main.test' }, { origin: 'https://main.test/path' }, { expiresAt: '2000-01-01T00:00:00.000Z' }]) expect(() => parseConnectionCard(JSON.stringify({ ...base, ...patch }))).toThrow()
+})
+it('Classic round-trips the same controls without changing consent, credential, or draft', () => {
+  const ask = vi.fn()
+  const phone = new OpenAGIPhoneCompanion({ pair: vi.fn(), ask, newConversation: vi.fn(), unlink: vi.fn(), connectAgent: vi.fn(), configureAmbient: vi.fn() }, [])
+  phone.paired(true); phone.interaction('idle')
+  const consent = document.querySelector<HTMLInputElement>('#recording-consent')!
+  consent.checked = true
+  phone.draft('saved words')
+  for (let n = 0; n < 3; n++) { phone.interfaceStyle('classic'); phone.interfaceStyle('focused') }
+  expect(document.querySelector('#recording-consent')).toBe(consent)
+  expect(consent.checked).toBe(true); expect(document.querySelector('#draft-text')?.textContent).toBe('saved words')
+  expect(document.querySelectorAll('#draft-review')).toHaveLength(1)
+  document.querySelector<HTMLButtonElement>('[data-action="ask"]')!.click(); expect(ask).toHaveBeenCalledOnce()
+  expect([...document.querySelectorAll('.experience-nav button')].map(b => b.textContent)).toEqual(['Talk', 'Inbox', 'History', '⚙'])
+  document.querySelector<HTMLButtonElement>('#read-lifelog')!.click()
+  document.querySelector<HTMLButtonElement>('#lifelog-close')!.click()
+  expect(document.querySelector<HTMLElement>('.history-page')!.hidden).toBe(false)
+  phone.history([{ question: 'Saved question', at: new Date().toISOString() }])
+  document.querySelector<HTMLButtonElement>('[data-answer]')!.click()
+  expect(document.querySelector<HTMLElement>('.talk-page')!.hidden).toBe(false)
+})
+it('serialized preferences retain overlapping updates and explicit lifelog pause on reload', async () => {
+  const store = storeFixture()
+  await Promise.all([store.update({ interfaceStyle: 'classic' }), store.update({ lifelogPaused: true }), store.update({ savedDraft: 'keep me' })])
+  await store.load()
+  expect(store.snapshot()).toMatchObject({ interfaceStyle: 'classic', lifelogPaused: true, savedDraft: 'keep me' })
+})
+it('an uncertain submission persists one identity, and checking it does not create work', async () => {
+  const store = storeFixture(); const conversationId = crypto.randomUUID(); await store.update({ conversationId })
+  let requestId = ''
+  const send = vi.fn((body: object) => {
+    const request = body as { op: string; id: string }
+    if (request.op === 'submit') { requestId = request.id; return Promise.reject(new Error('lost acceptance')) }
+    return Promise.resolve({ id: requestId, state: 'completed', revision: 2, result: { question: 'hi', reply: 'hello', sessionId: 'test' } })
+  })
+  const client = new G2ExperienceClient(store, send as never, () => 'https://main.example.test')
+  await expect(client.submit({ text: 'hi', conversationId }, undefined)).rejects.toThrow('lost acceptance')
+  expect(store.snapshot().pendingRequest?.id).toBe(requestId)
+  await client.resume(undefined)
+  expect(send.mock.calls.map(call => (call[0] as { op: string }).op)).toEqual(['submit', 'get'])
+  expect(store.snapshot().pendingRequest).toBeNull()
+})
+it('only explicit retry can submit a not-yet-accepted request, with the original id', async () => {
+  const store = storeFixture(), id = `${Date.now()}_${crypto.randomUUID()}`
+  await store.update({ pendingRequest: { id, text: 'hi', conversationId: crypto.randomUUID(), continuation: null, origin: 'https://main.example.test' } })
+  const send = vi.fn((body: object): Promise<RequestReceipt> => {
+    const request = body as { op: string; id: string }
+    if (request.op === 'get') return Promise.reject(new OpenAGIApiError('request_not_found', 404, 'not accepted'))
+    expect(request.id).toBe(id)
+    return Promise.resolve({ id, state: 'completed', revision: 2, result: { question: 'hi', reply: 'hello', sessionId: 'test' } })
+  })
+  const client = new G2ExperienceClient(store, send as never, () => 'https://main.example.test')
+  await expect(client.resume(undefined)).rejects.toThrow('not accepted')
+  expect(send).toHaveBeenCalledOnce()
+  await client.resume(undefined, undefined, true)
+  expect(send.mock.calls.map(call => (call[0] as { op: string }).op)).toEqual(['get', 'get', 'submit'])
+})

--- a/integration-clients/even-g2-overlay/src/openagi/-tests/live-app.test.ts
+++ b/integration-clients/even-g2-overlay/src/openagi/-tests/live-app.test.ts
@@ -265,24 +265,22 @@ it('opening a recent answer preserves active lifelog consent and microphone', as
   } finally { await f.app.systemExit() }
 })
 
-it('resumes paused lifelog on glasses only after explicit participant consent', async () => {
+it('keeps an explicit pause until Resume and reuses only main-validated consent', async () => {
   vi.useFakeTimers()
   const f = await fixture()
-  const proactive = vi.fn((b: { op: string; enabled?: boolean }) => Promise.resolve(b.op === 'consent' && b.enabled ? { consent: { id: 'retention', until: Date.now() + 60000 } } : { items: [] }))
+  const consent = { id: 'retention', until: Date.now() + 60000 }
+  const proactive = vi.fn((b: { op: string; enabled?: boolean }) => Promise.resolve((b.op === 'consent' && b.enabled) || b.op === 'settings' ? { consent } : { items: [] }))
   Object.assign(f.api, { proactive })
   try {
     await f.app.configureMemory(true, true)
     f.app.scrollDown(); f.app.tap(); await vi.advanceTimersByTimeAsync(500)
     expect(f.renderer.paused).toHaveBeenLastCalledWith(true)
     expect(f.app.proactive.memoryActive).toBe(false)
+    expect(f.store.snapshot().lifelogPaused).toBe(true)
     f.audio.start.mockClear(); proactive.mockClear()
-    f.app.tap()
-    expect(f.renderer.paused).toHaveBeenLastCalledWith(true, true)
-    expect(f.audio.start).not.toHaveBeenCalled()
-    f.app.doubleTap(); await vi.advanceTimersByTimeAsync(500)
-    expect(f.renderer.paused).toHaveBeenLastCalledWith(true)
+    f.app.tap(); await vi.advanceTimersByTimeAsync(500)
     expect(proactive.mock.calls.some(([b]) => b.op === 'consent' && b.enabled)).toBe(false)
-    f.app.tap(); await vi.advanceTimersByTimeAsync(500); f.app.tap(); await vi.advanceTimersByTimeAsync(1)
+    expect(proactive.mock.calls.some(([b]) => b.op === 'settings')).toBe(true)
     expect(f.audio.start).toHaveBeenCalledOnce()
     expect(f.app.proactive.memoryActive).toBe(true)
     expect(f.renderer.passive).toHaveBeenLastCalledWith(true, false, 'open agi')
@@ -759,7 +757,7 @@ it('triggers once from finalized wake speech, keeps interim words live during ag
   f.callbacks().transcript('Peri what time', false, 50)
   expect(f.api.askText).not.toHaveBeenCalled()
   f.callbacks().utterance('Peri'); f.callbacks().utterance('What time is it?')
-  expect(f.api.askText).toHaveBeenCalledOnce()
+  await vi.waitFor(() => expect(f.api.askText).toHaveBeenCalledOnce())
   f.callbacks().transcript('More speech', false, 30); f.callbacks().utterance('Peri do another thing')
   expect(f.phone.transcript).toHaveBeenLastCalledWith('More speech')
   expect(f.api.askText).toHaveBeenCalledOnce()

--- a/integration-clients/even-g2-overlay/src/openagi/-tests/pairing-recovery.test.ts
+++ b/integration-clients/even-g2-overlay/src/openagi/-tests/pairing-recovery.test.ts
@@ -4,12 +4,12 @@ import { OpenAGIPhoneCompanion } from '../../ui/openagi-phone-companion'
 import { OpenAGIStore } from '../store'
 
 it('reuses pending credentials after lost responses and ignores Pair once enrolled', async () => {
-  const store = new OpenAGIStore({ get: async () => null, set: async () => undefined, remove: async () => undefined })
+  const store = new OpenAGIStore({ get: () => Promise.resolve(null), set: () => Promise.resolve(), remove: () => Promise.resolve() })
   const enroll = vi.fn().mockRejectedValueOnce(new Error('lost')).mockRejectedValueOnce(new Error('lost'))
-    .mockImplementation(async (_code: string, id: string, token: string) => ({ nodeToken: token, node: { id, name: 'G2', platform: 'even_g2', enrolledAt: new Date().toISOString() } }))
+    .mockImplementation((_code: string, id: string, token: string) => Promise.resolve({ nodeToken: token, node: { id, name: 'G2', platform: 'even_g2', enrolledAt: new Date().toISOString() } }))
   type Args = ConstructorParameters<typeof OpenAGIG2App>
   const app = new OpenAGIG2App(
-    { enroll, heartbeat: async () => ({ ok: true }) } as unknown as Args[0], store,
+    { enroll, heartbeat: () => Promise.resolve({ ok: true }) } as unknown as Args[0], store,
     { active: false, stop: () => Promise.resolve() } as Args[2],
     { pairing: vi.fn(), message: vi.fn(), home: vi.fn() } as unknown as Args[3],
     { set: vi.fn(), paired: vi.fn() } as unknown as Args[4], [],

--- a/integration-clients/even-g2-overlay/src/openagi/-tests/phone-companion.test.ts
+++ b/integration-clients/even-g2-overlay/src/openagi/-tests/phone-companion.test.ts
@@ -123,13 +123,13 @@ it('keeps memory separate from wake listening and renders inbox evidence safely'
 it('exposes auto-send and labels Talk and Stop according to the saved setting', () => {
   const configureAutoSend = vi.fn()
   const phone = new OpenAGIPhoneCompanion({ pair: vi.fn(), ask: vi.fn(), newConversation: vi.fn(), unlink: vi.fn(), connectAgent: vi.fn(), configureAmbient: vi.fn(), configureAutoSend }, [])
-  phone.autoSend(true); phone.set('Recording question · live', '')
-  expect(document.querySelector('[data-action="ask"]')?.textContent).toBe('Stop talking · send')
+  phone.autoSend(true); phone.interaction('recording'); phone.set('Any translated status', '')
+  expect(document.querySelector('[data-action="ask"]')?.textContent).toBe('Stop & send')
   document.querySelector<HTMLInputElement>('#auto-send')?.click()
   expect(configureAutoSend).toHaveBeenCalledWith(false)
-  phone.autoSend(false); phone.set('Recording question', '')
-  expect(document.querySelector('[data-action="ask"]')?.textContent).toBe('Stop talking · review')
-  phone.set('Ready', '')
+  phone.autoSend(false)
+  expect(document.querySelector('[data-action="ask"]')?.textContent).toBe('Stop & review')
+  phone.interaction('idle'); phone.set('Ready', '')
   expect(document.querySelector('[data-action="ask"]')?.textContent).toBe('Talk')
 })
 function fixture() {

--- a/integration-clients/even-g2-overlay/src/openagi/-tests/proactive.test.ts
+++ b/integration-clients/even-g2-overlay/src/openagi/-tests/proactive.test.ts
@@ -32,10 +32,10 @@ it('coalesces rapid final events from one speaker without losing stream metadata
   f.client.stop()
 })
 function fixture() {
-  const api = { proactive: vi.fn(async (body: { op: string }) => body.op === 'consent' ? { consent: { id: 'session-consent', until: Date.now() + 3600_000 } } : ['notify', 'can-notify'].includes(body.op) ? { notify: true } : {
+  const api = { proactive: vi.fn((body: { op: string }) => Promise.resolve(body.op === 'consent' ? { consent: { id: 'session-consent', until: Date.now() + 3600_000 } } : ['notify', 'can-notify'].includes(body.op) ? { notify: true } : {
     settings: { enabled: true, categories: ['approvals'], retentionDays: 1, quietStart: 22, quietEnd: 8, timeZone: 'UTC', maxPerHour: 3 },
     quiet: false, items: [{ id: 'approval', title: 'Review needed', summary: 'Open main', important: true, seen: false, action: 'review-on-main', category: 'approvals' }],
-  }) }
+  })) }
   const view = { activity: vi.fn(), memoryStatus: vi.fn(), inbox: vi.fn(), proactiveSettings: vi.fn() }, notify = vi.fn(), idle = vi.fn(() => false)
   const client = new G2ProactiveClient(api as unknown as ConstructorParameters<typeof G2ProactiveClient>[0], view, idle, notify)
   return { api, view, client, notify, idle }
@@ -81,7 +81,7 @@ it('delivers an idle alert only after server permission and releases timers on e
 
 it('failed capture pauses memory without replaying audio or text', async () => {
   vi.useFakeTimers(); const f = fixture(); f.client.start(); await f.client.enableMemory(true)
-  f.api.proactive.mockImplementation(async body => { if (body.op === 'capture') throw new Error('offline'); return { items: [] } as never })
+  f.api.proactive.mockImplementation(body => body.op === 'capture' ? Promise.reject(new Error('offline')) : Promise.resolve({ items: [] } as never))
   f.client.capture('Remember to call the team'); await vi.advanceTimersByTimeAsync(120000)
   expect(f.api.proactive.mock.calls.filter(([b]) => b.op === 'capture')).toHaveLength(1)
   expect(f.view.memoryStatus).toHaveBeenLastCalledWith(false, expect.stringContaining('upload failed')); f.client.stop()

--- a/integration-clients/even-g2-overlay/src/openagi/-tests/question-recording.test.ts
+++ b/integration-clients/even-g2-overlay/src/openagi/-tests/question-recording.test.ts
@@ -51,10 +51,10 @@ it('auto-send uploads buffered audio once without a separate transcription reque
 
 it('defaults older pairings to auto-send and persists explicit confirmation preference', async () => {
   let saved: string | null = null
-  const storage = { get: async () => saved, set: async (_key: string, value: string) => { saved = value }, remove: async () => {} }
+  const storage = { get: () => Promise.resolve(saved), set: (_key: string, value: string) => { saved = value; return Promise.resolve() }, remove: () => Promise.resolve() }
   const store = new OpenAGIStore(storage)
   await store.update({ nodeToken: 'test-scoped-token-1234' })
-  const legacy = JSON.parse(saved!); delete legacy.autoSend; saved = JSON.stringify(legacy)
+  const legacy = JSON.parse(saved!) as Record<string, unknown>; delete legacy.autoSend; saved = JSON.stringify(legacy)
   const reopened = new OpenAGIStore(storage)
   expect((await reopened.load()).autoSend).toBe(true)
   await reopened.update({ autoSend: false })
@@ -239,6 +239,7 @@ it('streams tool history without stealing answer pages and confirms cancellation
   try {
     await app.startAsk(); receive(new Uint8Array(32000)); await app.finishAsk()
     const request = app.sendDraft()
+    await vi.advanceTimersByTimeAsync(0) // Persist delivery state before sending.
     progress({ type: 'progress', stage: 'tool', tool: 'computer_list_apps' })
     progress({ type: 'progress', stage: 'model' })
     expect(renderer.progress).toHaveBeenLastCalledWith('Thinking', expect.any(String), '', expect.stringContaining('Tool: computer_list_apps'))

--- a/integration-clients/even-g2-overlay/src/openagi/api-client.ts
+++ b/integration-clients/even-g2-overlay/src/openagi/api-client.ts
@@ -1,6 +1,8 @@
 import type { OpenAGIConfig } from './config'
 import { OpenAGIApiError } from './config'
 import type { InboxItem, ProactiveSettings } from './proactive'
+import type { OpenAGIStore } from './store'
+import { G2ExperienceClient, type G2Capabilities, type G2History } from './experience-client'
 
 type Fetch = typeof fetch
 export interface OpenAGINode {
@@ -21,6 +23,21 @@ const CAPABILITIES = [
 ]
 
 export class OpenAGIApiClient {
+  private experienceClient: G2ExperienceClient | null = null
+  async configureExperience(store: OpenAGIStore): Promise<G2Capabilities | null> {
+    this.experienceClient = new G2ExperienceClient(store, (body, signal) => this.json('/nodes/g2/experience', {
+      method: 'POST', body: JSON.stringify(body), signal: signal ? AbortSignal.any([signal, AbortSignal.timeout(12_000)]) : AbortSignal.timeout(6000),
+    }), () => this.validatedOrigin())
+    return this.experienceClient.probe()
+  }
+  resumePending(progress: (event: AskProgress) => void, signal: AbortSignal, allowSubmit = false): Promise<OpenAGIAskResult> {
+    if (!this.experienceClient) throw new OpenAGIApiError('recovery_unavailable', 503, 'Reconnect to main to check this saved question.')
+    return this.experienceClient.resume(progress, signal, allowSubmit)
+  }
+  async cancelPending(): Promise<void> { await this.experienceClient?.cancel() }
+  readHistory(continuation?: string, offset = 0, query = ''): Promise<G2History> {
+    return this.json('/nodes/g2/experience', { method: 'POST', body: JSON.stringify({ op: 'history', ...(continuation ? { continuation } : {}), offset, query }), signal: AbortSignal.timeout(10_000) })
+  }
   proactive(body: object, signal?: AbortSignal): Promise<G2LifelogPage & { items?: InboxItem[]; settings?: ProactiveSettings; consent?: { id: string; until: number }; quiet?: boolean; notify?: boolean }> {
     return this.json('/nodes/g2/proactive', { method: 'POST', body: JSON.stringify(body), signal: signal ? AbortSignal.any([signal, AbortSignal.timeout(10_000)]) : AbortSignal.timeout(10_000) })
   }
@@ -62,6 +79,7 @@ export class OpenAGIApiClient {
     return this.json('/nodes/revoke', { method: 'POST', body: JSON.stringify({ nodeId: credential.nodeId }) })
   }
   async ask(wav: Blob, conversationId: string, progress?: (event: AskProgress) => void, signal?: AbortSignal): Promise<OpenAGIAskResult> {
+    if (this.experienceClient?.capabilities?.recovery) return this.experienceClient.submit({ audioBase64: await blobToBase64(wav), conversationId }, progress, signal)
     return this.json('/nodes/g2/ask', {
       method: 'POST',
       signal,
@@ -85,6 +103,7 @@ export class OpenAGIApiClient {
     return origin
   }
   askText(text: string, conversationId: string, progress: (event: AskProgress) => void, signal: AbortSignal): Promise<OpenAGIAskResult> {
+    if (this.experienceClient?.capabilities?.recovery) return this.experienceClient.submit({ text, conversationId }, progress, signal)
     return this.json('/nodes/g2/ask', { method: 'POST', signal, body: JSON.stringify({ text, conversationId }) }, true, progress)
   }
   async listen(wav: Blob, conversationId: string, options: { wakePhrase: string; answerQuestions: boolean; forceAnswer?: boolean }, signal?: AbortSignal): Promise<OpenAGIListenResult> {

--- a/integration-clients/even-g2-overlay/src/openagi/connection-card.ts
+++ b/integration-clients/even-g2-overlay/src/openagi/connection-card.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+import { AgentOriginSchema } from './config'
+
+const Card = z.object({ format: z.literal('openagi-g2'), version: z.literal(1), origin: AgentOriginSchema, code: z.string().regex(/^\d{6}$/), expiresAt: z.string().datetime() }).strict()
+export function parseConnectionCard(text: string, now = Date.now()): z.infer<typeof Card> {
+  if (text.length > 2048) throw new Error('Connection card is too long.')
+  let parsed: unknown
+  try { parsed = JSON.parse(text) } catch { throw new Error('Paste the complete connection card from OpenAGI on your main computer.') }
+  const result = Card.safeParse(parsed)
+  if (!result.success) throw new Error('That is not a valid connection card. It should contain a main HTTPS URL and one pairing code, never an owner token.')
+  const expiry = Date.parse(result.data.expiresAt)
+  if (expiry <= now || expiry > now + 31 * 60_000) throw new Error('This card expired or the phone clock is incorrect. Create a new card on main.')
+  return result.data
+}

--- a/integration-clients/even-g2-overlay/src/openagi/experience-client.ts
+++ b/integration-clients/even-g2-overlay/src/openagi/experience-client.ts
@@ -1,0 +1,83 @@
+import type { OpenAGIStore } from './store'
+import type { AskProgress, OpenAGIAskResult } from './api-client'
+import { OpenAGIApiError } from './config'
+
+export interface G2Capabilities { protocol: number; recovery: boolean; history: boolean; mainRole: string; speech: { transcriptionConfigured: boolean; liveTranscriptionConfigured: boolean } }
+export interface G2Conversation { continuation: string; title: string; preview: string; at: string }
+export interface G2History { conversations?: G2Conversation[]; messages?: { role: string; text: string; at: string }[]; nextOffset?: number | null; archivedOnMain?: boolean }
+export interface RequestReceipt { id: string; state: 'accepted' | 'working' | 'completed' | 'cancelled' | 'unconfirmed'; revision: number; stage?: string; tool?: string; question?: string; text?: string; message?: string; result?: OpenAGIAskResult; events?: { seq: number; stage: string; tool?: string }[] }
+type Send = <T>(body: object, signal?: AbortSignal) => Promise<T>
+
+export class G2ExperienceClient {
+  capabilities: G2Capabilities | null = null
+  constructor(private readonly store: OpenAGIStore, private readonly send: Send, private readonly origin: () => string) {}
+  async probe(): Promise<G2Capabilities | null> {
+    try {
+      const result = await this.send<G2Capabilities>({ op: 'capabilities' })
+      this.capabilities = result.protocol === 1 && result.recovery === true ? result : null
+    } catch (error) {
+      if (!(error instanceof OpenAGIApiError) || ![404, 405].includes(error.status)) throw error
+      this.capabilities = null
+    }
+    return this.capabilities
+  }
+  async submit(payload: { text?: string; audioBase64?: string; conversationId: string }, progress: ((event: AskProgress) => void) | undefined, signal?: AbortSignal): Promise<OpenAGIAskResult> {
+    if (this.store.snapshot().pendingRequest) throw new OpenAGIApiError('request_pending', 409, 'A saved question needs attention. Check its result before asking again.')
+    const id = `${Date.now()}_${crypto.randomUUID()}`, continuation = this.store.snapshot().continuation
+    await this.store.update({ pendingRequest: { id, conversationId: payload.conversationId, continuation, text: payload.text ?? null, origin: this.origin() }, savedDraft: '' })
+    const receipt = await this.send<RequestReceipt>({ op: 'submit', id, question: { ...payload, ...(continuation ? { continuation } : {}) } }, signal)
+    return this.observe(receipt, progress, signal)
+  }
+  async resume(progress: ((event: AskProgress) => void) | undefined, signal?: AbortSignal, allowSubmit = false): Promise<OpenAGIAskResult> {
+    const pending = this.store.snapshot().pendingRequest
+    if (!pending || pending.origin !== this.origin()) throw new OpenAGIApiError('no_pending_request', 404, 'No saved request belongs to this main.')
+    let receipt: RequestReceipt
+    try { receipt = await this.send<RequestReceipt>({ op: 'get', id: pending.id }, signal) }
+    catch (error) {
+      if (!(error instanceof OpenAGIApiError) || error.code !== 'request_not_found' || !allowSubmit || !pending.text) throw error
+      receipt = await this.send<RequestReceipt>({ op: 'submit', id: pending.id, question: { text: pending.text, conversationId: pending.conversationId, ...(pending.continuation ? { continuation: pending.continuation } : {}) } }, signal)
+    }
+    return this.observe(receipt, progress, signal)
+  }
+  async cancel(): Promise<void> {
+    const pending = this.store.snapshot().pendingRequest
+    if (!pending || pending.origin !== this.origin()) return
+    const receipt = await this.send<RequestReceipt>({ op: 'cancel', id: pending.id })
+    if (receipt.state === 'cancelled') await this.store.update({ pendingRequest: null })
+  }
+  private async observe(initial: RequestReceipt, progress: ((event: AskProgress) => void) | undefined, signal?: AbortSignal): Promise<OpenAGIAskResult> {
+    let receipt = initial, revision = -1, stage = '', text = '', sequence = 0
+    const stopAt = Date.now() + 310_000
+    for (;;) {
+      signal?.throwIfAborted()
+      if (receipt.revision !== revision) {
+        revision = receipt.revision
+        const next = `${receipt.stage}:${receipt.tool}`
+        const events = receipt.events?.filter(e => e.seq > sequence) ?? []
+        for (const event of events) { sequence = event.seq; progress?.({ type: 'progress', stage: event.stage, tool: event.tool, question: receipt.question }) }
+        if (!events.length && next !== stage) progress?.({ type: 'progress', stage: receipt.stage, tool: receipt.tool, question: receipt.question })
+        stage = next
+        if (receipt.text && receipt.text !== text) { text = receipt.text; progress?.({ type: 'delta', text, reset: true }) }
+      }
+      progress?.({ type: 'heartbeat' })
+      if (receipt.state === 'completed' && receipt.result) {
+        await this.store.update({ pendingRequest: null, savedDraft: '' })
+        return receipt.result
+      }
+      if (receipt.state === 'cancelled' || receipt.state === 'unconfirmed') throw new OpenAGIApiError(`request_${receipt.state}`, 409, receipt.message ?? 'Check History before sending another question.')
+      if (Date.now() > stopAt) throw new OpenAGIApiError('request_pending', 408, 'Main is still processing. Check saved request to reconnect; it will not send twice.')
+      await delay(1000, signal)
+      receipt = await this.send<RequestReceipt>({ op: 'get', id: receipt.id }, signal)
+    }
+  }
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) { reject(new DOMException('Observer stopped', 'AbortError')); return }
+    const finish = (): void => { signal?.removeEventListener('abort', abort); resolve() }
+    const timer = setTimeout(finish, ms)
+    const abort = (): void => { clearTimeout(timer); signal?.removeEventListener('abort', abort); reject(new DOMException('Observer stopped', 'AbortError')) }
+    signal?.addEventListener('abort', abort, { once: true })
+  })
+}

--- a/integration-clients/even-g2-overlay/src/openagi/proactive.ts
+++ b/integration-clients/even-g2-overlay/src/openagi/proactive.ts
@@ -136,7 +136,7 @@ export class G2ProactiveClient {
     this.uploading = true
     const segments = this.queue.splice(0, 10), texts = segments.map(s => s.text), generation = this.generation
     try {
-      await this.api.proactive({ op: 'capture', consentId: this.consent.id, batchId: crypto.randomUUID(), texts, segments: segments.map(({ text: _text, ...metadata }) => metadata) }, this.controller.signal)
+      await this.api.proactive({ op: 'capture', consentId: this.consent.id, batchId: crypto.randomUUID(), texts, segments: segments.map(s => ({ at: s.at, endAt: s.endAt, streamId: s.streamId, speaker: s.speaker })) }, this.controller.signal)
       if (generation === this.generation) {
         this.view.activity?.(`Saved ${texts.length} final transcript segment(s) to main; checking explicit commitments.`)
         this.view.saveStatus?.(`Saved on main at ${new Date().toLocaleTimeString()}`)

--- a/integration-clients/even-g2-overlay/src/openagi/store.ts
+++ b/integration-clients/even-g2-overlay/src/openagi/store.ts
@@ -7,6 +7,11 @@ const StateSchema = z.object({
   nodeToken: z.string().min(16).max(4_096).nullable(),
   node: z.object({ id: z.string().uuid(), name: z.string(), platform: z.literal('even_g2'), enrolledAt: z.string() }).nullable(),
   conversationId: z.string().uuid().nullable(),
+  continuation: z.string().max(200).nullable().default(null),
+  interfaceStyle: z.enum(['focused', 'classic']).default('focused'),
+  lifelogPaused: z.boolean().default(false),
+  savedDraft: z.string().max(4000).default(''),
+  pendingRequest: z.object({ id: z.string().max(80), conversationId: z.string().uuid(), continuation: z.string().max(200).nullable(), text: z.string().max(4000).nullable(), origin: z.string().url() }).nullable().default(null),
   ambientEnabled: z.boolean().default(false),
   lifelogEnabled: z.boolean().default(false),
   backgroundListening: z.boolean().default(false),
@@ -21,7 +26,7 @@ const StateSchema = z.object({
   autoSend: z.boolean().default(true),
   connectionMode: z.enum(['enrollment', 'direct']).default('enrollment'),
   agentOrigin: z.string().url().nullable().default(null),
-  history: z.array(z.object({ conversationId: z.string().uuid(), question: z.string(), reply: z.string(), at: z.string() })).max(30).default([]),
+  history: z.array(z.object({ conversationId: z.string().uuid(), continuation: z.string().max(200).nullable().default(null), question: z.string(), reply: z.string(), at: z.string() })).max(30).default([]),
 })
 export type OpenAGIState = z.infer<typeof StateSchema>
 const KEY = 'openagi.g2.state.v2'
@@ -29,6 +34,7 @@ const KEY = 'openagi.g2.state.v2'
 function empty(nodeId: string = crypto.randomUUID(), preferences?: Pick<OpenAGIState, 'ambientEnabled' | 'listeningMode' | 'idleTapAction' | 'lifelogTalkMode' | 'wakePhrase' | 'answerQuestions' | 'speechModel' | 'speechTransport' | 'autoSend'>): OpenAGIState {
   return {
     version: 2, nodeId, nodeToken: null, node: null, conversationId: null,
+    continuation: null, interfaceStyle: 'focused', lifelogPaused: false, savedDraft: '', pendingRequest: null,
     lifelogEnabled: false, lifelogConsent: null, backgroundListening: false,
     ambientEnabled: preferences?.ambientEnabled ?? false, wakePhrase: preferences?.wakePhrase ?? 'open agi',
     listeningMode: preferences?.listeningMode ?? 'passive',
@@ -44,6 +50,7 @@ function empty(nodeId: string = crypto.randomUUID(), preferences?: Pick<OpenAGIS
 
 export class OpenAGIStore {
   private state: OpenAGIState = empty()
+  private writes: Promise<void> = Promise.resolve()
   constructor(private readonly storage: KeyValueStorage) {}
   async load(): Promise<OpenAGIState> {
     const raw = await this.storage.get(KEY)
@@ -54,19 +61,29 @@ export class OpenAGIStore {
   snapshot(): OpenAGIState { return structuredClone(this.state) }
   async remember(question: string, reply: string): Promise<void> {
     if (!this.state.conversationId) return
-    await this.update({ history: [...this.state.history, { conversationId: this.state.conversationId, question: question.slice(0, 4000), reply: reply.slice(0, 16000), at: new Date().toISOString() }].slice(-30) })
+    await this.update({ history: [...this.state.history, { conversationId: this.state.conversationId, continuation: this.state.continuation, question: question.slice(0, 4000), reply: reply.slice(0, 16000), at: new Date().toISOString() }].slice(-30) })
   }
-  async update(patch: Partial<Omit<OpenAGIState, 'version'>>): Promise<OpenAGIState> {
+  update(patch: Partial<Omit<OpenAGIState, 'version'>>): Promise<OpenAGIState> {
+    const savedPatch = structuredClone(patch)
+    const result = this.writes.then(() => this.persistUpdate(savedPatch))
+    this.writes = result.then(() => undefined, () => undefined)
+    return result
+  }
+  private async persistUpdate(patch: Partial<Omit<OpenAGIState, 'version'>>): Promise<OpenAGIState> {
     const changedMain = patch.agentOrigin !== undefined && patch.agentOrigin !== this.state.agentOrigin
     const changedCredential = patch.nodeToken !== undefined && patch.nodeToken !== this.state.nodeToken
-    const next = StateSchema.parse({ ...this.state, ...patch, ...(changedMain ? { history: [] } : {}), ...(changedMain || changedCredential ? { lifelogEnabled: false, lifelogConsent: null, backgroundListening: false } : {}), version: 2 })
+    const next = StateSchema.parse({ ...this.state, ...patch, ...(changedMain || changedCredential ? { history: [], continuation: null, pendingRequest: null, savedDraft: '', lifelogEnabled: false, lifelogPaused: false, lifelogConsent: null, backgroundListening: false } : {}), version: 2 })
     await this.storage.set(KEY, JSON.stringify(next))
     this.state = next
     return this.snapshot()
   }
   async clearCredential(): Promise<void> {
-    const next = empty(this.state.nodeId, this.state)
-    await this.storage.set(KEY, JSON.stringify(next))
-    this.state = next
+    const result = this.writes.then(async () => {
+      const next = empty(this.state.nodeId, this.state)
+      await this.storage.set(KEY, JSON.stringify(next))
+      this.state = next
+    })
+    this.writes = result.catch(() => undefined)
+    await result
   }
 }

--- a/integration-clients/even-g2-overlay/src/state/ask-state-machine.ts
+++ b/integration-clients/even-g2-overlay/src/state/ask-state-machine.ts
@@ -1,0 +1,28 @@
+export type AskState =
+  | { kind: 'idle' }
+  | { kind: 'capturing'; elapsedMs: number }
+  | { kind: 'transcribing' }
+  | { kind: 'answering'; question: string; answer: string; scope: string | null }
+  | { kind: 'answered'; question: string; pages: string[]; page: number; scope: string | null }
+  | { kind: 'error'; message: string }
+
+export function paginateText(text: string, maxCharacters = 420): string[] {
+  const normalized = text.replace(/\s+/g, ' ').trim()
+  if (!normalized) return ['No answer was returned.']
+  const pages: string[] = []
+  let remaining = normalized
+  while (remaining.length > maxCharacters) {
+    const candidate = remaining.slice(0, maxCharacters + 1)
+    const breakAt = Math.max(candidate.lastIndexOf(' '), maxCharacters > 40 ? maxCharacters - 40 : 1)
+    const safeBreak = avoidSurrogateSplit(remaining, Math.min(breakAt, maxCharacters))
+    pages.push(remaining.slice(0, safeBreak).trim())
+    remaining = remaining.slice(safeBreak).trim()
+  }
+  if (remaining) pages.push(remaining)
+  return pages
+}
+
+function avoidSurrogateSplit(text: string, index: number): number {
+  const code = text.charCodeAt(index - 1)
+  return code >= 0xd800 && code <= 0xdbff ? index - 1 : index
+}

--- a/integration-clients/even-g2-overlay/src/storage/recovery-store.ts
+++ b/integration-clients/even-g2-overlay/src/storage/recovery-store.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod'
+
+const StoredStateSchema = z.object({
+  version: z.literal(1),
+  deviceCredential: z.string().min(32).nullable(),
+  device: z.object({
+    id: z.string().uuid(),
+    displayName: z.string(),
+    workspace: z.object({ id: z.string(), name: z.string() }),
+  }).nullable(),
+  activeSession: z.object({
+    sessionId: z.string().uuid(),
+    recordingId: z.string().uuid(),
+    idempotencyKey: z.string().uuid(),
+    nextSequence: z.number().int().nonnegative(),
+    startedAt: z.string(),
+  }).nullable(),
+  liveCursor: z.string().nullable(),
+  liveRecordingId: z.string().uuid().nullable().default(null),
+})
+
+export type StoredState = z.infer<typeof StoredStateSchema>
+
+export interface KeyValueStorage {
+  get(key: string): Promise<string | null>
+  set(key: string, value: string): Promise<void>
+  remove(key: string): Promise<void>
+}
+
+const KEY = 'buildbetter.g2.state.v1'
+const EMPTY: StoredState = { version: 1, deviceCredential: null, device: null, activeSession: null, liveCursor: null, liveRecordingId: null }
+
+export class RecoveryStore {
+  private state: StoredState = structuredClone(EMPTY)
+
+  constructor(private readonly storage: KeyValueStorage) {}
+
+  async load(): Promise<StoredState> {
+    const raw = await this.storage.get(KEY)
+    if (!raw) return this.snapshot()
+    try {
+      this.state = StoredStateSchema.parse(JSON.parse(raw))
+    } catch {
+      await this.storage.remove(KEY)
+      this.state = structuredClone(EMPTY)
+    }
+    return this.snapshot()
+  }
+
+  snapshot(): StoredState {
+    return structuredClone(this.state)
+  }
+
+  async update(patch: Partial<Omit<StoredState, 'version'>>): Promise<StoredState> {
+    this.state = StoredStateSchema.parse({ ...this.state, ...patch, version: 1 })
+    await this.storage.set(KEY, JSON.stringify(this.state))
+    return this.snapshot()
+  }
+
+  async clear(): Promise<void> {
+    this.state = structuredClone(EMPTY)
+    await this.storage.remove(KEY)
+  }
+}
+
+export class BrowserKeyValueStorage implements KeyValueStorage {
+  get(key: string): Promise<string | null> { return Promise.resolve(localStorage.getItem(key)) }
+  set(key: string, value: string): Promise<void> { localStorage.setItem(key, value); return Promise.resolve() }
+  remove(key: string): Promise<void> { localStorage.removeItem(key); return Promise.resolve() }
+}

--- a/integration-clients/even-g2-overlay/src/ui/openagi-glasses-renderer.ts
+++ b/integration-clients/even-g2-overlay/src/ui/openagi-glasses-renderer.ts
@@ -52,7 +52,7 @@ export class OpenAGIGlassesRenderer {
   thinking(question?: string): void { this.show(`Ask agent\n\n${question ? tail(question, 300) : 'Transcribing your question…'}\n\nThinking…`, true) }
   review(text: string, page: number, pages: number, recovery?: 'speech' | 'delivery'): void {
     const title = recovery === 'delivery' ? 'Delivery uncertain · may repeat actions' : recovery === 'speech' ? 'Recovered · check missing words · not sent' : 'Review question · not sent'
-    this.show(`${title}\n\n${text}\n\n${page + 1}/${pages} · Swipe to read\nTap: ${recovery === 'delivery' ? 'send again' : 'send'} · Double-tap: discard`, true)
+    this.show(`${title}\n\n${text}\n\n${page + 1}/${pages} · Swipe to read\nTap: ${recovery === 'delivery' ? 'send again' : 'send'} · Double-tap: back (keeps draft)`, true)
   }
   confirmCancel(): void {
     this.show('Stop this request?\n\nCompleted actions cannot be undone.\n\nTap: stop request\nDouble-tap: keep waiting', true)

--- a/integration-clients/even-g2-overlay/src/ui/openagi-phone-companion.ts
+++ b/integration-clients/even-g2-overlay/src/ui/openagi-phone-companion.ts
@@ -1,5 +1,10 @@
 import type { SpeechModel } from '../openagi/live-speech'
 import type { InboxItem, InboxOperation, ProactiveSettings } from '../openagi/proactive'
+import { PhoneExperience, experienceStyles } from './phone-experience'
+import { parseConnectionCard } from '../openagi/connection-card'
+import type { G2Capabilities, G2History } from '../openagi/experience-client'
+
+export type PhoneInteraction = 'idle' | 'recording' | 'review' | 'working' | 'unavailable'
 
 export interface OpenAGIPhoneActions {
   pair(code: string, origin: string): void
@@ -33,6 +38,12 @@ export interface OpenAGIPhoneActions {
   configureLifelogTalkMode?(mode: 'tap' | 'hold'): void
   configureBackgroundListening?(enabled: boolean): void
   retryListening?(): void
+  configureInterface?(style: 'focused' | 'classic'): void
+  pauseLifelog?(): void
+  resumeRequest?(): void
+  dismissRequest?(): void
+  readHistory?(continuation?: string, offset?: number, query?: string): void
+  continueHistory?(continuation: string): void
 }
 
 export class OpenAGIPhoneCompanion {
@@ -44,6 +55,11 @@ export class OpenAGIPhoneCompanion {
   private lifelogNext: number | null = null
   private lifelogOffset = 0
   private lifelogQuery = ''
+  private experience: PhoneExperience
+  private interactionState: PhoneInteraction = 'unavailable'
+  private requestInProgress = false
+  private historyContinuation: string | undefined
+  private historyNext: number | null = null
 
   constructor(actions: OpenAGIPhoneActions, allowedOrigins: string[]) {
     const root = document.querySelector<HTMLDivElement>('#app')
@@ -51,9 +67,13 @@ export class OpenAGIPhoneCompanion {
     root.innerHTML = `
       <main class="shell">
         <header><div class="brand">Agents</div><div class="eyebrow">Even G2</div></header>
+        <label class="interface-switch">Interface<select id="interface-style"><option value="focused">Focused · new</option><option value="classic">Classic</option></select></label>
         <section class="card" role="status" aria-live="polite"><h1 id="status">Starting…</h1><p id="detail">Connecting to your agent.</p></section>
         <section id="pair" class="pair">
           <h2>Connect to your OpenAGI main</h2>
+          <p>Already have OpenAGI? On your main computer, open <strong>Connect glasses</strong> at /g2/connect. Paste its connection card below.</p>
+          <label for="connection-card">Connection card</label><textarea id="connection-card" autocomplete="off" placeholder="Paste your connection card"></textarea><button id="read-connection-card">Review connection</button><p id="card-status" role="status"></p>
+          <details><summary>New to OpenAGI?</summary><p>Install OpenAGI on a computer, select your model, then connect these glasses. Your computer stays in control; G2 does not need a separate agent subscription.</p><a href="https://github.com/Spshulem/openAGI#readme" target="_blank" rel="noopener noreferrer">Computer installation guide</a><p>You can preview the layout below without a microphone or agent connection.</p><button id="preview-interface">Preview interface · no recording</button></details>
           <label for="agent-origin">Main server URL</label>
           <input id="agent-origin" type="url" autocomplete="off" placeholder="https://your-main.example.com" value="${escapeHtml(allowedOrigins[0] ?? '')}">
           <p>Use the machine that hosts your main, not another node. G2 will connect as a node. Choose ONE method below.</p>
@@ -71,6 +91,7 @@ export class OpenAGIPhoneCompanion {
           <nav class="page-nav" aria-label="Agent pages"><button data-page-link="listen" aria-pressed="true">Listen</button><button id="read-lifelog" data-page-link="lifelog">Lifelog</button><button data-page-link="inbox">Inbox</button><button data-page-link="recent">Recent</button></nav>
           <button data-action="ask">Ask agent</button><button data-action="newConversation">New conversation</button>
           <button id="cancel-request" hidden>Cancel request</button>
+          <section id="pending-question" class="ambient" hidden><h2>Saved question</h2><p id="pending-detail">Check the same request without starting it twice.</p><button id="resume-request">Check / send saved question</button><button id="dismiss-request">Clear after checking History</button></section>
           <section id="draft-review" class="ambient" hidden><h2>Review question · not sent</h2><p id="draft-text"></p><button id="send-draft">Send question</button><button id="rerecord-draft">Re-record</button><button id="discard-draft">Discard</button></section>
           <button id="last-answer">Last answer</button>
           <button id="previous-page">Previous page</button><button id="next-page">Next page</button>
@@ -95,6 +116,7 @@ export class OpenAGIPhoneCompanion {
             <p id="background-status" role="status">Lock-screen listening off.</p>
             <p id="memory-status">Off. Give consent, then enable Keep lifelog on. It resumes when the app opens while that consent is valid. Switch off to stop recording and automatic resumption.</p>
             <button id="memory-resume">Return / resume lifelog</button>
+            <button id="pause-lifelog">Pause lifelog</button>
             <details><summary>Privacy and retention</summary><p>Final text is batched to your main, not raw audio. Speakers are unverified. Suggestions need your confirmation. Backgrounding stops the microphone unless experimental lock-screen listening is enabled for active live lifelog. Reopening resumes with the same consent, including after a crash. Consent expires after 4 hours and is never renewed automatically. Turn lifelog off to stop automatic resumption. Reconfirm consent if participants change. Unsent text is not replayed after exit.</p>
             <button id="delete-memory">Stop memory & delete retained transcripts</button>
             </details>
@@ -102,7 +124,7 @@ export class OpenAGIPhoneCompanion {
           <details class="ambient" data-page="listen"><summary>Talk, speech and activity settings</summary><h2>Talk controls</h2>
             <label>Talk while lifelog is on<select id="lifelog-talk-mode"><option value="tap">Tap to start / tap to stop</option><option value="hold">Hold to talk / release to finish</option></select></label>
             <p>Hold mode ignores quick taps for Talk. Wait for Listening before speaking; releasing during microphone setup cancels. Requires an Even app and firmware that deliver hold/release gestures. If holding does nothing, use tap mode or Ask on the phone.</p>
-            <label>Quick tap while lifelog is listening<select id="idle-tap"><option value="talk">Talk (ignored in hold mode)</option><option value="highlight">Mark moment</option></select></label><p>Swipe down for explicit Talk / Mark moment controls. Swipe up for Inbox. Double-tap pauses. During a held question, double-tap cancels without sending.</p>
+            <label>Quick tap while lifelog is listening<select id="idle-tap"><option value="talk">Talk (ignored in hold mode)</option><option value="highlight">Mark moment</option></select></label><p>Swipe down for Talk / Mark moment / Pause. Swipe up for Inbox. At home, double-tap opens Even’s exit dialog. During a held question, double-tap cancels without sending.</p>
             <label><input id="auto-send" type="checkbox" checked> Send automatically when I stop talking</label>
             <p>Turn off to review the transcript and confirm Send first. Passive listening resumes after a manual question; optional wake responses are controlled separately.</p>
             <p>Hold mode stops without sending if no release arrives within 30 seconds. Manual questions require the app to stay in the foreground; experimental lock-screen continuation applies only to an already-active lifelog.</p>
@@ -113,6 +135,8 @@ export class OpenAGIPhoneCompanion {
             <p>Through main works with a regular Deepgram speech key. Audio is forwarded live, not saved or uploaded as a whole recording. Direct mode skips that network hop but needs permission to create temporary tokens. Neither mode stores your permanent Deepgram key on the phone.</p>
             <details><summary>Live transcript · optional phone preview</summary><p id="live-transcript">Waiting for speech.</p><p id="speech-timing">Select Deepgram for live words, or OpenAI for transcription after recording.</p></details><h2>Activity</h2><ol id="activity-log"></ol></details>
           <section class="ambient" data-page="recent"><h2>Recent answers</h2><p>Select an answer to resume its conversation. Stored on this phone; disconnect clears history.</p><div id="recent-answers"></div><p id="answer-preview"></p></section>
+          <section class="ambient" data-page="recent"><div id="history-controls"><h2>Conversations on main</h2><label>Search recent conversation previews<input type="search" id="history-query" maxlength="200"></label><button id="refresh-history">Search / refresh</button><button id="older-history" hidden>Older</button><button id="continue-history" hidden>Continue this conversation</button><p id="history-status" role="status"></p></div><div id="main-history"></div></section>
+          <p id="connection-readiness" role="status">Connection has not been checked.</p>
           <section class="ambient" data-page="listen">
             <h2>Listening controls</h2><label><input id="ambient-enabled" type="checkbox"> Keep microphone listening while this app is open</label>
             <label>What should listening do?<select id="listening-mode"><option value="passive">Quiet listening · tap Talk for answers</option><option value="wake">Wake responses · answer when triggered</option></select></label>
@@ -137,6 +161,32 @@ export class OpenAGIPhoneCompanion {
       for (const panel of root.querySelectorAll<HTMLElement>('[data-page]')) panel.hidden = panel.dataset.page !== page
       for (const button of root.querySelectorAll<HTMLElement>('[data-page-link]')) button.setAttribute('aria-pressed', String(button.dataset.pageLink === page))
     }
+    this.experience = new PhoneExperience(root, showPage)
+    root.querySelector('#interface-style')?.addEventListener('change', () => actions.configureInterface?.(requiredSelect(root, '#interface-style').value === 'classic' ? 'classic' : 'focused'))
+    root.querySelector('#read-connection-card')?.addEventListener('click', () => {
+      const status = root.querySelector<HTMLElement>('#card-status')!
+      try {
+        const card = parseConnectionCard(root.querySelector<HTMLTextAreaElement>('#connection-card')!.value)
+        if (allowedOrigins.length && !allowedOrigins.includes(card.origin)) throw new Error('This installed package does not allow that main URL.')
+        root.querySelector<HTMLInputElement>('#agent-origin')!.value = card.origin
+        root.querySelector<HTMLInputElement>('#pair-code')!.value = card.code
+        status.textContent = `Ready to connect to ${card.origin}. Check this is your main, then tap Pair G2 below.`
+      } catch (error) { status.textContent = error instanceof Error ? error.message : 'Invalid connection card.' }
+    })
+    root.querySelector('#preview-interface')?.addEventListener('click', () => {
+      this.actionsSection.hidden = false; this.interaction('unavailable')
+      this.set('Interface preview', 'No microphone, pairing, or model is active. Connect above when you are ready.')
+    })
+    root.querySelector('#pause-lifelog')?.addEventListener('click', () => actions.pauseLifelog?.())
+    root.querySelector('#resume-request')?.addEventListener('click', () => actions.resumeRequest?.())
+    root.querySelector('#dismiss-request')?.addEventListener('click', () => { if (window.confirm('Have you checked History? Clearing this local reminder does not cancel main work or undo completed actions.')) actions.dismissRequest?.() })
+    root.querySelector('#refresh-history')?.addEventListener('click', () => { this.historyContinuation = undefined; actions.readHistory?.(undefined, 0, root.querySelector<HTMLInputElement>('#history-query')!.value) })
+    root.querySelector('#older-history')?.addEventListener('click', () => { if (this.historyNext !== null) actions.readHistory?.(this.historyContinuation, this.historyNext, root.querySelector<HTMLInputElement>('#history-query')!.value) })
+    root.querySelector('#continue-history')?.addEventListener('click', () => { if (this.historyContinuation) { actions.continueHistory?.(this.historyContinuation); showPage(root.dataset.experience === 'focused' ? 'talk' : 'recent') } })
+    root.querySelector('#main-history')?.addEventListener('click', event => {
+      const button = event.target instanceof Element ? event.target.closest<HTMLButtonElement>('[data-continuation]') : null
+      if (button?.dataset.continuation) { this.historyContinuation = button.dataset.continuation; actions.readHistory?.(this.historyContinuation) }
+    })
     for (const button of root.querySelectorAll<HTMLElement>('[data-page-link]')) button.addEventListener('click', () => showPage(button.dataset.pageLink!))
     showPage('listen')
     root.querySelector('#mark-moment')?.addEventListener('click', () => actions.markMoment?.())
@@ -158,7 +208,7 @@ export class OpenAGIPhoneCompanion {
     root.querySelector('#lifelog-search')?.addEventListener('click', () => readHistory(0, true))
     root.querySelector('#lifelog-next')?.addEventListener('click', () => { if (this.lifelogNext !== null) readHistory(this.lifelogNext) })
     root.querySelector('#lifelog-previous')?.addEventListener('click', () => readHistory(Math.max(0, this.lifelogOffset - 25)))
-    root.querySelector('#lifelog-close')?.addEventListener('click', () => showPage('listen'))
+    root.querySelector('#lifelog-close')?.addEventListener('click', () => showPage(root.dataset.experience === 'focused' ? 'history' : 'listen'))
     root.querySelector('#pair-button')?.addEventListener('click', () => actions.pair(input?.value.trim() ?? '', agentOrigin?.value.trim() ?? ''))
     root.querySelector('#agent-connect')?.addEventListener('click', () => {
       actions.connectAgent(agentOrigin?.value ?? '', agentToken?.value ?? '')
@@ -215,7 +265,7 @@ export class OpenAGIPhoneCompanion {
     root.querySelector('#speech-transport')?.addEventListener('change', configureSpeech)
     root.querySelector('#recent-answers')?.addEventListener('click', event => {
       const target = event.target instanceof Element ? event.target.closest<HTMLButtonElement>('button[data-answer]') : null
-      if (target?.dataset.answer !== undefined) actions.selectAnswer?.(Number(target.dataset.answer))
+      if (target?.dataset.answer !== undefined) { actions.selectAnswer?.(Number(target.dataset.answer)); showPage(root.dataset.experience === 'focused' ? 'talk' : 'recent') }
     })
     const configure = (): void => actions.configureAmbient(ambient?.checked === true, wakePhrase?.value.trim() || 'open agi', answerQuestions?.checked === true)
     ambient?.addEventListener('change', configure)
@@ -223,13 +273,39 @@ export class OpenAGIPhoneCompanion {
     wakePhrase?.addEventListener('change', configure)
     answerQuestions?.addEventListener('change', configure)
     injectStyles()
+    this.interfaceStyle('focused')
   }
   set(status: string, detail: string): void {
     this.status.textContent = status; this.detail.textContent = detail
-    const ask = this.actionsSection.querySelector<HTMLButtonElement>('[data-action="ask"]')
-    if (ask) ask.textContent = /Opening microphone|Recording question/.test(status) ? (this.sendOnStop ? 'Stop talking · send' : 'Stop talking · review') : status.startsWith('Review question') ? 'Send question' : 'Talk'
-    if (/failed|could not|check|not allowed/i.test(status)) this.status.scrollIntoView?.({ block: 'center' })
   }
+  interfaceStyle(style: 'focused' | 'classic'): void { this.experience.set(style); requiredSelect(document.querySelector('#app')!, '#interface-style').value = style }
+  interaction(state: PhoneInteraction): void {
+    this.interactionState = state
+    const ask = this.actionsSection.querySelector<HTMLButtonElement>('[data-action="ask"]')
+    if (ask) {
+      ask.textContent = state === 'recording' ? (this.sendOnStop ? 'Stop & send' : 'Stop & review') : state === 'review' ? 'Send question' : state === 'working' ? 'Working…' : 'Talk'
+      ask.disabled = this.requestInProgress || state === 'working' || state === 'unavailable'
+    }
+  }
+  pendingQuestion(text: string | null): void {
+    this.actionsSection.querySelector<HTMLElement>('#pending-question')!.hidden = text === null
+    this.actionsSection.querySelector<HTMLElement>('#pending-detail')!.textContent = text ?? ''
+  }
+  readiness(capabilities: G2Capabilities | null, problem?: string): void {
+    const element = this.actionsSection.querySelector<HTMLElement>('#connection-readiness')!
+    element.textContent = problem ?? (!capabilities ? 'Classic main · update OpenAGI for reconnectable questions and main history.'
+      : `${capabilities.mainRole === 'main' ? 'Connected to main' : 'Connected to a node — use your main instead'} · saved request recovery ready\nSpeech: ${capabilities.speech.liveTranscriptionConfigured ? 'live speech configured' : capabilities.speech.transcriptionConfigured ? 'buffered speech configured' : 'configure speech on main'}\nComputer and coding actions require connected hosts and approval on main.`)
+  }
+  mainHistory(page: G2History, continuation?: string): void {
+    this.historyContinuation = continuation; this.historyNext = page.nextOffset ?? null
+    const root = this.actionsSection.querySelector<HTMLElement>('#main-history')!; root.replaceChildren()
+    for (const item of page.conversations ?? []) { const b = document.createElement('button'); b.dataset.continuation = item.continuation; b.textContent = `${item.title}\n${item.preview}`; root.append(b) }
+    for (const message of page.messages ?? []) { const p = document.createElement('p'); const label = document.createElement('strong'); label.textContent = message.role === 'user' ? 'You: ' : 'OpenAGI: '; p.append(label, document.createTextNode(message.text)); root.append(p) }
+    this.actionsSection.querySelector<HTMLElement>('#older-history')!.hidden = this.historyNext === null
+    this.actionsSection.querySelector<HTMLElement>('#continue-history')!.hidden = !continuation
+    this.historyStatus(page.archivedOnMain ? 'Earlier archived messages remain on main.' : root.childElementCount ? 'Saved on your main · only this G2’s conversations' : 'No conversations found on main.')
+  }
+  historyStatus(text: string): void { this.actionsSection.querySelector<HTMLElement>('#history-status')!.textContent = text }
   paired(value: boolean): void { this.pairSection.hidden = value; this.actionsSection.hidden = !value; if (!value) this.lifelogStatus('') }
   listeningMode(mode: 'passive' | 'wake'): void {
     requiredSelect(this.actionsSection, '#listening-mode').value = mode
@@ -276,6 +352,9 @@ export class OpenAGIPhoneCompanion {
     const i = this.actionsSection.querySelector<HTMLInputElement>('#memory-enabled'); if (i) i.checked = active
     const p = this.actionsSection.querySelector('#memory-status'); if (p) p.textContent = detail
     if (!active) this.saveStatus(detail)
+    for (const id of ['pause-lifelog', 'mark-moment']) {
+      const button = this.actionsSection.querySelector<HTMLButtonElement>(`#${id}`); if (button) button.disabled = !active
+    }
   }
   lifelogEnabled(enabled: boolean): void { const input = this.actionsSection.querySelector<HTMLInputElement>('#memory-enabled'); if (input) input.checked = enabled }
   saveStatus(text: string): void { const p = this.actionsSection.querySelector('#save-status'); if (p) p.textContent = text }
@@ -309,6 +388,7 @@ export class OpenAGIPhoneCompanion {
     this.sendOnStop = enabled
     const input = this.actionsSection.querySelector<HTMLInputElement>('#auto-send')
     if (input) input.checked = enabled
+    this.interaction(this.interactionState)
   }
   draft(text: string | null, recovery?: 'speech' | 'delivery'): void {
     const panel = this.actionsSection.querySelector<HTMLElement>('#draft-review')
@@ -321,12 +401,14 @@ export class OpenAGIPhoneCompanion {
     if (preview) preview.textContent = text ?? ''
   }
   requestActive(active: boolean): void {
+    this.requestInProgress = active
     const cancel = this.actionsSection.querySelector<HTMLButtonElement>('#cancel-request')
     if (cancel) cancel.hidden = !active
     for (const selector of ['[data-action="ask"]', '[data-action="newConversation"]', '[data-action="unlink"]', '#last-answer', '#ambient-retry', '#send-draft', '#rerecord-draft', '#discard-draft']) {
       const input = this.actionsSection.querySelector<HTMLButtonElement | HTMLInputElement>(selector)
       if (input) input.disabled = active
     }
+    this.interaction(this.interactionState)
   }
   transcript(text: string): void { const node = this.actionsSection.querySelector('#live-transcript'); if (node) node.textContent = text }
   speechModel(model: SpeechModel): void { const select = this.actionsSection.querySelector<HTMLSelectElement>('#speech-model'); if (select) select.value = model }
@@ -402,5 +484,6 @@ function injectStyles(): void {
     #answer-preview:not(:empty){border-top:1px solid #364d3e;padding-top:18px;margin-top:4px;font-size:14px;line-height:1.65;white-space:pre-wrap}#answer-preview:empty{display:none}
     @media(max-width:360px){.shell{padding:20px 14px}.ambient{padding:16px}button{padding:12px;font-size:14px}}
     button.secondary{grid-column:1/-1;background:transparent;color:#dde5e0;border-color:#41564b}footer{font-size:12px;text-align:center;padding:10px 24px}code{word-break:break-all;color:#d9eee2}`
+  style.textContent += experienceStyles
   document.head.appendChild(style)
 }

--- a/integration-clients/even-g2-overlay/src/ui/phone-experience.ts
+++ b/integration-clients/even-g2-overlay/src/ui/phone-experience.ts
@@ -1,0 +1,92 @@
+// Layout only: move the existing controls and listeners, do not replace audio,
+// consent, credentials or navigation state when comparing interfaces.
+export class PhoneExperience {
+  private restores: (() => void)[] = []
+  private focused: HTMLElement | null = null
+  constructor(private readonly root: HTMLElement, private readonly show: (page: string) => void) {}
+  set(style: 'focused' | 'classic'): void {
+    for (const restore of this.restores.reverse()) restore()
+    this.restores = []; this.focused?.remove(); this.focused = null
+    this.root.dataset.experience = style
+    const legacy = this.root.querySelector<HTMLElement>('.page-nav')
+    if (legacy) legacy.hidden = style === 'focused'
+    if (style === 'classic') { this.show('listen'); return }
+    const actions = this.root.querySelector<HTMLElement>('#actions')!
+    const focused = document.createElement('div'); focused.id = 'focused-experience'; this.focused = focused
+    focused.innerHTML = `<nav class="experience-nav" aria-label="Main navigation"><button data-destination="talk">Talk</button><button data-destination="inbox">Inbox</button><button data-destination="history">History</button><button data-destination="settings" aria-label="Settings">⚙</button></nav>
+      <section data-page="talk" class="talk-page"><div id="talk-primary"></div><div id="talk-result"></div><details id="talk-activity"><summary>Activity</summary></details><section id="lifelog-simple" class="ambient"><h2>Lifelog</h2><p>Keep a quiet record. Ask only when you choose.</p><div id="lifelog-primary"></div></section></section>
+      <section data-page="history" class="history-page"><h2>History</h2><p>Your conversations and saved moments.</p><div id="history-destinations"></div><div id="history-main"></div><div id="history-local"></div></section>
+      <section data-page="settings" class="settings-page"><h2>Settings</h2><div id="settings-content"></div></section>`
+    actions.prepend(focused)
+    const move = (selector: string, destination: string): void => {
+      const node = this.root.querySelector<HTMLElement>(selector), target = focused.querySelector(destination)
+      if (!node || !target) return
+      const anchor = document.createComment('classic position'); node.before(anchor); target.append(node)
+      this.restores.push(() => { anchor.replaceWith(node) })
+    }
+    const moveLabel = (id: string, destination: string): void => {
+      const node = this.root.querySelector<HTMLElement>(`#${id}`)?.closest('label')
+      if (!node) return
+      node.dataset.controlLabel = id; move(`[data-control-label="${id}"]`, destination)
+    }
+    for (const selector of ['[data-action="ask"]', '#cancel-request', '#pending-question', '#draft-review', '[data-action="newConversation"]']) move(selector, '#talk-primary')
+    for (const selector of ['#live-transcript', '#speech-timing', '#answer-preview', '#previous-page', '#next-page']) move(selector, '#talk-result')
+    move('#activity-log', '#talk-activity')
+    for (const id of ['memory-enabled', 'recording-consent']) moveLabel(id, '#lifelog-primary')
+    for (const selector of ['#memory-status', '#save-status', '#memory-resume', '#pause-lifelog', '#mark-moment']) move(selector, '#lifelog-primary')
+    move('#history-controls', '#history-main'); move('#main-history', '#history-main')
+    move('#recent-answers', '#history-local'); move('#read-lifelog', '#history-destinations')
+    // Advanced cards remain intact, and restore to their exact Classic position.
+    for (const panel of [...actions.querySelectorAll<HTMLElement>(':scope > [data-page="listen"]')]) {
+      const page = panel.dataset.page; panel.dataset.page = 'settings'
+      this.restores.push(() => { panel.dataset.page = page })
+    }
+    for (const selector of ['#connection-readiness', '#blank-display', '[data-action="unlink"]', '#exit-agents']) {
+      move(selector, '#settings-content')
+    }
+    const recent = actions.querySelector<HTMLElement>(':scope > [data-page="recent"]')
+    if (recent) { recent.hidden = true; this.restores.push(() => { recent.hidden = false }) }
+    for (const button of focused.querySelectorAll<HTMLButtonElement>('[data-destination]')) button.addEventListener('click', () => {
+      const page = button.dataset.destination!
+      this.show(page)
+      for (const b of focused.querySelectorAll('nav button')) b.setAttribute('aria-pressed', String(b === button))
+    })
+    this.show('talk')
+    focused.querySelector('nav button')?.setAttribute('aria-pressed', 'true')
+  }
+}
+
+export const experienceStyles = `
+  [data-experience="focused"]{--ink:#e9edef;--muted:#a4b0b9;color:var(--ink)}
+  [data-experience="focused"] .brand{font-size:22px;letter-spacing:-.035em}
+  [data-experience="focused"] .eyebrow{color:var(--muted);letter-spacing:.06em}
+  [data-experience="focused"] .card,[data-experience="focused"] .ambient,[data-experience="focused"] .pair{background:#192127;border:1px solid #334049;box-shadow:none}
+  [data-experience="focused"] p,[data-experience="focused"] label{color:var(--muted)}
+  #focused-experience{display:contents}.talk-page,.history-page,.settings-page{display:grid;gap:20px;grid-column:1/-1}
+  .experience-nav{grid-column:1/-1;display:grid;grid-template-columns:1fr 1fr 1fr 48px;gap:6px;position:sticky;top:0;background:#10171c;z-index:3;padding:10px 0}
+  [data-experience="focused"] button{background:#263943;border-color:#415766;color:#e9edef;cursor:pointer;font-weight:550}
+  [data-experience="focused"] button[aria-pressed="true"],[data-experience="focused"] [data-action="ask"]{background:#e8eef2;color:#15232c;border-color:#e8eef2}
+  #talk-primary{display:grid;grid-template-columns:1fr 1fr;gap:12px}#talk-primary [data-action="ask"]{grid-column:1/-1;min-height:76px;font-size:22px}
+  #talk-primary #draft-review,#talk-primary #pending-question{grid-column:1/-1}
+  #talk-primary [data-action="newConversation"]{background:transparent;grid-column:1/-1}
+  #talk-result{display:grid;grid-template-columns:1fr 1fr;gap:12px}#talk-result p{grid-column:1/-1;white-space:pre-wrap;line-height:1.6;overflow-wrap:anywhere}
+  #talk-result #answer-preview{max-height:40vh;overflow:auto;margin:0;padding:18px 0}
+  #talk-activity{border-top:1px solid #334049;padding:14px 0;font-size:14px}
+  #lifelog-primary,#settings-content,#history-main,#main-history,#history-controls{display:grid;gap:14px;min-width:0}
+  #lifelog-primary label{display:flex;gap:12px;align-items:center;min-height:44px}
+  [data-experience="focused"] #lifelog-primary:has(#memory-enabled:not(:checked)) #save-status{display:none}
+  #lifelog-primary input[type=checkbox]{width:22px;height:22px;flex-shrink:0;accent-color:#abc8dc}
+  #main-history{max-height:55vh;overflow:auto;overscroll-behavior:contain}
+  #main-history button{text-align:left;display:grid;gap:8px}#main-history p{white-space:pre-wrap}
+  [data-experience="focused"] footer,[data-experience="focused"] #last-answer{display:none}
+  [data-experience="focused"] .ambient{padding:20px;gap:16px}
+  [data-experience="focused"] .ambient details{border-top:1px solid #334049;padding-top:16px}
+  [data-experience="focused"] .ambient>label{display:grid;gap:8px}
+  [data-experience="focused"] .ambient>label:has(input[type=checkbox]){display:flex;align-items:center;gap:12px;min-height:44px}
+  [data-experience="focused"] :focus-visible{outline:3px solid #b9d8ed;outline-offset:3px}
+  .interface-switch{display:flex;align-items:center;gap:10px;font-size:12px}.interface-switch select{padding:8px;min-height:44px}
+  #connection-card{min-height:100px;width:100%;font:inherit;padding:14px;background:#111b23;color:#edf4fa;border:1px solid #516573;border-radius:12px}
+  #connection-readiness{grid-column:1/-1;line-height:1.6;white-space:pre-wrap;font-size:14px}
+  @media(prefers-reduced-motion:reduce){*{scroll-behavior:auto!important}}
+  @media(max-width:360px){.experience-nav button{padding:9px 4px;font-size:13px}.shell{padding:18px 14px}}
+`

--- a/integration-clients/even-g2-overlay/tsconfig.json
+++ b/integration-clients/even-g2-overlay/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vitest/globals", "vite/client"]
+  },
+  "exclude": ["src/main.ts"],
+  "include": ["src", "test", "vite.config.ts", "vitest.config.ts", "eslint.config.js"]
+}

--- a/integration-clients/even-g2-overlay/vite.config.ts
+++ b/integration-clients/even-g2-overlay/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  server: { host: true, port: 5173 },
+  build: {
+    target: 'esnext',
+    sourcemap: false,
+    reportCompressedSize: true,
+  },
+})

--- a/integration-clients/even-g2-overlay/vitest.config.ts
+++ b/integration-clients/even-g2-overlay/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts', 'test/**/*.test.ts'],
+    coverage: { reporter: ['text', 'json-summary'] },
+  },
+})

--- a/src/agent-host.js
+++ b/src/agent-host.js
@@ -83,6 +83,7 @@ export class AgentHost {
       }
     }
 
+    options.signal?.throwIfAborted();
     const agent = this.store.getAgent(agentId);
     const sessionId = this.store.sessionKey({ channel, from, agentId, sessionId: input.sessionId });
 
@@ -245,6 +246,7 @@ export class AgentHost {
       }),
       context: {
         signal: options.signal,
+        ...(requestId ? { requestId } : {}),
         channel,
         ...(channel === "g2" ? { sourceNodeId: metadata.sourceNodeId } : {}),
         from,

--- a/src/agent-store.js
+++ b/src/agent-store.js
@@ -72,8 +72,9 @@ export class InMemoryAgentStore {
     return this.getSession(sessionId);
   }
 
-  listSessions() {
+  listSessions({ prefix = "", limit = Infinity } = {}) {
     return [...this.sessions.values()]
+      .filter(session => session.id.startsWith(prefix))
       .map((session) => ({
         id: session.id,
         createdAt: session.createdAt,
@@ -81,7 +82,7 @@ export class InMemoryAgentStore {
         messageCount: session.messages?.length ?? 0,
         lastMessage: session.messages?.at(-1)?.content ?? ""
       }))
-      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)).slice(0, limit);
   }
 }
 
@@ -218,10 +219,14 @@ export class FileBackedAgentStore extends InMemoryAgentStore {
     return this.getSession(sessionId);
   }
 
-  listSessions() {
+  listSessions({ prefix = "", limit = Infinity } = {}) {
     const entries = [];
-    for (const entry of readDirSafe(this.sessionsDir)) {
-      if (!entry.endsWith(".json")) continue;
+    let candidates = readDirSafe(this.sessionsDir).filter(entry => entry.endsWith(".json") && (!prefix || entry.startsWith(safeFilename(prefix))));
+    // Bound active-session reads for scoped history, newest writes first. Do
+    // not let filesystem enumeration order hide recently updated conversations.
+    if (Number.isFinite(limit)) candidates = candidates.map(entry => ({ entry, modified: fs.statSync(path.join(this.sessionsDir, entry)).mtimeMs }))
+      .sort((a, b) => b.modified - a.modified).slice(0, limit).map(item => item.entry);
+    for (const entry of candidates) {
       const filePath = path.join(this.sessionsDir, entry);
       try { this.assertSessionSize(filePath); } catch (error) {
         if (error.code !== "SESSION_TOO_LARGE") throw error;

--- a/src/g2-connect-page.js
+++ b/src/g2-connect-page.js
@@ -1,0 +1,17 @@
+// Owner-gated by hosted-interface. Cards contain a single-use code, no bearer.
+export const g2ConnectPage = `<!doctype html><html lang="en"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Connect glasses · OpenAGI</title>
+<style>body{font:17px system-ui;line-height:1.6;max-width:640px;margin:64px auto;padding:24px;color:#1b2329;background:#f7f8fa}h1{letter-spacing:-.04em}button{min-height:44px;padding:12px 20px;border:0;border-radius:12px;background:#172c37;color:white;font:inherit;cursor:pointer}textarea{box-sizing:border-box;width:100%;min-height:130px;border:1px solid #bdc7ce;border-radius:12px;padding:16px}section{margin:32px 0}</style>
+<a href="/">‹ OpenAGI</a><h1>Connect your glasses.</h1><p>Your computer is home. G2 is a companion, with its own revocable connection.</p>
+<ol><li>Run OpenAGI on the computer you want as main. Finish <a href="/setup">computer setup</a>.</li><li>Configure its exact HTTPS public URL. For private remote use, keep your phone and main on the same Tailscale network and use HTTPS Serve.</li><li>Open Agents in Even. Choose Connect, then paste the connection card below.</li></ol>
+<section><button id="generate">Create connection card</button> <button id="copy" hidden>Copy card</button><p id="status" role="status">Creates a code valid for 30 minutes and one pairing. Do not share it publicly.</p><textarea id="card" readonly aria-label="Connection card" hidden></textarea></section>
+<section><h2>Ready when you are.</h2><p>Choose live speech for words as you speak, or buffered speech for transcription after Stop. Your model and keys stay on main.</p><p>First try a read-only question. Lifelog is optional and needs participant consent. Computer actions need separate approval; readable coding sessions are not automatically controllable.</p><p><a href="/g2/proactive">Notifications</a> · <a href="/g2/lifelog">Lifelog privacy</a> · <a href="/setup">Models and budget</a></p></section>
+<script>
+const statusText=document.querySelector('#status'), card=document.querySelector('#card'), generate=document.querySelector('#generate'), copy=document.querySelector('#copy');
+generate.onclick=async()=>{generate.disabled=true;card.hidden=true;copy.hidden=true;card.value='';try{
+ const r=await fetch('/nodes/enrollment-code',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({platform:'even_g2'})}); const data=await r.json();
+ if(!r.ok)throw new Error(data.error||'Could not create code');
+ const url=new URL(data.publicUrl);if(url.protocol!=='https:'||url.username||url.password||url.pathname!=='/'||url.search||url.hash)throw new Error('Set OPENAGI_PUBLIC_URL to an exact HTTPS origin in main setup, then try again.');
+ card.value=JSON.stringify({format:'openagi-g2',version:1,origin:url.origin,code:data.code,expiresAt:data.expiresAt});card.hidden=false;copy.hidden=false;statusText.textContent='Paste into Agents on your phone. Expires '+new Date(data.expiresAt).toLocaleTimeString()+'.';
+}catch(e){statusText.textContent=e.message==='Invalid URL'?'Set your main HTTPS public URL in setup first.':e.message;}finally{generate.disabled=false;}};
+copy.onclick=async()=>{try{await navigator.clipboard.writeText(card.value);statusText.textContent='Copied. Paste the card into Agents.';}catch{card.focus();card.select();statusText.textContent='Select and copy the card manually.';}};
+</script></html>`;

--- a/src/g2-requests.js
+++ b/src/g2-requests.js
@@ -1,0 +1,191 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { ensureDir, writeJsonAtomic } from "./file-utils.js";
+import { resolveDataDir } from "./data-dir.js";
+import { G2ChannelError } from "./integrations/g2-channel.js";
+
+const WINDOW_MS = 24 * 60 * 60 * 1000;
+const ACTIVE = new Set(["accepted", "working"]);
+const STAGES = new Set(["transcribing", "transcribed", "accepted", "routing", "thinking", "model", "tool", "tool-complete"]);
+const hash = value => createHash("sha256").update(value).digest("hex");
+const fail = (code, status, message) => new G2ChannelError(code, status, message);
+
+// Single-main coordinator. Receipts are claims, not a queue: disconnected or
+// restarted work is NEVER automatically replayed. Audio stays in the invocation
+// closure only. External effects cannot be rolled back or made exactly-once here.
+export class G2Requests {
+  constructor({ channel, dir, now = Date.now, write = writeJsonAtomic, sweepMs = 1000, onCancel } = {}) {
+    this.channel = channel; this.now = now; this.write = write; this.onCancel = onCancel;
+    this.dir = dir ?? path.join(resolveDataDir(), "g2-requests");
+    this.records = new Map(); this.running = new Map(); this.closed = false; this.storageFailed = false;
+    ensureDir(this.dir);
+    const files = fs.readdirSync(this.dir).filter(f => /^[a-f0-9]{64}\.json$/.test(f));
+    if (files.length > 512) throw fail("request_storage_unavailable", 503, "Request recovery needs attention on main.");
+    for (const file of files) {
+      const location = path.join(this.dir, file);
+      if (fs.statSync(location).size > 256 * 1024) throw fail("request_storage_unavailable", 503, "Request recovery needs attention on main.");
+      const record = JSON.parse(fs.readFileSync(location, "utf8"));
+      if (record.version !== 1 || !Number.isFinite(record.createdAt) || file !== `${this.key(record.nodeId, record.id)}.json`)
+        throw fail("request_storage_unavailable", 503, "Request recovery needs attention on main.");
+      if (record.expiresAt < this.now()) { fs.unlinkSync(location); continue; }
+      if (ACTIVE.has(record.state)) {
+        const completed = this.completedMessage(record);
+        Object.assign(record, completed ? { state: "completed", result: { question: record.question ?? "", reply: completed.content.slice(0, 32000), sessionId: record.sessionId } }
+          : { state: "unconfirmed", message: "Main restarted. Check this conversation before sending another request; actions may have completed." });
+        record.revision++; this.persist(record);
+      }
+      this.records.set(this.key(record.nodeId, record.id), record);
+    }
+    this.timer = sweepMs ? setInterval(() => this.sweep(), sweepMs) : null;
+    this.timer?.unref?.();
+  }
+
+  key(nodeId, id) { return hash(JSON.stringify([nodeId, id])); }
+  checkId(id) {
+    if (typeof id !== "string" || !/^\d{13}_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id))
+      throw fail("invalid_request_id", 400, "A fresh request identity is required.");
+    const created = Number(id.split("_")[0]);
+    if (created < this.now() - WINDOW_MS || created > this.now() + 60_000)
+      throw fail("request_expired", 410, "Recovery expired or the phone clock is incorrect. Check History before sending again.");
+    return created;
+  }
+  persist(record) {
+    try { this.write(path.join(this.dir, `${this.key(record.nodeId, record.id)}.json`), record); }
+    catch { this.storageFailed = true; throw fail("request_storage_unavailable", 503, "Main could not save request recovery. Nothing new was sent; check main storage."); }
+  }
+  public(record) {
+    const { id, state, revision, createdAt, expiresAt, deadline, sessionId, question, stage, tool, text, result, message, events } = record;
+    return structuredClone({ id, state, revision, createdAt, expiresAt, deadline, sessionId, question, stage, tool, text, result, message, events });
+  }
+  get(nodeId, id) {
+    this.channel.assertEnrolled(nodeId); this.checkId(id); this.sweep();
+    const record = this.records.get(this.key(nodeId, id));
+    if (!record) throw fail("request_not_found", 404, "Main has not accepted this request. The saved question can be sent with the same identity.");
+    return this.public(record);
+  }
+  submit(nodeId, id, body) {
+    this.channel.assertEnrolled(nodeId); const createdAt = this.checkId(id);
+    if (this.closed || this.storageFailed) throw fail("request_storage_unavailable", 503, "Main request recovery is unavailable. Check main before retrying.");
+    const payload = validateRequest(body);
+    const digest = hash(JSON.stringify(payload)), key = this.key(nodeId, id);
+    this.sweep();
+    const existing = this.records.get(key);
+    if (existing) {
+      if (existing.digest !== digest) throw fail("request_conflict", 409, "This request identity already belongs to a different question.");
+      return this.public(existing);
+    }
+    const own = [...this.records.values()].filter(r => r.nodeId === nodeId);
+    if (this.records.size >= 512 || own.length >= 100 || this.running.size >= 16 || own.some(r => ACTIVE.has(r.state)))
+      throw fail("request_busy", 429, "Another question is active or the daily recovery limit was reached. Check History first.");
+    const sessionId = this.channel.sessionIdFor(nodeId, payload.conversationId, payload.continuation);
+    const record = { version: 1, id, nodeId, digest, sessionId, state: "accepted", revision: 1,
+      createdAt, expiresAt: createdAt + WINDOW_MS, deadline: this.now() + 300_000,
+      question: payload.text ?? "", stage: "accepted", tool: "", text: "", events: [], sequence: 0 };
+    this.persist(record); // Must succeed before an agent/transcription call.
+    this.records.set(key, record);
+    const controller = new AbortController(); this.running.set(key, controller);
+    void Promise.resolve().then(async () => {
+      if (!ACTIVE.has(record.state) || controller.signal.aborted || this.closed) { this.running.delete(key); return; }
+      try {
+        this.channel.assertEnrolled(nodeId);
+        record.state = "working"; let lastSaved = 0;
+        const update = () => {
+          record.revision++;
+          if (this.now() - lastSaved >= 750) { this.persist(record); lastSaved = this.now(); }
+        };
+        const result = await this.channel.ask(payload, nodeId, {
+          requestId: id, continuation: payload.continuation, signal: controller.signal,
+          onProgress: progress => {
+            if (!ACTIVE.has(record.state)) return;
+            try {
+              this.channel.assertEnrolled(nodeId);
+              if (STAGES.has(progress.stage)) record.stage = progress.stage;
+              record.tool = typeof progress.tool === "string" ? progress.tool.replace(/[^\w.:-]/g, "").slice(0, 100) : "";
+              if (STAGES.has(progress.stage)) {
+                record.events.push({ seq: ++record.sequence, stage: record.stage, tool: record.tool });
+                record.events = record.events.slice(-80);
+              }
+              if (typeof progress.question === "string") record.question = progress.question.slice(0, 4000);
+              update();
+            } catch { this.stop(record, "unconfirmed", "Progress could not be saved or access changed. Check main before repeating actions."); }
+          },
+          onTextDelta: delta => {
+            if (!ACTIVE.has(record.state) || typeof delta.text !== "string") return;
+            record.text = ((delta.reset ? "" : record.text) + delta.text).slice(0, 32000);
+            try { update(); } catch { this.stop(record, "unconfirmed", "Main could not save progress. Check History before repeating actions."); }
+          }
+        });
+        this.channel.assertEnrolled(nodeId);
+        if (!ACTIVE.has(record.state) || controller.signal.aborted) return;
+        record.result = { question: String(result.question ?? record.question).slice(0, 4000), reply: String(result.reply ?? "").slice(0, 32000), sessionId };
+        record.text = "";
+        record.state = "completed"; record.revision++; this.persist(record);
+      } catch (error) {
+        if (!ACTIVE.has(record.state)) return;
+        const completed = this.completedMessage(record);
+        if (completed) {
+          record.state = "completed"; record.result = { question: record.question, reply: completed.content.slice(0, 32000), sessionId };
+        } else {
+          record.state = "unconfirmed";
+          record.message = error instanceof G2ChannelError ? error.message : "The question did not finish. Check History before trying again; some actions may have completed.";
+        }
+        record.revision++; try { this.persist(record); } catch { /* durable claim remains; never replay */ }
+      } finally { this.running.delete(key); }
+    });
+    return this.public(record);
+  }
+  completedMessage(record) {
+    try {
+      return this.channel.agentHost?.store?.getSession(record.sessionId)?.messages?.findLast(m =>
+        m.role === "assistant" && m.channel === "g2" && m.metadata?.requestId === record.id && m.metadata?.status !== "failed" && typeof m.content === "string");
+    } catch { return null; }
+  }
+  stop(record, state, message) {
+    if (!ACTIVE.has(record.state)) return;
+    record.state = state; record.message = message; record.revision++;
+    this.running.get(this.key(record.nodeId, record.id))?.abort();
+    // Keep the running slot until the underlying promise settles. An executor
+    // that ignores abort must not admit an unbounded series of replacement jobs.
+    try { this.persist(record); } catch { /* fail closed on new admissions */ }
+    try { Promise.resolve(this.onCancel?.(record)).catch(() => {}); } catch { /* main owns authority */ }
+  }
+  cancel(nodeId, id) {
+    this.get(nodeId, id);
+    const record = this.records.get(this.key(nodeId, id));
+    this.stop(record, "cancelled", "Cancelled. Actions already completed are not undone.");
+    return this.public(record);
+  }
+  sweep() {
+    for (const [key, record] of this.records) {
+      if (ACTIVE.has(record.state)) {
+        try { this.channel.assertEnrolled(record.nodeId); }
+        catch { this.stop(record, "cancelled", "This G2 connection was revoked."); }
+        if (this.now() >= record.deadline) this.stop(record, "unconfirmed", "The question exceeded five minutes. Check History before repeating actions.");
+      }
+      if (record.expiresAt < this.now() && !this.running.has(key)) {
+        try { fs.unlinkSync(path.join(this.dir, `${key}.json`)); this.records.delete(key); }
+        catch { this.storageFailed = true; }
+      }
+    }
+  }
+  close() {
+    this.closed = true; clearInterval(this.timer);
+    for (const record of this.records.values()) this.stop(record, "unconfirmed", "Main stopped. Check History before sending another request.");
+  }
+}
+
+function validateRequest(body) {
+  if (!body || typeof body !== "object" || Array.isArray(body) || Object.keys(body).some(k => !["text", "audioBase64", "conversationId", "continuation", "language"].includes(k)))
+    throw fail("invalid_question", 400, "Unsupported question fields.");
+  if (typeof body.conversationId !== "string" || !body.conversationId.trim() || body.conversationId.length > 200)
+    throw fail("invalid_conversation", 400, "Choose a conversation first.");
+  if (body.continuation !== undefined && (typeof body.continuation !== "string" || body.continuation.length > 200))
+    throw fail("invalid_conversation", 400, "Invalid conversation reference.");
+  const textOnly = typeof body.text === "string";
+  if (textOnly ? (!body.text.trim() || body.text.length > 4000 || body.audioBase64 !== undefined)
+    : (body.text !== undefined || typeof body.audioBase64 !== "string" || body.audioBase64.length > 1_281_000))
+    throw fail("invalid_question", 400, "Send one question of at most 4000 characters or 30 seconds.");
+  return { ...(textOnly ? { text: body.text.trim() } : { audioBase64: body.audioBase64 }), conversationId: body.conversationId,
+    ...(body.continuation ? { continuation: body.continuation } : {}), ...(typeof body.language === "string" ? { language: body.language.slice(0, 20) } : {}) };
+}

--- a/src/hosted-interface.js
+++ b/src/hosted-interface.js
@@ -4,6 +4,8 @@ import path from "node:path";
 import { EventEmitter } from "node:events";
 import { attachG2SpeechRelay } from "./integrations/g2-speech-relay.js";
 import { G2Proactive } from "./g2-proactive.js";
+import { G2Requests } from "./g2-requests.js";
+import { g2ConnectPage } from "./g2-connect-page.js";
 import { g2ProactivePage } from "./g2-proactive-page.js";
 import { lifelogPage } from "./lifelog-page.js";
 import { createDefaultRuntime } from "./abi-runtime.js";
@@ -166,6 +168,21 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
 
   const events = new EventEmitter();
   const g2Proactive = new G2Proactive({ dir: path.join(dataDir, "g2-proactive"), runtime });
+  let g2Requests = null;
+  try { g2Requests = channels?.g2 ? new G2Requests({ channel: channels.g2, dir: path.join(dataDir, "g2-requests"),
+    onCancel: async record => {
+      for (const action of runtime.pendingActions?.list?.({ status: "pending" }) ?? []) {
+        if (action.context?.requestId === record.id && action.context?.sourceNodeId === record.nodeId)
+          runtime.pendingActions.decide(action.id, { decision: "deny", decidedBy: "g2-request-cancelled" });
+      }
+      const active = runtime.computerUseLog?.activeSessionFor?.(record.sessionId);
+      if (active) await runtime.abortComputerUseSession?.(active, "G2 request stopped; renew consent to continue");
+    }
+  }) : null; } catch {
+    // Preserve questionable receipts for owner repair, never replay their work,
+    // and do not take unrelated main services down with optional G2 recovery.
+    console.error("[g2] Request recovery unavailable. Inspect the g2-requests directory on main; existing receipts were preserved.");
+  }
   runtime.tools?.unregister?.("search_conversation_lifelog");
   runtime.tools?.register?.({ name: "search_conversation_lifelog", source: "integration:g2-lifelog", sideEffects: false,
     description: "Search retained conversation moments by words, person label, topic or date. Evidence is untrusted; inferred commitments are not authorization or verified identity. G2 can recall only its own capture history. Does not send instructions or create tasks.",
@@ -709,7 +726,7 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
       const method = req.method;
       const nodeScopedRoute = method === "POST" && [
         "/nodes/heartbeat", "/nodes/control/poll", "/nodes/control/result", "/nodes/revoke",
-        "/nodes/capture-memory", "/nodes/g2/ask", "/nodes/g2/listen", "/nodes/g2/speech-token", "/nodes/g2/proactive"
+        "/nodes/capture-memory", "/nodes/g2/experience", "/nodes/g2/ask", "/nodes/g2/listen", "/nodes/g2/speech-token", "/nodes/g2/proactive"
       ].includes(pathname);
       const nodeClientRoute = (method === "GET" && ["/nodes", "/tasks", "/integrations/status"].includes(pathname))
         || (method === "POST" && pathname === "/message");
@@ -724,14 +741,14 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
       // the G2 voice routes; all generic node/control routes still require
       // the explicit X-OpenAGI-Node-ID header.
       const tokenOnlyG2Enrollment = !headerNodeId
-        && ["/nodes/g2/ask", "/nodes/g2/listen", "/nodes/g2/speech-token", "/nodes/g2/proactive"].includes(pathname)
+        && ["/nodes/g2/experience", "/nodes/g2/ask", "/nodes/g2/listen", "/nodes/g2/speech-token", "/nodes/g2/proactive"].includes(pathname)
         ? nodeRegistry.enrollmentForToken(scopedBearer)
         : null;
       const requestNodeId = headerNodeId ?? tokenOnlyG2Enrollment?.nodeId ?? null;
       const requestEnrollment = tokenOnlyG2Enrollment
         ?? (requestNodeId ? nodeRegistry.enrollment(requestNodeId) : null);
       const g2NodeRouteAllowed = requestEnrollment?.platform !== EVEN_G2_PLATFORM
-        || ["/nodes/heartbeat", "/nodes/revoke", "/nodes/g2/ask", "/nodes/g2/listen", "/nodes/g2/speech-token", "/nodes/g2/proactive"].includes(pathname);
+        || ["/nodes/heartbeat", "/nodes/revoke", "/nodes/g2/experience", "/nodes/g2/ask", "/nodes/g2/listen", "/nodes/g2/speech-token", "/nodes/g2/proactive"].includes(pathname);
       // On an authenticated main, operational node routes accept ONLY the
       // credential enrolled for this stable node id. A main-wide dashboard
       // token must never let one paired node poll another node's control queue.
@@ -745,7 +762,7 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
       // normal auth gate below still runs; this does not make the route public.
       const authenticatedG2CrossOrigin = requestEnrollment?.platform === EVEN_G2_PLATFORM
         && nodeScopedAuth
-        && ["/nodes/heartbeat", "/nodes/revoke", "/nodes/g2/ask", "/nodes/g2/listen", "/nodes/g2/speech-token", "/nodes/g2/proactive"].includes(pathname);
+        && ["/nodes/heartbeat", "/nodes/revoke", "/nodes/g2/experience", "/nodes/g2/ask", "/nodes/g2/listen", "/nodes/g2/speech-token", "/nodes/g2/proactive"].includes(pathname);
 
       // Setup wizard. Available always (so you can re-run /setup to change keys),
       // but on first run it bypasses the auth gate since no token exists yet.
@@ -977,6 +994,7 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
         }
         nodeControlBroker.removeNode(nodeId, "node credential was revoked by the main owner");
         nodeRegistry.revoke(nodeId);
+        g2Requests?.sweep();
         return sendJson(res, 200, { ok: true, nodeId, revoked: true });
       }
       if (method === "POST" && pathname === "/nodes/enroll") {
@@ -1204,6 +1222,7 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
         }
         nodeControlBroker.removeNode(requestNodeId, "node credential was revoked");
         nodeRegistry.revoke(requestNodeId);
+        g2Requests?.sweep();
         return sendJson(res, 200, { ok: true, revoked: true });
       }
       if (method === "POST" && pathname === "/nodes/control/poll") {
@@ -1539,6 +1558,9 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
       if (method === "GET" && pathname === "/g2/lifelog") {
         res.setHeader("Cache-Control", "no-store"); return sendHtml(res, 200, lifelogPage);
       }
+      if (method === "GET" && pathname === "/g2/connect") {
+        res.setHeader("Cache-Control", "no-store"); return sendHtml(res, 200, g2ConnectPage);
+      }
       if (method === "GET" && pathname === "/g2/proactive") {
         res.setHeader("Cache-Control", "no-store"); return sendHtml(res, 200, g2ProactivePage);
       }
@@ -1561,6 +1583,25 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
           }
           return sendG2NodeJson(res, 200, g2Proactive.dispatch(nodeId, body));
         } catch (error) { return sendG2NodeJson(res, [400, 403, 404, 409, 429, 503].includes(error.status) ? error.status : 500, { error: error.status ? error.message : "Could not update proactive inbox" }); }
+      }
+      if (method === "POST" && pathname === "/nodes/g2/experience") {
+        if (!nodeScopedAuth || requestEnrollment?.platform !== EVEN_G2_PLATFORM) return sendG2NodeJson(res, 403, { error: "forbidden_node" });
+        if (!g2Requests) return sendG2NodeJson(res, 503, { error: channels?.g2 ? "request_storage_unavailable" : "agent-host-disabled" });
+        try {
+          const body = await readJsonLimited(req, 1536 * 1024);
+          const fields = { capabilities: ["op"], submit: ["op", "id", "question"], get: ["op", "id"], cancel: ["op", "id"], history: ["op", "continuation", "offset", "query"] };
+          if (!body || typeof body !== "object" || Array.isArray(body) || !Object.hasOwn(fields, body.op)
+            || Object.keys(body).some(k => !fields[body.op].includes(k))) return sendG2NodeJson(res, 400, { error: "unsupported_experience_fields" });
+          if (body.op === "capabilities") return sendG2NodeJson(res, 200, {
+            protocol: 1, recovery: true, history: true, mainRole: readNodeConfig(dataDir)?.remote ? "node" : "main",
+            speech: channels.g2.status(), recoveryHours: 24,
+            computer: "Requires a connected computer and explicit approval on main.",
+            coding: "Only sessions shared by connected coding hosts are accessible; listing does not grant control."
+          });
+          if (body.op === "history") return sendG2NodeJson(res, 200, channels.g2.history(requestNodeId, body));
+          if (body.op === "submit") return sendG2NodeJson(res, 202, g2Requests.submit(requestNodeId, body.id, body.question));
+          return sendG2NodeJson(res, 200, g2Requests[body.op](requestNodeId, body.id));
+        } catch (error) { return sendG2NodeError(res, error); }
       }
       if (method === "POST" && pathname === "/nodes/g2/ask") {
         if (!channels?.g2) return sendG2NodeJson(res, 503, { error: "agent-host-disabled" });
@@ -3297,6 +3338,7 @@ export function createHostedInterface(runtime = createDefaultRuntime(), options 
       });
     },
     close() {
+      g2Requests?.close();
       clearInterval(g2RetentionTimer);
       g2Proactive.close();
       return new Promise((resolve, reject) => {
@@ -3605,6 +3647,7 @@ function isG2NodeCorsRoute(pathname) {
     "/nodes/heartbeat",
     "/nodes/revoke",
     "/nodes/g2/ask",
+    "/nodes/g2/experience",
     "/nodes/g2/listen",
     "/nodes/g2/speech-token",
     "/nodes/g2/proactive"
@@ -4600,6 +4643,7 @@ function renderApp() {
   <header>
     <h1>OpenAGI</h1>
     <span id="status" class="status">connecting…</span>
+    <a href="/g2/connect" class="ui-btn ui-btn-secondary">Connect glasses</a>
     <nav id="nav">
       <!-- Primary tabs — the everyday surfaces. Keeps the nav readable
            on narrow windows; the other 11 tabs live behind "More ▾". -->

--- a/src/integrations/g2-channel.js
+++ b/src/integrations/g2-channel.js
@@ -142,7 +142,13 @@ export class G2Channel {
   async answer(question, wav, conversationId, nodeId, enrollment, options = {}) {
     const nodeNamespace = createHash("sha256").update(nodeId, "utf8").digest("base64url");
     const conversationNamespace = createHash("sha256").update(conversationId, "utf8").digest("base64url");
-    const sessionId = `node:${nodeNamespace}:${conversationNamespace}:main`;
+    const sessionId = options.continuation ? this.sessionIdFor(nodeId, conversationId, options.continuation)
+      : `node:${nodeNamespace}:${conversationNamespace}:main`;
+    const store = this.agentHost.store;
+    if (store?.saveSession) {
+      const session = store.getSession(sessionId);
+      store.saveSession({ ...session, metadata: { ...session.metadata, g2NodeId: nodeId } });
+    }
     const turn = await this.agentHost.handleMessage({
       channel: "g2",
       from: `node:${nodeId}:${conversationNamespace}`,
@@ -151,6 +157,7 @@ export class G2Channel {
       text: question,
       metadata: {
         sourceNodeId: nodeId,
+        ...(options.requestId ? { requestId: options.requestId } : {}),
         nodePlatform: EVEN_G2_PLATFORM,
         nodeName: enrollment.name ?? "Even G2",
         audioDurationSeconds: Number(((wav.length - 44) / 32_000).toFixed(3))
@@ -160,6 +167,49 @@ export class G2Channel {
       at: nowIso(), op: "ask", nodeId, sessionId: turn.session?.id ?? sessionId, audioBytes: wav.length
     });
     return { question, reply: turn.reply, sessionId: turn.session?.id ?? sessionId };
+  }
+
+  sessionIdFor(nodeId, conversationId, continuation) {
+    this.assertEnrolled(nodeId);
+    const prefix = g2SessionPrefix(nodeId);
+    if (continuation !== undefined) {
+      const sessionId = typeof continuation === "string" && continuation.startsWith("g2:") ? continuation.slice(3) : "";
+      if (!sessionId.startsWith(prefix) || !/^[\w-]{43}:main$/.test(sessionId.slice(prefix.length)))
+        throw new G2ChannelError("invalid_conversation", 403, "That conversation does not belong to this G2.");
+      const session = this.agentHost.store?.getSession(sessionId);
+      if (!isG2Session(session, nodeId)) throw new G2ChannelError("invalid_conversation", 404, "This G2 conversation was not found.");
+      return sessionId;
+    }
+    return `${prefix}${createHash("sha256").update(conversationId, "utf8").digest("base64url")}:main`;
+  }
+
+  history(nodeId, { continuation, offset = 0, query = "" } = {}) {
+    this.assertEnrolled(nodeId);
+    const store = this.agentHost.store;
+    if (!store?.listSessions) throw new G2ChannelError("history_unavailable", 503, "Main history is not configured.");
+    if (!Number.isSafeInteger(offset) || offset < 0 || offset > 1000 || typeof query !== "string" || query.length > 200)
+      throw new G2ChannelError("invalid_history", 400, "Invalid history page.");
+    if (continuation) {
+      const id = this.sessionIdFor(nodeId, "", continuation), session = store.getSession(id);
+      const publicMessages = session.messages.filter(m => ["user", "assistant"].includes(m.role) && m.channel === "g2" && typeof m.content === "string");
+      const end = Math.max(0, publicMessages.length - offset), start = Math.max(0, end - 30);
+      return { continuation, messages: publicMessages.slice(start, end).map(m => ({ id: m.id, role: m.role, text: m.content.slice(0, 16000), at: m.createdAt })),
+        nextOffset: start > 0 ? offset + 30 : null, archivedOnMain: session.metadata?.historyArchived === true };
+    }
+    const matches = [], prefix = g2SessionPrefix(nodeId);
+    for (const summary of store.listSessions({ prefix, limit: 200 })) {
+      if (!summary.id.startsWith(prefix) || summary.recoveryNeeded) continue;
+      // Project one bounded session at a time; never retain hundreds of full
+      // conversation files just to build a twenty-row history page.
+      const s = store.getSession(summary.id);
+      if (!isG2Session(s, nodeId)) continue;
+      const messages = s.messages.filter(m => ["user", "assistant"].includes(m.role) && m.channel === "g2" && typeof m.content === "string");
+      const item = { continuation: `g2:${s.id}`, title: (messages.find(m => m.role === "user")?.content ?? "Conversation").slice(0, 160),
+        preview: (messages.at(-1)?.content ?? "").slice(0, 240), at: s.updatedAt };
+      if (`${item.title} ${item.preview}`.toLowerCase().includes(query.toLowerCase())) matches.push(item);
+    }
+    return { conversations: matches.slice(offset, offset + 20), nextOffset: matches.length > offset + 20 ? offset + 20 : null,
+      searchScope: "Question and reply previews from this G2’s 200 most recently updated active conversations; full archives remain on main." };
   }
 
   async transcribe(wav, language, signal) {
@@ -186,6 +236,12 @@ export class G2Channel {
     if (!text) throw new G2ChannelError("empty_transcription", 422, "I did not hear a question. Try again a little closer to the microphone.");
     return text;
   }
+}
+
+function g2SessionPrefix(nodeId) { return `node:${createHash("sha256").update(nodeId, "utf8").digest("base64url")}:`; }
+function isG2Session(session, nodeId) {
+  return session?.id?.startsWith(g2SessionPrefix(nodeId)) && (session.metadata?.g2NodeId === nodeId
+    || session.messages?.some(m => m.channel === "g2" && m.role === "user" && m.metadata?.sourceNodeId === nodeId));
 }
 
 function normalizedWords(value) {

--- a/src/pending-actions.js
+++ b/src/pending-actions.js
@@ -342,6 +342,8 @@ function serializableContext(ctx) {
   if (!ctx) return null;
   return {
     sessionId: ctx.sessionId ?? null,
+    ...(typeof ctx.requestId === "string" ? { requestId: ctx.requestId.slice(0, 200) } : {}),
+    ...(typeof ctx.sourceNodeId === "string" ? { sourceNodeId: ctx.sourceNodeId.slice(0, 200) } : {}),
     agentId: ctx.agentId ?? null,
     channel: ctx.channel ?? null,
     from: ctx.from ?? null,

--- a/src/setup-wizard.js
+++ b/src/setup-wizard.js
@@ -210,6 +210,7 @@ export function renderWizard({ proposedToken, existingEnv = {} } = {}) {
       <p>OpenAGI is an always-on local agent: chat, scheduled prompts, MCP tools, SMS/Telegram channels, automatic task tracking from your calls/issues/notes.<br>
       Everything runs on this machine. State stays in <code>${escapeHtml(envFilePath().replace(/\\/g, "/"))}</code>.</p>
       <p>This wizard takes ~3 minutes. You can change anything later by re-running <code>/setup</code> or via the <code>Integrations</code> tab.</p>
+      <p><strong>Using Even G2?</strong> Finish setup on your main computer, then open <a href="/g2/connect" target="_blank" rel="noopener">Connect glasses</a> for a single-use connection card and speech-readiness guidance. Your glasses never need your owner token.</p>
     </div>
 
     <div class="step">

--- a/src/tool-registry.js
+++ b/src/tool-registry.js
@@ -165,6 +165,7 @@ export class ToolRegistry {
   }
 
   async invoke(name, args, context = {}) {
+    if (context?.signal?.aborted) return { ok: false, error: "Request cancelled; tool was not run." };
     const tool = this.tools.get(name);
     if (!tool) {
       return { ok: false, error: `Unknown tool: ${name}` };
@@ -214,6 +215,7 @@ export class ToolRegistry {
       }
     }
     const toolConfirm = tool.needsConfirmation && safeConfirmationRequired(tool.confirmationRequired, invocationArgs, context);
+    if (context?.signal?.aborted) return { ok: false, error: "Request cancelled; tool was not run." };
     const scrutinyConfirm = context?.__scrutinyPolicy === "confirm"
       && tool.sideEffects
       && safeConfirmationRequired(tool.scrutinyConfirmationRequired, invocationArgs, context);

--- a/test/computer-server.test.js
+++ b/test/computer-server.test.js
@@ -395,7 +395,8 @@ test("helper runner writes payload to stdin, bounds output, and never places it 
 
 test("helper cancellation requests cooperative cleanup before any hard kill", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openagi-helper-cancel-"));
-  const helper = path.join(dir, "helper.js");
+  // Explicit CommonJS: a shared temp parent may itself declare type: module.
+  const helper = path.join(dir, "helper.cjs");
   const marker = path.join(dir, "cleanup-complete");
   const ready = path.join(dir, "ready");
   fs.writeFileSync(helper, `#!/usr/bin/env node\nconst fs=require('node:fs');process.on('SIGTERM',()=>{fs.writeFileSync(${JSON.stringify(marker)},'yes');setTimeout(()=>process.exit(2),20)});fs.writeFileSync(${JSON.stringify(ready)},'yes');process.stdin.resume();setInterval(()=>{},1000);\n`, { mode: 0o700 });

--- a/test/g2-experience.test.js
+++ b/test/g2-experience.test.js
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { G2Channel } from "../src/integrations/g2-channel.js";
+import { InMemoryAgentStore } from "../src/agent-store.js";
+import { NodeRegistry } from "../src/node-registry.js";
+import { createDurableRuntime, createHostedInterface } from "../src/index.js";
+import { isPublicRoute } from "../src/auth.js";
+
+test("experience requires live G2 credentials even without owner auth", async t => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "g2-experience-"));
+  const nodeRegistry = new NodeRegistry({ dir: path.join(dataDir, "nodes") });
+  const id = randomUUID(), token = "g".repeat(43), other = randomUUID();
+  nodeRegistry.enroll(id, token, { platform: "even_g2" });
+  nodeRegistry.enroll(other, "n".repeat(43), { platform: "openagi" });
+  let turns = 0;
+  const channel = new G2Channel({ dir: path.join(dataDir, "g2"), nodeRegistry, apiKey: "", deepgramApiKey: "",
+    agentHost: { handleMessage: async input => { turns++; return { reply: "hi", session: { id: input.sessionId } }; }, store: new InMemoryAgentStore() } });
+  const runtime = createDurableRuntime({ dataDir });
+  const app = createHostedInterface(runtime, { dataDir, port: 0, authToken: "", nodeRegistry,
+    channels: { g2: channel, start() {}, stop() {}, status: () => ({}) } });
+  const { url } = await app.listen();
+  t.after(async () => { await app.close(); await runtime.observations?.close?.(); fs.rmSync(dataDir, { recursive: true, force: true }); });
+  const post = (body, headers = {}) => fetch(`${url}/nodes/g2/experience`, { method: "POST", headers: { "content-type": "application/json", ...headers }, body: JSON.stringify(body) });
+  assert.equal(isPublicRoute("/nodes/g2/experience"), false);
+  assert.equal((await post({ op: "capabilities" })).status, 401);
+  assert.equal((await post({ op: "capabilities" }, { authorization: "Bearer owner" })).status, 401);
+  assert.equal((await post({ op: "capabilities" }, { authorization: `Bearer ${"n".repeat(43)}`, "x-openagi-node-id": other })).status, 403);
+  const headers = { authorization: `Bearer ${token}`, origin: "null" };
+  const ready = await post({ op: "capabilities" }, headers);
+  assert.equal(ready.status, 200); assert.equal(ready.headers.get("access-control-allow-origin"), "*");
+  assert.equal((await ready.json()).protocol, 1); assert.equal(turns, 0);
+  assert.equal((await post({ op: "capabilities", nodeId: other }, headers)).status, 400);
+  assert.ok([401, 403].includes((await post({ op: "capabilities" }, { ...headers, "x-openagi-node-id": other })).status));
+  assert.equal((await fetch(`${url}/nodes/g2/experience`, { method: "OPTIONS" })).status, 204);
+  assert.equal((await post({ op: "history" }, headers)).status, 200); assert.equal(turns, 0);
+  const requestId = `${Date.now()}_${randomUUID()}`;
+  const body = { op: "submit", id: requestId, question: { text: "hello", conversationId: randomUUID() } };
+  assert.equal((await post(body, headers)).status, 202);
+  assert.equal((await post(body, headers)).status, 202); assert.equal(turns, 1);
+  assert.equal((await (await post({ op: "get", id: requestId }, headers)).json()).state, "completed");
+  nodeRegistry.revoke(id);
+  assert.ok([401, 403].includes((await post({ op: "get", id: requestId }, headers)).status));
+});
+
+test("history continues legacy sessions exactly and redacts private metadata", async t => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "g2-history-")); t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const store = new InMemoryAgentStore(), inputs = [];
+  const channel = new G2Channel({ dir, nodeRegistry: { enrollment: () => ({ platform: "even_g2" }) },
+    agentHost: { store, handleMessage: async input => { inputs.push(input); store.appendMessage(input.sessionId, { ...input, role: "user", content: input.text }); return { reply: "reply", session: { id: input.sessionId } }; } } });
+  const legacyId = channel.sessionIdFor("node-a", "old-conversation");
+  store.appendMessage(legacyId, { role: "user", channel: "g2", content: "old question", metadata: { sourceNodeId: "node-a", secret: "private" } });
+  store.appendMessage(legacyId, { role: "tool", content: "secret arguments" });
+  store.appendMessage("owner-session", { role: "user", content: "private owner" });
+  const history = channel.history("node-a"); assert.equal(history.conversations.length, 1);
+  const continuation = history.conversations[0].continuation;
+  const read = channel.history("node-a", { continuation });
+  assert.equal(read.messages.length, 1); assert.equal(JSON.stringify(read).includes("private"), false);
+  await channel.ask({ text: "follow-up", conversationId: randomUUID() }, "node-a", { continuation });
+  assert.equal(inputs[0].sessionId, legacyId);
+  assert.throws(() => channel.sessionIdFor("node-b", "new", continuation), { status: 403 });
+  assert.throws(() => channel.sessionIdFor("node-a", "new", "g2:owner-session"), { status: 403 });
+});
+
+test("bounded session listing selects newest conversations before applying its limit", () => {
+  const store = new InMemoryAgentStore();
+  for (let i = 0; i < 5; i++) store.sessions.set(`g2-test-${i}`, { id: `g2-test-${i}`, updatedAt: `2026-09-0${i + 1}`, messages: [] });
+  assert.deepEqual(store.listSessions({ prefix: "g2-test-", limit: 2 }).map(s => s.id), ["g2-test-4", "g2-test-3"]);
+});
+
+test("damaged recovery storage does not prevent main startup or erase receipts", async t => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "g2-storage-fault-"));
+  const receipts = path.join(dataDir, "g2-requests"); fs.mkdirSync(receipts);
+  const file = path.join(receipts, `${"a".repeat(64)}.json`); fs.writeFileSync(file, "not json");
+  const runtime = createDurableRuntime({ dataDir });
+  const app = createHostedInterface(runtime, { dataDir, port: 0, authToken: "",
+    channels: { g2: {}, start() {}, stop() {}, status: () => ({}) } });
+  t.after(async () => { await app.close(); await runtime.observations?.close?.(); fs.rmSync(dataDir, { recursive: true, force: true }); });
+  const { url } = await app.listen();
+  assert.equal((await fetch(url)).status, 200);
+  assert.equal(fs.readFileSync(file, "utf8"), "not json");
+});

--- a/test/g2-requests.test.js
+++ b/test/g2-requests.test.js
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { G2Requests } from "../src/g2-requests.js";
+
+function fixture(t, extra = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "g2-receipts-"));
+  let now = Date.now(), enrolled = true, calls = 0, finish;
+  const channel = {
+    assertEnrolled() { if (!enrolled) throw Object.assign(new Error("revoked"), { status: 403 }); },
+    sessionIdFor: () => "test-session",
+    ask: async (_body, _node, options) => {
+      calls++; options.onProgress({ stage: "thinking", secret: "never save" });
+      return new Promise(resolve => { finish = resolve; });
+    },
+  };
+  const options = { dir, channel, now: () => now, sweepMs: 0, ...extra };
+  const store = new G2Requests(options);
+  t.after(() => { store.close(); fs.rmSync(dir, { recursive: true, force: true }); });
+  return { dir, store, options, id: () => `${now}_${randomUUID()}`, body: { text: "hello", conversationId: "test-conversation" },
+    calls: () => calls, tick: ms => { now += ms; store.sweep(); }, revoke: () => { enrolled = false; store.sweep(); },
+    finish: () => finish({ question: "hello", reply: "done", sessionId: "test-session" }) };
+}
+const flush = () => new Promise(resolve => setImmediate(resolve));
+
+test("durable claim deduplicates simultaneous/reconnected submissions and rejects changes", async t => {
+  const f = fixture(t); const id = f.id();
+  assert.equal(f.store.submit("a", id, f.body).state, "accepted");
+  f.store.submit("a", id, f.body);
+  assert.throws(() => f.store.submit("a", id, { ...f.body, text: "different" }), { code: "request_conflict" });
+  await flush(); assert.equal(f.calls(), 1);
+  assert.throws(() => f.store.get("b", id), { code: "request_not_found" });
+  f.finish(); await flush();
+  assert.equal(f.store.get("a", id).result.reply, "done");
+  assert.equal(f.store.submit("a", id, f.body).state, "completed");
+  assert.equal(f.calls(), 1);
+  const file = path.join(f.dir, fs.readdirSync(f.dir)[0]);
+  assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+  assert.equal(fs.readFileSync(file, "utf8").includes("never save"), false);
+});
+
+test("restart never replays an interrupted claim; expired ids cannot become new work", async t => {
+  const f = fixture(t); const id = f.id(); f.store.submit("a", id, f.body); await flush();
+  const restored = new G2Requests(f.options); t.after(() => restored.close());
+  assert.equal(restored.get("a", id).state, "unconfirmed");
+  assert.equal(restored.submit("a", id, f.body).state, "unconfirmed");
+  assert.equal(f.calls(), 1);
+  f.tick(25 * 60 * 60 * 1000);
+  assert.throws(() => f.store.submit("a", id, f.body), { code: "request_expired" });
+  assert.throws(() => f.store.submit("a", "not-an-id", f.body), { code: "invalid_request_id" });
+});
+
+test("admission is bounded; cancel and deadline ignore late success", async t => {
+  const f = fixture(t); const id = f.id(); f.store.submit("a", id, f.body); await flush();
+  assert.throws(() => f.store.submit("a", f.id(), f.body), { code: "request_busy" });
+  assert.equal(f.store.cancel("a", id).state, "cancelled");
+  f.finish(); await flush(); assert.equal(f.store.get("a", id).state, "cancelled");
+  const next = f.id(); f.store.submit("a", next, f.body); await flush(); f.tick(301_000);
+  assert.equal(f.store.get("a", next).state, "unconfirmed");
+  f.finish(); await flush(); assert.equal(f.store.get("a", next).state, "unconfirmed");
+});
+
+test("revocation aborts active work and denies reads; a failed claim write never executes", async t => {
+  const f = fixture(t); const id = f.id(); f.store.submit("a", id, f.body); await flush();
+  f.revoke(); assert.throws(() => f.store.get("a", id), { status: 403 });
+  const broken = fixture(t, { write: () => { throw new Error("disk full"); } });
+  assert.throws(() => broken.store.submit("a", broken.id(), broken.body), { code: "request_storage_unavailable" });
+  await flush(); assert.equal(broken.calls(), 0);
+});
+
+test("immediate cancellation releases admission slots without starting the agent", async t => {
+  const f = fixture(t);
+  for (let i = 0; i < 20; i++) {
+    const id = f.id(); f.store.submit("a", id, f.body); f.store.cancel("a", id); await flush();
+    assert.equal(f.store.running.size, 0);
+  }
+  assert.equal(f.calls(), 0);
+});
+
+test("restart reconciles an already persisted public reply without repeating work", async t => {
+  const f = fixture(t), id = f.id(); f.store.submit("a", id, f.body); await flush();
+  f.options.channel.agentHost = { store: { getSession: () => ({ messages: [{ role: "assistant", channel: "g2", content: "Already done", metadata: { requestId: id } }] }) } };
+  const restored = new G2Requests(f.options); t.after(() => restored.close());
+  assert.equal(restored.get("a", id).state, "completed");
+  assert.equal(restored.submit("a", id, f.body).result.reply, "Already done");
+  assert.equal(f.calls(), 1);
+});

--- a/test/node-heartbeat-sender.test.js
+++ b/test/node-heartbeat-sender.test.js
@@ -38,15 +38,16 @@ test("a paired instance heartbeats immediately on listen instead of waiting for 
 
   try {
     // The main's roster now includes the main itself, so a bare count can't
-    // tell "the node checked in" apart from "only the main is listed" — poll
-    // for the row that is not this main, and identify it by nodeId.
+    // tell "the node checked in" apart from "only the main is listed". Also,
+    // enrollment creates an "unknown" row before the eager heartbeat arrives;
+    // wait for online rather than racing that intermediate registration row.
     let arrival = null;
     for (let attempt = 0; attempt < 20 && !arrival; attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 25));
       const json = await (await fetch(`${mainBase}/nodes`, {
         headers: { authorization: `Bearer ${oneTimePairingCredential}` }
       })).json();
-      arrival = json.nodes.find((n) => !n.self) ?? null;
+      arrival = json.nodes.find((n) => !n.self && n.status === "online") ?? null;
     }
     assert.ok(arrival, "the node's heartbeat reached the main");
     assert.equal(arrival.role, "node");


### PR DESCRIPTION
## Summary
Build a reversible 0.4.18 candidate on top of PR #103. Add Focused Talk/Inbox/History/Settings with Classic comparison, one-time connection cards, scoped main history and exact continuation, durable deduplicated request receipts with recovery/cancellation, preserved drafts, persistent Lifelog pause, and public tool-progress events.

## Safety and rollback
Retain the reviewed 0.4.17 baseline at 08b80e194d3643ae1e9ca20a69c17d8560996648 and the old bundle. Keep current pairing/storage identity and legacy ask APIs. New request routes require live G2-scoped credentials; no owner token in connection cards, no persisted raw-audio retry, no replay after main restart, no added computer authority. No deployment or Even Hub submission.

## Verification
BuildBot3 Node 22.21.1: 1181 backend tests passed, zero failed, one browser-integration test skipped. Client: 197 tests passed; TypeScript, ESLint, production build, Even packaging, bundle-size and packaged-secret checks passed. Staged and publication-range Git safety scans passed. The existing helper-cancellation fixture was made explicitly CommonJS after a shared /tmp module setting caused its initial failure.

Artifact: OpenAGI-Agent-0.4.18-f176f89.ehpk (95823 bytes).
SHA-256: b57b7d72f68a8e393e2b748e8b9e40805d3f56860d9530875eef499c1986b99a

See docs/verification/2026-09-12-g2-experience.md for exact inputs, limitations and physical acceptance. Package input is f176f8962ae052182e1760bdc3548505e0425996; later commits only fix a test fixture and record verification.

## Outstanding acceptance
Physical phone/glasses onboarding, readability, audio latency, hold/release, pause/reopen, reconnect/cancel, native exit and experimental phone-lock capture. Full visual/responsive browser QA remains open. No claim that phone-lock recording or every item in the broader scope is delivered. Keep draft until device validation and product comparison.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds node-scoped request persistence and new G2 HTTP routes that affect ask continuity and deduplication; changes are additive with heavy test coverage but still touch auth-bound conversation and recovery paths.
> 
> **Overview**
> Delivers a **reversible G2 0.4.18 candidate** that pairs main-side **durable request receipts** and a new authenticated **`POST /nodes/g2/experience`** flow (capabilities, submit/get/cancel, scoped history) with a reworked **Even G2 overlay** branded **OpenAGI for G2**.
> 
> The phone companion gains **Focused** navigation (**Talk / Inbox / History / Settings**) plus a **Classic** comparison mode, **pasteable connection cards** for pairing, **main-owned history continuation**, and clearer **Lifelog pause** behavior. The glasses app now **persists drafts and pending requests**, **resumes or cancels** in-flight work without duplicate agent turns, and treats **Back on review** as draft-safe instead of discard-by-default.
> 
> **Build and CI**: standalone client entry (`openagi-main.ts`), pinned **pnpm** lockfile, packaging version from `package.json`, bundle/secret checks, and a **G2 experience** GitHub workflow running root tests plus overlay typecheck/lint/test/package gates.
> 
> Scope, contracts, task checklist, and verification notes (including artifact checksum and open physical acceptance) are added under `docs/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0177d1b711a6d7dd296a3cc7eaeeebb5539aaaa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->